### PR TITLE
divide installation events for mixpanel tracking

### DIFF
--- a/tools/installer/installer.iss
+++ b/tools/installer/installer.iss
@@ -120,6 +120,50 @@ begin
   end;
 end;
 
+procedure CurPageChanged(CurPageID: Integer);
+var
+  UUID: String;
+begin
+  case CurPageID of
+    wpSelectDir:
+      begin
+        UUID := UseUUID();
+        Log('Install: Request Mixpanel.');
+        Log('UUID: ' + UUID);
+        MixpanelTrack('Installer/SelectDir', UUID);
+      end;
+    wpSelectTasks:
+      begin
+        UUID := UseUUID();
+        Log('Install: Request Mixpanel.');
+        Log('UUID: ' + UUID);
+        MixpanelTrack('Installer/SelectTasks', UUID);
+      end;
+    wpReady:
+      begin
+        UUID := UseUUID();
+        Log('Install: Request Mixpanel.');
+        Log('UUID: ' + UUID);
+        MixpanelTrack('Installer/Ready', UUID);
+      end;
+    wpInstalling:
+      begin
+        UUID := UseUUID();
+        Log('Install: Request Mixpanel.');
+        Log('UUID: ' + UUID);
+        MixpanelTrack('Installer/Installing', UUID);
+      end;
+    wpFinished:
+      begin
+        UUID := UseUUID();
+        Log('UnInstall: Request Mixpanel.');
+        Log('UUID: ' + UUID);
+        MixpanelTrack('Installer/Finished', UUID);
+      end;
+  end;
+  Result := True;
+end;
+
 [Run]
 Filename: "{cmd}"; Parameters: "/C ""taskkill /im ""{#MyAppName}.exe"""" /f /t"
 

--- a/tools/installer/installer.iss
+++ b/tools/installer/installer.iss
@@ -161,7 +161,6 @@ begin
         MixpanelTrack('Installer/Finished', UUID);
       end;
   end;
-  Result := True;
 end;
 
 [Run]


### PR DESCRIPTION
### Description

This PR divides the installation events for Mixpanel tracking to assess potential drop-offs.

Mixpanel events will be sent for the following Wizard page events sequentially:

**1. Select Directory**
<img width="453" alt="Select_Directory" src="https://user-images.githubusercontent.com/42176649/114696510-b471bb00-9d57-11eb-8200-409e989c923f.PNG">

**2. Select Tasks**
<img width="452" alt="Select_Tasks" src="https://user-images.githubusercontent.com/42176649/114696565-c2274080-9d57-11eb-99fa-1bf1d2cd671a.PNG">

**3. Ready**
<img width="452" alt="Ready" src="https://user-images.githubusercontent.com/42176649/114696589-c8b5b800-9d57-11eb-9bf8-148211e9da08.PNG">

**4. Installing**
<img width="452" alt="Installing" src="https://user-images.githubusercontent.com/42176649/114696622-d23f2000-9d57-11eb-8983-185bf42d2ad7.PNG">

**5. Finished**
<img width="452" alt="Finished" src="https://user-images.githubusercontent.com/42176649/114696643-d8350100-9d57-11eb-9018-e1bacb8eb25e.PNG">

Also, I've set up an [Installation Detailed Report](https://mixpanel.com/s/3k0FCn) on Mixpanel.
