### PR TITLE
Make arena cached info updated on `Show()` in `RankingBoard`.

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/RankingBoard.cs
+++ b/nekoyume/Assets/_Scripts/UI/RankingBoard.cs
@@ -277,7 +277,7 @@ namespace Nekoyume.UI
                 return;
             }
 
-            var (_, arenaInfo) = _weeklyCachedInfo[0];
+            var arenaInfo = _weeklyCachedInfo[0].arenaInfo;
             if (!arenaInfo.Active)
             {
                 currentAvatarCellView.ShowMyDefaultInfo();

--- a/nekoyume/Assets/_Scripts/UI/RankingBoard.cs
+++ b/nekoyume/Assets/_Scripts/UI/RankingBoard.cs
@@ -177,10 +177,7 @@ namespace Nekoyume.UI
             stage.LoadBackground("ranking");
             _player = stage.GetPlayer();
             _player.gameObject.SetActive(false);
-            if (_weeklyCachedInfo.Count < 4)
-            {
-                UpdateWeeklyCache(States.Instance.WeeklyArenaState);
-            }
+            UpdateWeeklyCache(States.Instance.WeeklyArenaState);
 
             _state.SetValueAndForceNotify(stateType);
 
@@ -200,13 +197,8 @@ namespace Nekoyume.UI
             _npc.gameObject.SetActive(false);
 
             AudioController.instance.PlayMusic(AudioController.MusicCode.Ranking);
-
             WeeklyArenaStateSubject.WeeklyArenaState
-                .Subscribe(state =>
-                {
-                    UpdateWeeklyCache(state);
-                    UpdateArena();
-                })
+                .Subscribe(SubscribeWeeklyArenaState)
                 .AddTo(_disposablesFromShow);
         }
 
@@ -257,6 +249,12 @@ namespace Nekoyume.UI
             }
         }
 
+        private void SubscribeWeeklyArenaState(WeeklyArenaState state)
+        {
+            UpdateWeeklyCache(state);
+            UpdateArena();
+        }
+
         private void UpdateArena()
         {
             var weeklyArenaState = States.Instance.WeeklyArenaState;
@@ -279,12 +277,8 @@ namespace Nekoyume.UI
                 return;
             }
 
-            var (rank, arenaInfo) = _weeklyCachedInfo[0];
-            if (arenaInfo.Active)
-            {
-                currentAvatarCellView.Show((rank, arenaInfo, arenaInfo));
-            }
-            else
+            var (_, arenaInfo) = _weeklyCachedInfo[0];
+            if (!arenaInfo.Active)
             {
                 currentAvatarCellView.ShowMyDefaultInfo();
                 LocalLayerModifier.AddWeeklyArenaInfoActivator(Game.Game.instance.TableSheets.CharacterSheet);
@@ -335,8 +329,7 @@ namespace Nekoyume.UI
                     return;
                 }
 
-                var (currentAvatarRank, currentAvatarArenaInfo) = weeklyArenaState
-                    .GetArenaInfos(currentAvatarAddress.Value, 0, 0)
+                var (currentAvatarRank, currentAvatarArenaInfo) = _weeklyCachedInfo
                     .FirstOrDefault(info =>
                         info.arenaInfo.AvatarAddress.Equals(currentAvatarAddress));
 


### PR DESCRIPTION
### Description

1. Make arena cached info updated on `Show()` in `RankingBoard`.

### How to test

1. Open `RankingBoard` and do some battle action. (ex. `HackAndSlash`, `RankingBattle`, `MimisbrunnrBattle`)
2. Check if the current player's arena info is correctly match with scroll and bottom cell.

### Required Reviewers

@planetarium/9c-dev 

