### PR TITLE
Skipping pack on PR

### DIFF
--- a/.github/workflows/pack.yml
+++ b/.github/workflows/pack.yml
@@ -1,15 +1,10 @@
 on:
   push:
     branches:
-    - master
+    - main
     - development
     - rc-*
     tags: ['*']
-  pull_request:
-    branches:
-      - master
-      - development
-      - rc-*
 
 name: Pack
 


### PR DESCRIPTION
This PR adjusts `.github/workflows/pack.yaml` to skip `pack` during PR.