### PR TITLE
Improve de-equip ring system

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Module/Item/EquipmentSlots.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/Item/EquipmentSlots.cs
@@ -170,14 +170,13 @@ namespace Nekoyume.UI.Module
             if (itemSubType == ItemSubType.Ring)
             {
                 var itemId = equipment.ItemId;
-                slot = typeSlots.FirstOrDefault(
-                           e =>
-                               !e.IsEmpty &&
-                               e.Item is ItemUsable itemUsable &&
-                               itemUsable.ItemId.Equals(itemId))
+                slot = typeSlots.FirstOrDefault(e =>
+                           !e.IsEmpty &&
+                           e.Item is ItemUsable itemUsable &&
+                           itemUsable.ItemId.Equals(itemId))
                        ?? typeSlots.FirstOrDefault(e => e.IsEmpty)
                        ?? typeSlots.OrderBy(e => CPHelper.GetCP((ItemUsable) e.Item))
-                           .FirstOrDefault();
+                           .First();
             }
             else
             {

--- a/nekoyume/Assets/_Scripts/UI/Module/Item/EquipmentSlots.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/Item/EquipmentSlots.cs
@@ -169,11 +169,15 @@ namespace Nekoyume.UI.Module
 
             if (itemSubType == ItemSubType.Ring)
             {
-                slot = typeSlots.OrderBy(e => CPHelper.GetCP((ItemUsable) e.Item,
-                               Game.Game.instance.TableSheets.CostumeStatSheet))
-                           .FirstOrDefault()
+                var itemId = equipment.ItemId;
+                slot = typeSlots.FirstOrDefault(
+                           e =>
+                               !e.IsEmpty &&
+                               e.Item is ItemUsable itemUsable &&
+                               itemUsable.ItemId.Equals(itemId))
                        ?? typeSlots.FirstOrDefault(e => e.IsEmpty)
-                       ?? typeSlots.First();
+                       ?? typeSlots.OrderBy(e => CPHelper.GetCP((ItemUsable) e.Item))
+                           .FirstOrDefault();
             }
             else
             {

--- a/nekoyume/Assets/_Scripts/UI/Module/Item/EquipmentSlots.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/Item/EquipmentSlots.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using Nekoyume.Battle;
 using Nekoyume.Model;
 using Nekoyume.Model.Item;
 using Nekoyume.Model.State;
@@ -168,11 +169,9 @@ namespace Nekoyume.UI.Module
 
             if (itemSubType == ItemSubType.Ring)
             {
-                var itemId = equipment.ItemId;
-                slot = typeSlots.FirstOrDefault(e =>
-                           !e.IsEmpty &&
-                           e.Item is ItemUsable itemUsable &&
-                           itemUsable.ItemId.Equals(itemId))
+                slot = typeSlots.OrderBy(e => CPHelper.GetCP((ItemUsable) e.Item,
+                               Game.Game.instance.TableSheets.CostumeStatSheet))
+                           .FirstOrDefault()
                        ?? typeSlots.FirstOrDefault(e => e.IsEmpty)
                        ?? typeSlots.First();
             }


### PR DESCRIPTION
### Description

1. In the past, if there were not enough slots to equip the ring on, the first ring was detached.
2. Now, If there is a lack of slots when mounting the ring, the ring with a lower CP will be de-equipped.

### How to test

1. Equip a ring in second slot that has lower CP than a ring in first slot.
2. Wear any ring and check if the ring in the second slot has been replaced.

### Required Reviewers

@planetarium/9c-dev @Namyujeong 

### Related Links

[반지 갈아 낄 때 슬롯 두 개 중 낮은 CP 쪽을 갈아 끼도록](https://app.asana.com/0/1141562434100787/1199226930849869/f)

### Screenshot
![210802_improve-de_equip-ring (2)](https://user-images.githubusercontent.com/48484989/127870812-33e47835-ebac-4c9c-8a10-3e129e1e8b73.gif)


