### PR TITLE
Update avatar state when entering the lobby

### DIFF
--- a/nekoyume/Assets/_Scripts/State/States.cs
+++ b/nekoyume/Assets/_Scripts/State/States.cs
@@ -203,8 +203,9 @@ namespace Nekoyume.State
 
             if (isNew)
             {
-                // NOTE: 새로운 아바타를 처음 선택할 때에는 모든 워크샵 슬롯을 업데이트 합니다.
-                SetCombinationSlotStates(avatarState);
+                var curAvatarState = new AvatarState((Dictionary) Game.Game.instance.Agent.GetState(avatarState.address));
+                AddOrReplaceAvatarState(curAvatarState, CurrentAvatarKey);
+                SetCombinationSlotStates(curAvatarState);
             }
 
             if (Game.Game.instance.Agent is RPCAgent agent)


### PR DESCRIPTION
### Description

- Fixed the avatar state to be updated when entering the lobby with another character.

### Related Links

- [[몬스터콜렉션] 캐릭터 2개 이상 보유 중일 경우 몬스터콜렉션 보상이 획득되지 않는 현상](https://app.asana.com/0/1133453747809944/1200413250524054/f)

### Required Reviewers

- @planetarium/9c-dev , @Namyujeong 
