### PR TITLE
fix celebrate popup localization

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/CelebratesPopup.cs
+++ b/nekoyume/Assets/_Scripts/UI/CelebratesPopup.cs
@@ -120,16 +120,16 @@ namespace Nekoyume.UI
                     menuText.text = string.Empty;
                     break;
                 case nameof(Combination):
-                    menuText.text = L10nManager.Localize("UI_COMBINATION");
+                    menuText.text = L10nManager.Localize("UI_MAIN_MENU_COMBINATION");
                     break;
                 case nameof(RankingBoard):
-                    menuText.text = L10nManager.Localize("UI_RANKING");
+                    menuText.text = L10nManager.Localize("UI_MAIN_MENU_RANKING");
                     break;
                 case nameof(Shop):
-                    menuText.text = L10nManager.Localize("UI_SHOP");
+                    menuText.text = L10nManager.Localize("UI_MAIN_MENU_SHOP");
                     break;
                 case nameof(MimisbrunnrPreparation):
-                    menuText.text = L10nManager.Localize("UI_MIMISBRUNNR");
+                    menuText.text = L10nManager.Localize("UI_MAIN_MENU_MIMISBRUNNR");
                     break;
             }
 


### PR DESCRIPTION
### Description

Set the translation key appropriate for the menu name in the new menu opening celebration window.
새 메뉴 오픈될때, 25렙때 아레나 열렸다고 해야되는데 랭킹으로 보이고 있어서, 메인화면에서 쓰는 레이블 그대로 가져왔습니다.

### How to test

Just check the file changes

### Related Links

### Required Reviewers

### Screenshot
