### PR TITLE
Fix HUD bugs

### DIFF
--- a/nekoyume/Assets/_Scripts/Game/Character/CharacterBase.cs
+++ b/nekoyume/Assets/_Scripts/Game/Character/CharacterBase.cs
@@ -178,16 +178,17 @@ namespace Nekoyume.Game.Character
 
         private void InitializeHudContainer()
         {
+            // No pooling. Widget.Create<HudContainer> didn't pooling HUD object.
+            // HUD Pooling causes HUD positioning bug.
             if (!HudContainer)
             {
-                var hud = Widget.FindOrCreate<HudContainer>();
-                HudContainer = hud;
+                HudContainer = Widget.Create<HudContainer>(true);
             }
         }
 
         protected virtual void InitializeHpBar()
         {
-            HPBar = Widget.FindOrCreate<HpBar>();
+            HPBar = Widget.Create<HpBar>(true);
             HPBar.transform.SetParent(HudContainer.transform);
             HPBar.transform.localPosition = Vector3.zero;
             HPBar.transform.localScale = Vector3.one;
@@ -441,16 +442,17 @@ namespace Nekoyume.Game.Character
 
         public void DisableHUD()
         {
+            // No pooling. HUD Pooling causes HUD positioning bug.
             if (HPBar)
             {
-                HPBar.gameObject.SetActive(false);
+                Destroy(HPBar.gameObject);
                 HPBar = null;
             }
 
+            // No pooling. HUD Pooling causes HUD positioning bug.
             if (HudContainer)
             {
-                HudContainer.UpdateAlpha(0);
-                HudContainer.gameObject.SetActive(false);
+                Destroy(HudContainer.gameObject);
                 HudContainer = null;
             }
 

--- a/nekoyume/Assets/_Scripts/Game/Character/CharacterBase.cs
+++ b/nekoyume/Assets/_Scripts/Game/Character/CharacterBase.cs
@@ -445,6 +445,10 @@ namespace Nekoyume.Game.Character
             {
                 HPBar.gameObject.SetActive(false);
                 HPBar = null;
+            }
+
+            if (HudContainer)
+            {
                 HudContainer.UpdateAlpha(0);
                 HudContainer.gameObject.SetActive(false);
                 HudContainer = null;

--- a/nekoyume/Assets/_Scripts/Game/Entrance/RoomEntering.cs
+++ b/nekoyume/Assets/_Scripts/Game/Entrance/RoomEntering.cs
@@ -41,7 +41,7 @@ namespace Nekoyume.Game.Entrance
             var player = stage.GetPlayer(roomPosition - new Vector2(3.0f, 0.0f));
             player.transform.localScale = Vector3.one;
             player.SetSortingLayer(SortingLayer.NameToID("Character"), 100);
-            player.DisableHUD();
+
             player.StopAllCoroutines();
             player.StartRun();
             if (player.Costumes.Any(value => value.Id == 40100002))

--- a/nekoyume/Assets/_Scripts/Game/Entrance/RoomEntering.cs
+++ b/nekoyume/Assets/_Scripts/Game/Entrance/RoomEntering.cs
@@ -41,7 +41,6 @@ namespace Nekoyume.Game.Entrance
             var player = stage.GetPlayer(roomPosition - new Vector2(3.0f, 0.0f));
             player.transform.localScale = Vector3.one;
             player.SetSortingLayer(SortingLayer.NameToID("Character"), 100);
-
             player.StopAllCoroutines();
             player.StartRun();
             if (player.Costumes.Any(value => value.Id == 40100002))

--- a/nekoyume/Assets/_Scripts/UI/Widget.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget.cs
@@ -179,7 +179,7 @@ namespace Nekoyume.UI
             return true;
         }
 
-        public static T FindOrCreate<T>() where T : HudWidget
+        public static T FindOrCreate<T>() where T : Widget
         {
             var type = typeof(T);
             var names = type.ToString().Split('.');
@@ -187,18 +187,24 @@ namespace Nekoyume.UI
             var resName = $"UI/Prefabs/{widgetName}";
             var pool = Game.Game.instance.Stage.objectPool;
             var go = pool.Get(widgetName, false);
-            if (go is null)
+            if (go)
+            {
+                var widget = go.GetComponent<T>();
+                go.transform.SetParent(MainCanvas.instance.GetLayerRootTransform(widget.WidgetType));
+                return widget;
+            }
+            else
             {
                 Debug.Log("create new");
-                var res = Resources.Load<GameObject>(resName);
-                var go2 = Instantiate(res, MainCanvas.instance.transform);
-                go2.name = widgetName;
-                pool.Add(go2, 1);
-                return go2.GetComponent<T>();
-            }
+                var prefab = Resources.Load<GameObject>(resName);
+                go = Instantiate(prefab, MainCanvas.instance.RectTransform);
+                go.name = widgetName;
+                pool.Add(go, 1);
+                var widget = go.GetComponent<T>();
+                go.transform.SetParent(MainCanvas.instance.GetLayerRootTransform(widget.WidgetType));
 
-            go.transform.SetParent(MainCanvas.instance.GetLayerRootTransform(WidgetType.Hud));
-            return go.GetComponent<T>();
+                return widget;
+            }
         }
 
         public virtual bool IsActive()


### PR DESCRIPTION
### Description

1. Sometimes, position of HUD is abnormal.
2. and Enter any stage - enter lobby - enter menu 'character' - unequip title - equip title, player can not show character title when follow this step.
3. and Somtimes player don't show character title. no.2 is some example.

### Changes in codes

1. `DisableHUD()` (in CharacterBase.cs) did disable/destroy if `HPBar` has enabled. Now, if HudContainer is enable it destroy that.
2. `HUDWidget` is not target of Object pooling. It causes bugs.
3. Do not call `DisableHUD()` in `RoomEntering.cs`. This is a useless method call and causes the problem of not displaying HUD.

### How to test

1. Enter any stage.
2. Check HP bar's position. (issue no.1)
3. Enter lobby, check character's title. (issue no.2)

### Related Links

[전투 진행 시 첫번째 몹의 HP바 대신 플레이어의 HP가 표시되는 현상](https://app.asana.com/0/1141562434100787/1200458232192887/f)
[[UI] 칭호를 장착한 채로 전투에 진입했다가 나오면 칭호가 보이지 않는 현상](https://app.asana.com/0/1141562434100787/1200727618925441/f)
[[UI] 칭호가 중복 출력되는 현상](https://app.asana.com/0/1141562434100787/1200564162338403/f)

### Screenshot

Issue 1, HP bar position bug
![image](https://user-images.githubusercontent.com/48484989/128153911-9623d1a5-b068-4c6c-ad21-86dd2111bcd4.png)

Issue 2, didn't show character's title
![image](https://user-images.githubusercontent.com/48484989/128300283-454fb3ff-9d0e-4149-a114-544b4246084e.png)
![image](https://user-images.githubusercontent.com/48484989/128300329-58ddebb4-3d19-4004-9376-1fb03b128a79.png)

These have now been fixed :)
