### PR TITLE
Fixed issue with dailyReward action

### DIFF
--- a/nekoyume/Assets/_Scripts/BlockChain/ActionRenderHandler.cs
+++ b/nekoyume/Assets/_Scripts/BlockChain/ActionRenderHandler.cs
@@ -209,34 +209,7 @@ namespace Nekoyume.BlockChain
             _renderer.EveryRender<DailyReward>()
                 .Where(ValidateEvaluationForCurrentAgent)
                 .ObserveOnMainThread()
-                .Subscribe(eval =>
-                {
-                    if (GameConfigStateSubject.ActionPointState.ContainsKey(eval.Action.avatarAddress))
-                    {
-                        GameConfigStateSubject.ActionPointState.Remove(
-                            eval.Action.avatarAddress);
-                    }
-
-                    if (eval.Exception is null &&
-                        eval.Action.avatarAddress == States.Instance.CurrentAvatarState.address)
-                    {
-                        LocalLayer.Instance
-                            .ClearAvatarModifiers<AvatarDailyRewardReceivedIndexModifier>(
-                                eval.Action.avatarAddress);
-
-                        UpdateCurrentAvatarState(eval);
-
-                        UI.Notification.Push(
-                            Nekoyume.Model.Mail.MailType.System,
-                            L10nManager.Localize("UI_RECEIVED_DAILY_REWARD"));
-                        var avatarAddress = eval.Action.avatarAddress;
-                        var itemId = eval.Action.dailyRewardResult.materials.First().Key.ItemId;
-                        var itemCount = eval.Action.dailyRewardResult.materials.First().Value;
-                        LocalLayerModifier.RemoveItem(avatarAddress, itemId, itemCount);
-                        LocalLayerModifier.AddNewAttachmentMail(avatarAddress, eval.Action.dailyRewardResult.id);
-                    }
-
-                }).AddTo(_disposables);
+                .Subscribe(ResponseDailyReward).AddTo(_disposables);
         }
 
         private void RankingBattle()
@@ -671,6 +644,34 @@ namespace Nekoyume.BlockChain
             else
             {
                 Debug.Log(eval.Exception);
+            }
+        }
+
+        private void ResponseDailyReward(ActionBase.ActionEvaluation<DailyReward> eval)
+        {
+            if (GameConfigStateSubject.ActionPointState.ContainsKey(eval.Action.avatarAddress))
+            {
+                GameConfigStateSubject.ActionPointState.Remove(
+                    eval.Action.avatarAddress);
+            }
+
+            if (eval.Exception is null &&
+                eval.Action.avatarAddress == States.Instance.CurrentAvatarState.address)
+            {
+                LocalLayer.Instance
+                    .ClearAvatarModifiers<AvatarDailyRewardReceivedIndexModifier>(
+                        eval.Action.avatarAddress);
+
+                UpdateCurrentAvatarState(eval);
+
+                UI.Notification.Push(
+                    Nekoyume.Model.Mail.MailType.System,
+                    L10nManager.Localize("UI_RECEIVED_DAILY_REWARD"));
+                var avatarAddress = eval.Action.avatarAddress;
+                var itemId = eval.Action.dailyRewardResult.materials.First().Key.ItemId;
+                var itemCount = eval.Action.dailyRewardResult.materials.First().Value;
+                LocalLayerModifier.RemoveItem(avatarAddress, itemId, itemCount);
+                LocalLayerModifier.AddNewAttachmentMail(avatarAddress, eval.Action.dailyRewardResult.id);
             }
         }
 

--- a/nekoyume/Assets/_Scripts/BlockChain/ActionUnrenderHandler.cs
+++ b/nekoyume/Assets/_Scripts/BlockChain/ActionUnrenderHandler.cs
@@ -257,10 +257,12 @@ namespace Nekoyume.BlockChain
                 return;
             }
 
-            if (!GameConfigStateSubject.ActionPointState.ContainsKey(eval.Action.avatarAddress))
+            // This should be not inversed with `ActionRenderHandler`.
+            // When DailyReward is unrendered, use of ActionPoint is cancelled. So loading indicator should not appear.
+            if (GameConfigStateSubject.ActionPointState.ContainsKey(eval.Action.avatarAddress))
             {
-                GameConfigStateSubject.ActionPointState.Add(
-                    eval.Action.avatarAddress, true);
+                GameConfigStateSubject.ActionPointState.Remove(
+                    eval.Action.avatarAddress);
             }
 
             if (eval.Action.avatarAddress != States.Instance.CurrentAvatarState.address)

--- a/nekoyume/Assets/_Scripts/BlockChain/ActionUnrenderHandler.cs
+++ b/nekoyume/Assets/_Scripts/BlockChain/ActionUnrenderHandler.cs
@@ -257,6 +257,17 @@ namespace Nekoyume.BlockChain
                 return;
             }
 
+            if (GameConfigStateSubject.ActionPointState.ContainsKey(eval.Action.avatarAddress))
+            {
+                GameConfigStateSubject.ActionPointState.Remove(
+                    eval.Action.avatarAddress);
+            }
+
+            if (eval.Action.avatarAddress != States.Instance.CurrentAvatarState.address)
+            {
+                return;
+            }
+
             var avatarAddress = eval.Action.avatarAddress;
             var fungibleId = eval.Action.dailyRewardResult.materials.First().Key.ItemId;
             var itemCount = eval.Action.dailyRewardResult.materials.First().Value;
@@ -264,7 +275,7 @@ namespace Nekoyume.BlockChain
             var avatarState = eval.OutputStates.GetAvatarState(avatarAddress);
             ReactiveAvatarState.DailyRewardReceivedIndex.SetValueAndForceNotify(
                 avatarState.dailyRewardReceivedIndex);
-            GameConfigStateSubject.IsChargingActionPoint.SetValueAndForceNotify(false);
+
             UpdateCurrentAvatarState(avatarState);
         }
 

--- a/nekoyume/Assets/_Scripts/BlockChain/ActionUnrenderHandler.cs
+++ b/nekoyume/Assets/_Scripts/BlockChain/ActionUnrenderHandler.cs
@@ -257,10 +257,10 @@ namespace Nekoyume.BlockChain
                 return;
             }
 
-            if (GameConfigStateSubject.ActionPointState.ContainsKey(eval.Action.avatarAddress))
+            if (!GameConfigStateSubject.ActionPointState.ContainsKey(eval.Action.avatarAddress))
             {
-                GameConfigStateSubject.ActionPointState.Remove(
-                    eval.Action.avatarAddress);
+                GameConfigStateSubject.ActionPointState.Add(
+                    eval.Action.avatarAddress, true);
             }
 
             if (eval.Action.avatarAddress != States.Instance.CurrentAvatarState.address)

--- a/nekoyume/Assets/_Scripts/State/Subjects/GameConfigStateSubject.cs
+++ b/nekoyume/Assets/_Scripts/State/Subjects/GameConfigStateSubject.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+using Libplanet;
 using Nekoyume.Model.State;
 using UniRx;
 
@@ -9,8 +9,8 @@ namespace Nekoyume.State.Subjects
         public static readonly Subject<GameConfigState> GameConfigState =
             new Subject<GameConfigState>();
 
-        public static readonly ReactiveProperty<bool> IsChargingActionPoint
-            = new ReactiveProperty<bool>();
+        public static readonly ReactiveDictionary<Address, bool> ActionPointState =
+            new ReactiveDictionary<Address, bool>();
 
         public static void OnNext(GameConfigState state)
         {

--- a/nekoyume/Assets/_Scripts/UI/Module/ActionPoint.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/ActionPoint.cs
@@ -88,7 +88,6 @@ namespace Nekoyume.UI.Module
                 SetActionPoint(States.Instance.CurrentAvatarState.actionPoint, false);
             }
 
-
             ReactiveAvatarState.ActionPoint
                 .Subscribe(x => SetActionPoint(x, true))
                 .AddTo(_disposables);
@@ -105,8 +104,7 @@ namespace Nekoyume.UI.Module
                 if (GameConfigStateSubject.ActionPointState.ContainsKey(address))
                 {
                     var value = GameConfigStateSubject.ActionPointState[address];
-                    loading.SetActive(value);
-                    text.enabled = !value;
+                    Charger(value);
                 }
                 else
                 {

--- a/nekoyume/Assets/_Scripts/UI/Module/DailyBonus.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/DailyBonus.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using JetBrains.Annotations;
+using Libplanet;
 using Nekoyume.Game.Controller;
 using Nekoyume.Game.VFX;
 using Nekoyume.L10n;
@@ -187,7 +189,14 @@ namespace Nekoyume.UI.Module
                 L10nManager.Localize("UI_RECEIVING_DAILY_REWARD"));
 
             Game.Game.instance.ActionManager.DailyReward();
-            GameConfigStateSubject.IsChargingActionPoint.SetValueAndForceNotify(true);
+
+            var address = States.Instance.CurrentAvatarState.address;
+            if (GameConfigStateSubject.ActionPointState.ContainsKey(address))
+            {
+                GameConfigStateSubject.ActionPointState.Remove(address);
+            }
+            GameConfigStateSubject.ActionPointState.Add(address, true);
+
             StartCoroutine(CoGetDailyRewardAnimation());
         }
 


### PR DESCRIPTION
### Description

1. Fixed unrender(render) to work only when the action avatar address and the current avatar address are the same
2. Bind Action Point Status by Avatar

### Related Links

- [[캐릭터] 번영도 사용으로 행동력 충전 타이밍에 캐릭터 교체 시 캐릭터가 복제 되는 현상](https://app.asana.com/0/1133453747809944/1200433573439997/f)
- https://github.com/planetarium/NineChronicles/issues/234


### Required Reviewers

@planetarium/9c-dev , @Namyujeong 