### PR TITLE
Fix changing ring bug in MimisBrunnr Preparation

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/MimisbrunnrPreparation.cs
+++ b/nekoyume/Assets/_Scripts/UI/MimisbrunnrPreparation.cs
@@ -658,7 +658,7 @@ namespace Nekoyume.UI
                            ?? consumableSlots[0];
                     return true;
                 case ItemType.Equipment:
-                    return equipmentSlots.TryGetToEquip((Equipment) item, out slot);
+                    return equipmentSlots.TryGetToEquip((Equipment) item, out slot, true);
                 default:
                     slot = null;
                     return false;

--- a/nekoyume/Assets/_Scripts/UI/MimisbrunnrPreparation.cs
+++ b/nekoyume/Assets/_Scripts/UI/MimisbrunnrPreparation.cs
@@ -658,7 +658,7 @@ namespace Nekoyume.UI
                            ?? consumableSlots[0];
                     return true;
                 case ItemType.Equipment:
-                    return equipmentSlots.TryGetToEquip((Equipment) item, out slot, true);
+                    return equipmentSlots.TryGetToEquip((Equipment) item, out slot, ElementalType.Fire);
                 default:
                     slot = null;
                     return false;

--- a/nekoyume/Assets/_Scripts/UI/Module/Item/EquipmentSlots.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/Item/EquipmentSlots.cs
@@ -149,9 +149,9 @@ namespace Nekoyume.UI.Module
         /// </summary>
         /// <param name="equipment"></param>
         /// <param name="slot"></param>
-        /// <param name="filterType"></param>
+        /// <param name="elementalTypeToIgnore"></param>
         /// <returns></returns>
-        public bool TryGetToEquip(Equipment equipment, out EquipmentSlot slot, ElementalType? filterType = null)
+        public bool TryGetToEquip(Equipment equipment, out EquipmentSlot slot, ElementalType? elementalTypeToIgnore = null)
         {
             if (equipment is null)
             {
@@ -173,15 +173,19 @@ namespace Nekoyume.UI.Module
             {
                 var itemId = equipment.ItemId;
 
-                slot = (typeSlots.FirstOrDefault(e =>
+                // Find the first slot which contains the same `non-fungible item`
+                slot = typeSlots.FirstOrDefault(e =>
                             !e.IsEmpty &&
                             e.Item is ItemUsable itemUsable &&
                             itemUsable.ItemId.Equals(itemId))
-                        ?? typeSlots.FirstOrDefault(e => e.IsEmpty))
-                        ?? (filterType != null
+                        // Find the first empty slot.
+                        ?? typeSlots.FirstOrDefault(e => e.IsEmpty)
+                        // Find the first slot of equipment with `elementalTypeToIgnore` excluded.
+                        ?? (elementalTypeToIgnore != null
                             ? typeSlots.FirstOrDefault(e =>
-                                !e.Item.ElementalType.Equals(filterType))
+                                !e.Item.ElementalType.Equals(elementalTypeToIgnore))
                             : null)
+                        // Find the first slot of equipment with lowest cp.
                         ?? typeSlots.OrderBy(e => CPHelper.GetCP((ItemUsable) e.Item))
                             .First();
             }

--- a/nekoyume/Assets/_Scripts/UI/Module/Item/EquipmentSlots.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/Item/EquipmentSlots.cs
@@ -151,7 +151,7 @@ namespace Nekoyume.UI.Module
         /// <param name="slot"></param>
         /// <param name="isMimisBrunnr">기본적으로는 false이고, 미미르의 샘 준비 UI에서만 장착 규칙이 달라 true를 입력하면 된다.</param>
         /// <returns></returns>
-        public bool TryGetToEquip(Equipment equipment, out EquipmentSlot slot, bool isMimisBrunnr = false)
+        public bool TryGetToEquip(Equipment equipment, out EquipmentSlot slot, ElementalType? equipmentType = null)
         {
             if (equipment is null)
             {
@@ -172,28 +172,16 @@ namespace Nekoyume.UI.Module
             if (itemSubType == ItemSubType.Ring)
             {
                 var itemId = equipment.ItemId;
-                if (isMimisBrunnr)
-                {
-                    slot = typeSlots.FirstOrDefault(e =>
-                               !e.IsEmpty &&
-                               e.Item is ItemUsable itemUsable &&
-                               itemUsable.ItemId.Equals(itemId))
-                           ?? typeSlots.FirstOrDefault(e => e.IsEmpty)
-                           ?? typeSlots.FirstOrDefault(e =>
-                               !e.Item.ElementalType.Equals(ElementalType.Fire))
-                           ?? typeSlots.OrderBy(e => CPHelper.GetCP((ItemUsable) e.Item))
-                               .First();
-                }
-                else
-                {
-                    slot = typeSlots.FirstOrDefault(e =>
-                               !e.IsEmpty &&
-                               e.Item is ItemUsable itemUsable &&
-                               itemUsable.ItemId.Equals(itemId))
-                           ?? typeSlots.FirstOrDefault(e => e.IsEmpty)
-                           ?? typeSlots.OrderBy(e => CPHelper.GetCP((ItemUsable) e.Item))
-                               .First();
-                }
+
+                slot = typeSlots.FirstOrDefault(e =>
+                           !e.IsEmpty &&
+                           e.Item is ItemUsable itemUsable &&
+                           itemUsable.ItemId.Equals(itemId))
+                       ?? typeSlots.FirstOrDefault(e => e.IsEmpty)
+                       ?? typeSlots.FirstOrDefault(e =>
+                           !e.Item.ElementalType.Equals(equipmentType))
+                       ?? typeSlots.OrderBy(e => CPHelper.GetCP((ItemUsable) e.Item))
+                           .First();
             }
             else
             {

--- a/nekoyume/Assets/_Scripts/UI/Module/Item/EquipmentSlots.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/Item/EquipmentSlots.cs
@@ -176,16 +176,16 @@ namespace Nekoyume.UI.Module
                 // Find the first slot which contains the same `non-fungible item`
                 slot = typeSlots.FirstOrDefault(e =>
                             !e.IsEmpty &&
-                            e.Item is ItemUsable itemUsable &&
-                            itemUsable.ItemId.Equals(itemId))
+                            e.Item is INonFungibleItem nonFungibleItem &&
+                            nonFungibleItem.NonFungibleId.Equals(itemId))
                         // Find the first empty slot.
                         ?? typeSlots.FirstOrDefault(e => e.IsEmpty)
-                        // Find the first slot of equipment with `elementalTypeToIgnore` excluded.
+                        // Find the first slot of `ElementalType` that is different from `elementalTypeToIgnore`.
                         ?? (elementalTypeToIgnore != null
                             ? typeSlots.FirstOrDefault(e =>
                                 !e.Item.ElementalType.Equals(elementalTypeToIgnore))
                             : null)
-                        // Find the first slot of equipment with lowest cp.
+                        // Find the first slot with the lowest 'CP'.
                         ?? typeSlots.OrderBy(e => CPHelper.GetCP((ItemUsable) e.Item))
                             .First();
             }

--- a/nekoyume/Assets/_Scripts/UI/Module/Item/EquipmentSlots.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/Item/EquipmentSlots.cs
@@ -149,9 +149,9 @@ namespace Nekoyume.UI.Module
         /// </summary>
         /// <param name="equipment"></param>
         /// <param name="slot"></param>
-        /// <param name="isMimisBrunnr">기본적으로는 false이고, 미미르의 샘 준비 UI에서만 장착 규칙이 달라 true를 입력하면 된다.</param>
+        /// <param name="filterType"></param>
         /// <returns></returns>
-        public bool TryGetToEquip(Equipment equipment, out EquipmentSlot slot, ElementalType? equipmentType = null)
+        public bool TryGetToEquip(Equipment equipment, out EquipmentSlot slot, ElementalType? filterType = null)
         {
             if (equipment is null)
             {
@@ -173,15 +173,17 @@ namespace Nekoyume.UI.Module
             {
                 var itemId = equipment.ItemId;
 
-                slot = typeSlots.FirstOrDefault(e =>
-                           !e.IsEmpty &&
-                           e.Item is ItemUsable itemUsable &&
-                           itemUsable.ItemId.Equals(itemId))
-                       ?? typeSlots.FirstOrDefault(e => e.IsEmpty)
-                       ?? typeSlots.FirstOrDefault(e =>
-                           !e.Item.ElementalType.Equals(equipmentType))
-                       ?? typeSlots.OrderBy(e => CPHelper.GetCP((ItemUsable) e.Item))
-                           .First();
+                slot = (typeSlots.FirstOrDefault(e =>
+                            !e.IsEmpty &&
+                            e.Item is ItemUsable itemUsable &&
+                            itemUsable.ItemId.Equals(itemId))
+                        ?? typeSlots.FirstOrDefault(e => e.IsEmpty))
+                        ?? (filterType != null
+                            ? typeSlots.FirstOrDefault(e =>
+                                !e.Item.ElementalType.Equals(filterType))
+                            : null)
+                        ?? typeSlots.OrderBy(e => CPHelper.GetCP((ItemUsable) e.Item))
+                            .First();
             }
             else
             {

--- a/nekoyume/Assets/_Scripts/UI/Module/Item/EquipmentSlots.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/Item/EquipmentSlots.cs
@@ -171,13 +171,11 @@ namespace Nekoyume.UI.Module
 
             if (itemSubType == ItemSubType.Ring)
             {
-                var itemId = equipment.ItemId;
-
                 // Find the first slot which contains the same `non-fungible item`
                 slot = typeSlots.FirstOrDefault(e =>
                             !e.IsEmpty &&
                             e.Item is INonFungibleItem nonFungibleItem &&
-                            nonFungibleItem.NonFungibleId.Equals(itemId))
+                            nonFungibleItem.NonFungibleId.Equals(equipment.NonFungibleId))
                         // Find the first empty slot.
                         ?? typeSlots.FirstOrDefault(e => e.IsEmpty)
                         // Find the first slot of `ElementalType` that is different from `elementalTypeToIgnore`.

--- a/nekoyume/Assets/_Scripts/UI/Module/Item/EquipmentSlots.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/Item/EquipmentSlots.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Nekoyume.Battle;
 using Nekoyume.Model;
+using Nekoyume.Model.Elemental;
 using Nekoyume.Model.Item;
 using Nekoyume.Model.State;
 using UnityEngine;
@@ -148,8 +149,9 @@ namespace Nekoyume.UI.Module
         /// </summary>
         /// <param name="equipment"></param>
         /// <param name="slot"></param>
+        /// <param name="isMimisBrunnr">기본적으로는 false이고, 미미르의 샘 준비 UI에서만 장착 규칙이 달라 true를 입력하면 된다.</param>
         /// <returns></returns>
-        public bool TryGetToEquip(Equipment equipment, out EquipmentSlot slot)
+        public bool TryGetToEquip(Equipment equipment, out EquipmentSlot slot, bool isMimisBrunnr = false)
         {
             if (equipment is null)
             {
@@ -170,13 +172,28 @@ namespace Nekoyume.UI.Module
             if (itemSubType == ItemSubType.Ring)
             {
                 var itemId = equipment.ItemId;
-                slot = typeSlots.FirstOrDefault(e =>
-                           !e.IsEmpty &&
-                           e.Item is ItemUsable itemUsable &&
-                           itemUsable.ItemId.Equals(itemId))
-                       ?? typeSlots.FirstOrDefault(e => e.IsEmpty)
-                       ?? typeSlots.OrderBy(e => CPHelper.GetCP((ItemUsable) e.Item))
-                           .First();
+                if (isMimisBrunnr)
+                {
+                    slot = typeSlots.FirstOrDefault(e =>
+                               !e.IsEmpty &&
+                               e.Item is ItemUsable itemUsable &&
+                               itemUsable.ItemId.Equals(itemId))
+                           ?? typeSlots.FirstOrDefault(e => e.IsEmpty)
+                           ?? typeSlots.FirstOrDefault(e =>
+                               !e.Item.ElementalType.Equals(ElementalType.Fire))
+                           ?? typeSlots.OrderBy(e => CPHelper.GetCP((ItemUsable) e.Item))
+                               .First();
+                }
+                else
+                {
+                    slot = typeSlots.FirstOrDefault(e =>
+                               !e.IsEmpty &&
+                               e.Item is ItemUsable itemUsable &&
+                               itemUsable.ItemId.Equals(itemId))
+                           ?? typeSlots.FirstOrDefault(e => e.IsEmpty)
+                           ?? typeSlots.OrderBy(e => CPHelper.GetCP((ItemUsable) e.Item))
+                               .First();
+                }
             }
             else
             {


### PR DESCRIPTION
### Description

1. Preblem : If enter mimis brunnr preparation UI with one or more of the two rings are not fire type, you can change ring only first slot.
2. Now, you try to equip a ring in mimis brunnr preparation, it will use new getting slot pipeline.

### How to test

1. Equip rings, one or more of the two should not be a fire type.
2. Enter mimis brunnr preparation UI.
3. Check can change rings normally.

### Related Links

[[미미르의 샘] 반지 두개를 모두 장착한 채로 진입시 준비 UI에서 첫번째 반지만 교체되어 진입 불가](https://app.asana.com/0/1141562434100787/1200727618925461/f)

### Screenshot

![210806_mimis_ring](https://user-images.githubusercontent.com/48484989/128447700-01114bf7-d8a9-426f-99bf-22a44f7852f1.gif)