### PR TITLE
Refresh shop sell

### DIFF
--- a/nekoyume/Assets/_Scripts/BlockChain/ActionRenderHandler.cs
+++ b/nekoyume/Assets/_Scripts/BlockChain/ActionRenderHandler.cs
@@ -402,7 +402,7 @@ namespace Nekoyume.BlockChain
                 OneLinePopup.Push(MailType.Auction, message);
 
                 UpdateCurrentAvatarState(eval);
-                Widget.Find<ShopSell>().ForceNotifyActiveFunc();
+                Widget.Find<ShopSell>().Refresh();
             }
         }
 
@@ -423,7 +423,7 @@ namespace Nekoyume.BlockChain
             var format = L10nManager.Localize("NOTIFICATION_SELL_CANCEL_COMPLETE");
             OneLinePopup.Push(MailType.Auction, string.Format(format, itemBase.GetLocalizedName()));
             UpdateCurrentAvatarState(eval);
-            Widget.Find<ShopSell>().ForceNotifyActiveFunc();
+            Widget.Find<ShopSell>().Refresh();
         }
 
         private void ResponseBuy(ActionBase.ActionEvaluation<Buy> eval)

--- a/nekoyume/Assets/_Scripts/BlockChain/ActionUnrenderHandler.cs
+++ b/nekoyume/Assets/_Scripts/BlockChain/ActionUnrenderHandler.cs
@@ -231,6 +231,7 @@ namespace Nekoyume.BlockChain
             var count = eval.Action.count;
             LocalLayerModifier.RemoveItem(avatarAddress, itemId, blockIndex, count);
             UpdateCurrentAvatarState(eval);
+            Widget.Find<ShopSell>().Refresh();
         }
 
         private void ResponseSellCancellation(ActionBase.ActionEvaluation<SellCancellation> eval)
@@ -247,6 +248,7 @@ namespace Nekoyume.BlockChain
             var count = order is FungibleOrder fungibleOrder ? fungibleOrder.ItemCount : 1;
             LocalLayerModifier.AddItem(avatarAddress, tradableItem.TradableId, tradableItem.RequiredBlockIndex, count);
             UpdateCurrentAvatarState(eval);
+            Widget.Find<ShopSell>().Refresh();
         }
 
         private void ResponseDailyReward(ActionBase.ActionEvaluation<DailyReward> eval)

--- a/nekoyume/Assets/_Scripts/UI/Shop/ShopSell.cs
+++ b/nekoyume/Assets/_Scripts/UI/Shop/ShopSell.cs
@@ -102,16 +102,19 @@ namespace Nekoyume.UI
         public void Show()
         {
             base.Show();
-            Refresh();
+            Refresh(true);
+            AudioController.instance.PlayMusic(AudioController.MusicCode.Shop);
         }
 
-        private void Refresh()
+        public void Refresh(bool isResetType = false)
         {
             ReactiveShopState.InitSellDigests();
             shopItems.Show();
-            inventory.SharedModel.State.Value = ItemType.Equipment;
+            if (isResetType)
+            {
+                inventory.SharedModel.State.Value = ItemType.Equipment;
+            }
             inventory.SharedModel.ActiveFunc.SetValueAndForceNotify(inventoryItem => (inventoryItem.ItemBase.Value is ITradableItem));
-            AudioController.instance.PlayMusic(AudioController.MusicCode.Shop);
         }
 
         public override void Close(bool ignoreCloseAnimation = false)
@@ -453,11 +456,6 @@ namespace Nekoyume.UI
                 : NPCAnimation.Type.Emotion_01);
 
             speechBubble.SetKey(key);
-        }
-
-        public void ForceNotifyActiveFunc()
-        {
-            inventory.SharedModel.ActiveFunc.SetValueAndForceNotify(inventoryItem => (inventoryItem.ItemBase.Value is ITradableItem));
         }
     }
 }


### PR DESCRIPTION
### Description

Update shop sell state whenever `sell` and `sellCancellation` actions are called in Render and Unrender

### How to test

- sell item

### Related Links

- [[마켓] 코스튬 판매 등록 하였는데 장착중인 장비 UI에 그대로 남아있는 현상](https://app.asana.com/0/1133453747809944/1200564162338390/f)
- [(일정추적용) 판매&판매취소만 랜더,언랜더에서 쪽 갱신 될 때마다 판매 매대를 업데이트되게 수정](https://app.asana.com/0/958521740385861/1200569616769910/f)

### Required Reviewers

@Namyujeong, @plafina2 , @planetarium/9c-dev 

### Screenshot

![ezgif com-gif-maker (1)](https://user-images.githubusercontent.com/40553495/124695047-6bc43b00-df1d-11eb-8530-d02498e25963.gif)
