### PR TITLE
Fix icon of installer

### DIFF
--- a/tools/installer/installer.iss
+++ b/tools/installer/installer.iss
@@ -2,7 +2,6 @@
 #define MyAppPublisher "Nine Corporation"
 #define MyAppURL "https://nine-chronicles.com/"
 #define GameExeName "Nine Chronicles.exe"
-#define GameIconName "icon.ico"
 
 [Setup]
 ; NOTE: The value of AppId uniquely identifies this application. Do not use the same AppId value in installers for other applications.
@@ -42,7 +41,7 @@ Source: ".\vc_redist.x64.exe"; DestDir: "{tmp}"; Flags: deleteafterinstall
 
 [Icons]
 Name: "{autoprograms}\{#MyAppName}"; Filename: "{app}\{#GameExeName}"
-Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#GameExeName}"; IconFilename: "{app}\{#GameIconName}"; Tasks: CreateDesktopIcon
+Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#GameExeName}"; Tasks: CreateDesktopIcon
 Name: "{userstartup}\{#MyAppName}"; Filename: "{app}\{#GameExeName}"; Tasks: RegisterStartup
 
 [Code]


### PR DESCRIPTION
## 머지 데드라인: 2021년 3월 9일


## 관련 이슈 링크

- [런처 아이콘 제대로 나오도록 복구하기](https://app.asana.com/0/1199193534352239/1199574035843077/f)


## 이 PR로 해결되는 문제

- [x] 인스톨러를 통해서 나인크로니클을 설치하는 경우에 바탕화면 바로가기 아이콘이 잘 나오게 됩니다.


## 필수 리뷰어

@planetarium/9c-dev 중 1분 이상
