### PR TITLE
Fix UI blocking on loading ranking information.

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Rank.cs
+++ b/nekoyume/Assets/_Scripts/UI/Rank.cs
@@ -189,6 +189,14 @@ namespace Nekoyume.UI
         private async void UpdateCategoryAsync(RankCategory category, bool toggleOn)
         {
             preloadingObject.SetActive(true);
+            if (category == RankCategory.Weapon)
+            {
+                Find<SystemPopup>().Show("UI_ALERT_NOT_IMPLEMENTED_TITLE", "UI_ALERT_NOT_IMPLEMENTED_CONTENT");
+                CurrentCategory = _previousCategory;
+                ToggleCategory(CurrentCategory);
+                return;
+            }
+
             if (toggleOn)
             {
                 ToggleCategory(category);
@@ -215,7 +223,8 @@ namespace Nekoyume.UI
                 return;
             }
 
-            if (!SharedModel.IsInitialized)
+            var isApiLoaded = SharedModel.IsInitialized;
+            if (!isApiLoaded)
             {
                 missingObject.SetActive(true);
                 refreshObject.SetActive(false);
@@ -230,6 +239,11 @@ namespace Nekoyume.UI
             switch (category)
             {
                 case RankCategory.Ability:
+                    if (!isApiLoaded)
+                    {
+                        break;
+                    }
+
                     var abilityRankingInfos = SharedModel.AbilityRankingInfos;
                     if (SharedModel.AgentAbilityRankingInfos
                         .TryGetValue(states.CurrentAvatarKey, out var abilityInfo))
@@ -244,6 +258,11 @@ namespace Nekoyume.UI
                     rankScroll.Show(abilityRankingInfos, true);
                     break;
                 case RankCategory.Stage:
+                    if (!isApiLoaded)
+                    {
+                        break;
+                    }
+
                     var stageRankingInfos = SharedModel.StageRankingInfos;
                     if (SharedModel.AgentStageRankingInfos
                         .TryGetValue(states.CurrentAvatarKey, out var stageInfo))
@@ -258,6 +277,11 @@ namespace Nekoyume.UI
                     rankScroll.Show(stageRankingInfos, true);
                     break;
                 case RankCategory.Mimisburnnr:
+                    if (!isApiLoaded)
+                    {
+                        break;
+                    }
+
                     var mimisbrunnrRankingInfos = SharedModel.MimisbrunnrRankingInfos;
                     if (SharedModel.AgentMimisbrunnrRankingInfos
                         .TryGetValue(states.CurrentAvatarKey, out var mimisbrunnrInfo))
@@ -278,9 +302,7 @@ namespace Nekoyume.UI
                         Find<SystemPopup>().Show("UI_ALERT_NOT_IMPLEMENTED_TITLE", "UI_ALERT_NOT_IMPLEMENTED_CONTENT");
                         CurrentCategory = _previousCategory;
                         ToggleCategory(CurrentCategory);
-                        return;
                     }
-
                     break;
                 default:
                     break;


### PR DESCRIPTION
### Description
1. SSIA
1. Add error message in error situation on loading ranking.

### How to test
1. To check if UI blocking is fixed, go to Rank.cs and add this line like this. (line 58)
`await Task.Delay(100000);`

```cs
                return Task.Run(async () =>
                {
                    var sw = new Stopwatch();
                    sw.Start();
                    await Task.Delay(100000);

                    LoadAbilityRankingInfos(displayCount);
                    await Task.WhenAll(
                        LoadStageRankingInfos(apiClient, displayCount),
                        LoadMimisbrunnrRankingInfos(apiClient, displayCount)
                    );
                    IsInitialized = true;
                    sw.Stop();
                    UnityEngine.Debug.LogWarning($"total elapsed : {sw.Elapsed}");
                });
```

Then, ranking will be loaded after 100 seconds(100000 ms).
You can adjust the delay by changing the integer value.


1. Start game and go to ranking before the delay is over.
1. Check if clicking equipment ranking tab doesn't block UI anymore.
1. To check if error message is properly displayed, change this line into this.
`await Task.Delay(100000);` -> `throw new System.Exception();`
1. Start game and go to ranking.
1. Check if ranking displays error message properly.

### Related Links
https://github.com/planetarium/NineChronicles/issues/438
https://github.com/planetarium/NineChronicles/issues/434
https://github.com/planetarium/NineChronicles/issues/283

### Required Reviewers
@planetarium/9c-dev Namyujeong



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1141562434100787/1200513756850353) by [Unito](https://www.unito.io)
