### PR TITLE
Bugfix/change action point reference

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Module/DailyBonus.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/DailyBonus.cs
@@ -161,8 +161,7 @@ namespace Nekoyume.UI.Module
                 return;
             }
 
-            if (actionPoint != null &&
-                actionPoint.IsRemained)
+            if (States.Instance.CurrentAvatarState.actionPoint > 0)
             {
                 var confirm = Widget.Find<Confirm>();
                 confirm.Show("UI_CONFIRM", "UI_AP_REFILL_CONFIRM_CONTENT");

--- a/nekoyume/Assets/_Scripts/UI/Tween/DigitTextTweener.cs
+++ b/nekoyume/Assets/_Scripts/UI/Tween/DigitTextTweener.cs
@@ -1,3 +1,4 @@
+using System;
 using DG.Tweening;
 using TMPro;
 using UnityEngine;
@@ -23,6 +24,11 @@ namespace Nekoyume.UI.Tween
         private void Awake()
         {
             text = GetComponent<TextMeshProUGUI>();
+        }
+
+        private void OnDisable()
+        {
+            KillTween();
         }
 
         public Tweener Play()


### PR DESCRIPTION
### Description

Fixed an issue where the alert popup was not displayed when using Prosperity even though the action was full, and it was charged immediately.

### Related Links

[[행동력] 행동력이 가득 차있는데 번영도 사용 시 얼랏팝업이 출력되지 않고 바로 충전되는 현상](https://app.asana.com/0/1133453747809944/1200564162338386/f)

### Required Reviewers

@planetarium/9c-dev 

