### PR TITLE
Fix stage progress bar vfx freezing

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/StageProgressBar.cs
+++ b/nekoyume/Assets/_Scripts/UI/StageProgressBar.cs
@@ -142,8 +142,8 @@ namespace Nekoyume.UI
             while (current < value - smoothenFinishThreshold)
             {
                 current = Mathf.Lerp(current, value, Time.deltaTime * speed);
-                slider.value = current;
                 vfxOffset.anchoredPosition = new Vector2(current * _xLength, vfxOffset.anchoredPosition.y);
+                slider.value = current;
                 yield return null;
             }
 
@@ -176,8 +176,8 @@ namespace Nekoyume.UI
 
         private void UpdateSliderValue(float value)
         {
-            slider.value = value;
             vfxOffset.anchoredPosition = new Vector2(value * _xLength, vfxOffset.anchoredPosition.y);
+            slider.value = value;
             _smoothenCoroutine = null;
         }
 


### PR DESCRIPTION
### Description

1. Sometimes, `StageProgressBarVfx` was freeze.
2. When `Time.timeScale` was larger than normal size, vfx did not seem to catch up with `offset`'s position.
3. Now, vfx follow the position of the offset unconditionally regardless of `Time.timeScale`.

### How to test

1. Increase the time.timeScale.
2. Play any stage
3. Check vfx in StageProgressBar

### Related Links

[[UI] 스테이지 달성도 바 이펙트 포인터가 중간에 멈춰 있는 현상](https://app.asana.com/0/1141562434100787/1200344973096674/f)

### Screenshot

![210803_fix_StageProgressBarVfx (1)](https://user-images.githubusercontent.com/48484989/127948586-4c74fd00-ade1-4cab-89e7-0e16fc829b3b.gif)