### PR TITLE
ci(gh-actions): checkout submodule recursively

### DIFF
--- a/.github/bin/check-libplanet-version.sh
+++ b/.github/bin/check-libplanet-version.sh
@@ -2,7 +2,7 @@
 
 root="$(dirname "$0")/../.."
 packages="$root/nekoyume/Assets/Packages"
-libplanet="$root/nekoyume/Assets/_Scripts/Lib9c/Lib9c/.Libplanet"
+libplanet="$root/nekoyume/Assets/_Scripts/Lib9c/lib9c/.Libplanet"
 
 libplanet_mtime="$(git --git-dir="$libplanet/.git" \
                        log -1 --format=%ad --date=iso)"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,12 +11,12 @@ jobs:
     - uses: actions/checkout@master
       if: github.event_name != 'pull_request'
       with:
-        submodules: true
+        submodules: recursive
     - uses: actions/checkout@master
       if: github.event_name == 'pull_request'
       with:
         ref: ${{ github.pull_request.head.sha }}
-        submodules: true
+        submodules: recursive
     - run: hooks/pre-commit
     - uses: unsplash/comment-on-pr@master
       env:


### PR DESCRIPTION
### Description

The `check-libplanet-version` step faileds in some pull requests. And the log is like below:

```
fatal: not a git repository: '.github/bin/../../nekoyume/Assets/_Scripts/Lib9c/Lib9c/.Libplanet/.git'
Libplanet was updated at .
Libplanet.RocksDBStore.dll seems outdated (2021-03-08 18:05:57 +0900).
Libplanet.Stun.dll seems outdated (2021-03-08 18:05:57 +0900).
Libplanet.dll seems outdated (2021-03-08 18:05:57 +0900).
```

The log said there is no `.Libplanet` and `Build` workflow didn't checkout submodules recursively. And the path `Lib9c` was incorrect also so this pull request fixed them.

After this pull request...

```
Libplanet was updated at 2021-02-17 13:19:16 +0900.
Libplanet.RocksDBStore.dll seems up-to-date (2021-03-17 14:43:51 +0900).
Libplanet.Stun.dll seems up-to-date (2021-03-17 14:43:51 +0900).
Libplanet.dll seems up-to-date (2021-03-17 14:43:51 +0900).
```

### How to test

Please see the log of GitHub Actions `Build` workflow `Runs .github/bin/check-libplanet-version.sh` step and the step successes.

### Related Links

None.

### Required Reviewers

@planetarium/9c-dev 

### Screenshot

None.