### PR TITLE
Apply fallback background data of Item's grade on ItemView.

### DIFF
--- a/nekoyume/Assets/_Scripts/Game/ScriptableObject/ItemViewDataScriptableObject.cs
+++ b/nekoyume/Assets/_Scripts/Game/ScriptableObject/ItemViewDataScriptableObject.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
+using System.Linq;
 using Nekoyume.Game.ScriptableObject;
 using UnityEngine;
 
@@ -8,6 +9,22 @@ namespace Nekoyume
         order = int.MaxValue)]
     public class ItemViewDataScriptableObject : ScriptableObject
     {
-        public List<ItemViewData> datas;
+        [SerializeField]
+        private int fallbackGrade;
+
+        [SerializeField]
+        private List<ItemViewData> datas;
+
+        public ItemViewData GetItemViewData(int grade)
+        {
+            ItemViewData data = null;
+            data = datas.FirstOrDefault(x => x.Grade == grade);
+            if (data is null)
+            {
+                data = datas.FirstOrDefault(x => x.Grade == fallbackGrade);
+            }
+
+            return data;
+        }
     }
 }

--- a/nekoyume/Assets/_Scripts/UI/Module/Item/ItemView.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/Item/ItemView.cs
@@ -93,8 +93,7 @@ namespace Nekoyume.UI.Module
             }
             base.SetData(row);
 
-
-            var data = itemViewData.datas.FirstOrDefault(x => x.Grade == row.Grade);
+            var data = itemViewData.GetItemViewData(row.Grade);
             enhancementImage.GetComponent<Image>().material = data.EnhancementMaterial;
 
             _disposablesAtSetData.DisposeAllAndClear();

--- a/nekoyume/Assets/_Scripts/UI/Module/Item/VanillaItemView.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/Item/VanillaItemView.cs
@@ -56,7 +56,7 @@ namespace Nekoyume.UI.Module
                 return;
             }
 
-            var data = itemViewData.datas.FirstOrDefault(x => x.Grade == itemRow.Grade);
+            var data = itemViewData.GetItemViewData(itemRow.Grade);
             gradeImage.overrideSprite = data.GradeBackground;
 
             gradeHsv.range = data.GradeHsvRange;


### PR DESCRIPTION
### Description

1. Prevent NRE on displaying dummy data equipment (10100000, 10200000) and equipment that its grade is outside bound of the background data.

### How to test

1. Launch game on editor mode.
2. Open inventory and check if NRE is not occurring.

### Required Reviewers

@Namyujeong and @planetarium/9c-dev 
