### PR TITLE
Fix bug in skipping recipe selection in tutorial.

### DIFF
--- a/nekoyume/Assets/_Scripts/State/States.cs
+++ b/nekoyume/Assets/_Scripts/State/States.cs
@@ -7,6 +7,7 @@ using Nekoyume.Action;
 using Nekoyume.BlockChain;
 using Nekoyume.Model.State;
 using Nekoyume.State.Subjects;
+using Nekoyume.UI;
 using UnityEngine;
 
 namespace Nekoyume.State
@@ -217,6 +218,7 @@ namespace Nekoyume.State
             var avatarState = _avatarStates[CurrentAvatarKey];
             LocalLayer.Instance.InitializeCurrentAvatarState(avatarState);
             UpdateCurrentAvatarState(avatarState, initializeReactiveState);
+            Widget.Find<Combination>().LoadRecipeVFXSkipMap();
 
             if (isNew)
             {

--- a/nekoyume/Assets/_Scripts/UI/LoginDetail.cs
+++ b/nekoyume/Assets/_Scripts/UI/LoginDetail.cs
@@ -387,7 +387,6 @@ namespace Nekoyume.UI
         private void OnDidAvatarStateLoaded(AvatarState avatarState)
         {
             PlayerPrefs.SetString(RecentlyLoggedInAvatarKey, avatarState.address.ToString());
-            Find<Combination>().LoadRecipeVFXSkipMap();
             if (_isCreateMode)
             {
                 Close();

--- a/nekoyume/Assets/_Scripts/UI/Menu.cs
+++ b/nekoyume/Assets/_Scripts/UI/Menu.cs
@@ -532,6 +532,12 @@ namespace Nekoyume.UI
                 return;
             }
 
+            // Temporarily Lock tutorial recipe.
+            var skipMap = Find<Combination>().RecipeVFXSkipMap;
+            if (skipMap.ContainsKey(firstRecipeRow.Id))
+            {
+                skipMap.Remove(firstRecipeRow.Id);
+            }
             GoToCombinationEquipmentRecipe(firstRecipeRow.Id);
         }
 

--- a/nekoyume/Assets/_Scripts/UI/Menu.cs
+++ b/nekoyume/Assets/_Scripts/UI/Menu.cs
@@ -533,11 +533,13 @@ namespace Nekoyume.UI
             }
 
             // Temporarily Lock tutorial recipe.
-            var skipMap = Find<Combination>().RecipeVFXSkipMap;
+            var combination = Find<Combination>();
+            var skipMap = combination.RecipeVFXSkipMap;
             if (skipMap.ContainsKey(firstRecipeRow.Id))
             {
                 skipMap.Remove(firstRecipeRow.Id);
             }
+            combination.SaveRecipeVFXSkipMap();
             GoToCombinationEquipmentRecipe(firstRecipeRow.Id);
         }
 

--- a/nekoyume/Assets/_Scripts/UI/Scroller/RecipeCellView.cs
+++ b/nekoyume/Assets/_Scripts/UI/Scroller/RecipeCellView.cs
@@ -69,7 +69,8 @@ namespace Nekoyume.UI.Scroller
         public readonly Subject<RecipeCellView> OnClick =
             new Subject<RecipeCellView>();
 
-        public bool IsLocked => lockParent.activeSelf;
+        public bool IsLocked => lockParent.activeSelf ||
+            !Widget.Find<Combination>().RecipeVFXSkipMap.ContainsKey(EquipmentRowData.Id);
         public ItemSubType ItemSubType { get; protected set; }
         public ElementalType ElementalType { get; protected set; }
         public StatType StatType { get; protected set; }


### PR DESCRIPTION
## Fixed bugs

- [ ] Fixes bug in skipping recipe selection in tutorial.


## Required Reviewers

@Namyujeong and @planetarium/nine-chronicles-engineers 


## Test Method

- Delete all `PlayerPrefs` and create new character.
- Proceed to stage 3.
- Enter equipment combination tutorial and unlock recipe.
- Stop the client.
- Reconnect to the created character.
- Re-enter to the equipment combination tutorial and check if the recipe selection is not skipped.


