### PR TITLE
Restore and fix bug in `HelpPopup`, add `+` mark on additional option.

### DIFF
--- a/nekoyume/Assets/_Scripts/Game/Stage.cs
+++ b/nekoyume/Assets/_Scripts/Game/Stage.cs
@@ -324,6 +324,7 @@ namespace Nekoyume.Game
 
             IsInStage = true;
             yield return StartCoroutine(CoStageEnter(log));
+            HelpPopup.HelpMe(100005, true);
             foreach (var e in log)
             {
                 yield return StartCoroutine(e.CoExecute(this));

--- a/nekoyume/Assets/_Scripts/UI/AvatarInfo.cs
+++ b/nekoyume/Assets/_Scripts/UI/AvatarInfo.cs
@@ -147,6 +147,7 @@ namespace Nekoyume.UI
             var currentAvatarState = Game.Game.instance.States.CurrentAvatarState;
             IsTweenEnd.Value = false;
             Show(currentAvatarState, ignoreShowAnimation);
+            HelpPopup.HelpMe(100013, true);
         }
 
         protected override void OnTweenComplete()

--- a/nekoyume/Assets/_Scripts/UI/BattleResult.cs
+++ b/nekoyume/Assets/_Scripts/UI/BattleResult.cs
@@ -254,6 +254,7 @@ namespace Nekoyume.UI
             repeatButton.gameObject.SetActive(false);
             nextButton.gameObject.SetActive(false);
             UpdateView();
+            HelpPopup.HelpMe(100006, true);
         }
 
         public override void Close(bool ignoreCloseAnimation = false)

--- a/nekoyume/Assets/_Scripts/UI/CombinationMain.cs
+++ b/nekoyume/Assets/_Scripts/UI/CombinationMain.cs
@@ -69,6 +69,7 @@ namespace Nekoyume.UI
             }
 
             NPCShowAnimation();
+            HelpPopup.HelpMe(100007, true);
         }
 
         public override void Close(bool ignoreCloseAnimation = false)

--- a/nekoyume/Assets/_Scripts/UI/CombinationSlots.cs
+++ b/nekoyume/Assets/_Scripts/UI/CombinationSlots.cs
@@ -27,6 +27,7 @@ namespace Nekoyume.UI
         {
             base.Show(ignoreShowAnimation);
             UpdateSlots(Game.Game.instance.Agent.BlockIndex);
+            HelpPopup.HelpMe(100008, true);
         }
 
         public void SetCaching(int slotIndex, bool value, long requiredBlockIndex = 0, ItemUsable itemUsable = null)

--- a/nekoyume/Assets/_Scripts/UI/Craft.cs
+++ b/nekoyume/Assets/_Scripts/UI/Craft.cs
@@ -152,6 +152,11 @@ namespace Nekoyume.UI
             {
                 equipmentToggle.isOn = true;
             }
+
+            if (!Game.Game.instance.Stage.TutorialController.IsPlaying)
+            {
+                HelpPopup.HelpMe(100016, true);
+            }
         }
 
         private void ShowEquipment()

--- a/nekoyume/Assets/_Scripts/UI/Login.cs
+++ b/nekoyume/Assets/_Scripts/UI/Login.cs
@@ -72,6 +72,12 @@ namespace Nekoyume.UI
             AudioController.instance.PlayMusic(AudioController.MusicCode.SelectCharacter);
         }
 
+        protected override void OnCompleteOfShowAnimationInternal()
+        {
+            base.OnCompleteOfShowAnimationInternal();
+            HelpPopup.HelpMe(100000, true);
+        }
+
         private void ClearPlayers()
         {
             foreach (var player in players)

--- a/nekoyume/Assets/_Scripts/UI/Mail.cs
+++ b/nekoyume/Assets/_Scripts/UI/Mail.cs
@@ -109,6 +109,7 @@ namespace Nekoyume.UI
             {
                 blur.Show();
             }
+            HelpPopup.HelpMe(100010, true);
         }
 
         public override void Close(bool ignoreCloseAnimation = false)

--- a/nekoyume/Assets/_Scripts/UI/Menu.cs
+++ b/nekoyume/Assets/_Scripts/UI/Menu.cs
@@ -378,6 +378,7 @@ namespace Nekoyume.UI
             status.Close(true);
             Find<EventBanner>().Close(true);
             Find<HeaderMenu>().UpdateAssets(HeaderMenu.AssetVisibleState.Battle);
+            HelpPopup.HelpMe(100019, true);
         }
 
         public void UpdateGuideQuest(AvatarState avatarState)
@@ -418,6 +419,7 @@ namespace Nekoyume.UI
 
             if (nextStageId > 4)
             {
+                HelpPopup.HelpMe(100001, true);
                 return;
             }
 
@@ -448,6 +450,7 @@ namespace Nekoyume.UI
                 if (!States.Instance.CurrentAvatarState.inventory.HasItem(recipeRow.MaterialId))
                 {
                     tutorialController.SaveTutorialProgress(2);
+                    HelpPopup.HelpMe(100001, true);
                 }
                 else
                 {

--- a/nekoyume/Assets/_Scripts/UI/MimisbrunnrPreparation.cs
+++ b/nekoyume/Assets/_Scripts/UI/MimisbrunnrPreparation.cs
@@ -209,6 +209,7 @@ namespace Nekoyume.UI
             _tempStats = _player.Model.Stats.Clone() as CharacterStats;
             inventory.SharedModel.UpdateEquipmentNotification(GetElementalTypes());
             startButton.gameObject.SetActive(true);
+            HelpPopup.HelpMe(100020, true);
         }
 
         public override void Close(bool ignoreCloseAnimation = false)

--- a/nekoyume/Assets/_Scripts/UI/Module/ItemInformation.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/ItemInformation.cs
@@ -314,7 +314,7 @@ namespace Nekoyume.UI.Module
             if (statView.Equals(default) ||
                 statView.StatView is null)
                 throw new NotFoundComponentException<StatView>();
-            statView.StatView.Show(statType, value);
+            statView.StatView.Show(statType, value, true);
 
             for (int i = 0; i < count; ++i)
             {

--- a/nekoyume/Assets/_Scripts/UI/Module/Stat/StatView.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/Stat/StatView.cs
@@ -30,12 +30,14 @@ namespace Nekoyume.UI.Module
             Show(statMapEx.StatType, statMapEx.TotalValueAsInt);
         }
 
-        public virtual void Show(StatType statType, int value)
+        public virtual void Show(StatType statType, int value, bool showPlus = false)
         {
-            Show(statType.ToString(),
+            var valueString =
                 statType == StatType.SPD
                     ? (value / 100f).ToString(CultureInfo.InvariantCulture)
-                    : value.ToString());
+                    : value.ToString();
+
+            Show(statType.ToString(), showPlus ? $"+{valueString}" : valueString);
         }
 
         public virtual void Show(string statType, string value)

--- a/nekoyume/Assets/_Scripts/UI/Quest.cs
+++ b/nekoyume/Assets/_Scripts/UI/Quest.cs
@@ -68,6 +68,7 @@ namespace Nekoyume.UI
             {
                 blur.Show();
             }
+            HelpPopup.HelpMe(100011, true);
         }
 
         public override void Close(bool ignoreCloseAnimation = false)

--- a/nekoyume/Assets/_Scripts/UI/QuestPreparation.cs
+++ b/nekoyume/Assets/_Scripts/UI/QuestPreparation.cs
@@ -202,6 +202,7 @@ namespace Nekoyume.UI
             _tempStats = _player.Model.Stats.Clone() as CharacterStats;
             inventory.SharedModel.UpdateEquipmentNotification();
             questButton.gameObject.SetActive(true);
+            HelpPopup.HelpMe(100004, true);
         }
 
         public override void Close(bool ignoreCloseAnimation = false)

--- a/nekoyume/Assets/_Scripts/UI/RankingBoard.cs
+++ b/nekoyume/Assets/_Scripts/UI/RankingBoard.cs
@@ -201,6 +201,7 @@ namespace Nekoyume.UI
             _npc.gameObject.SetActive(true);
             _npc.SpineController.Appear();
             ShowSpeech("SPEECH_RANKING_BOARD_GREETING_", CharacterAnimation.Type.Greeting);
+            HelpPopup.HelpMe(100015, true);
         }
 
         public override void Close(bool ignoreCloseAnimation = false)

--- a/nekoyume/Assets/_Scripts/UI/Settings.cs
+++ b/nekoyume/Assets/_Scripts/UI/Settings.cs
@@ -1,4 +1,4 @@
-﻿using TMPro;
+using TMPro;
 using UnityEngine.UI;
 using UnityEngine;
 using System.Collections.Generic;
@@ -128,6 +128,7 @@ namespace Nekoyume.UI
             {
                 blur.Show();
             }
+            HelpPopup.HelpMe(100014, true);
         }
 
         public void ApplyCurrentSettings()

--- a/nekoyume/Assets/_Scripts/UI/Shop/ShopBuy.cs
+++ b/nekoyume/Assets/_Scripts/UI/Shop/ShopBuy.cs
@@ -111,6 +111,7 @@ namespace Nekoyume.UI
                 Reset();
                 Find<ShopSell>().gameObject.SetActive(false);
                 Find<DataLoadingScreen>().Close();
+                HelpPopup.HelpMe(100018, true);
             }
         }
 

--- a/nekoyume/Assets/_Scripts/UI/StageInformation.cs
+++ b/nekoyume/Assets/_Scripts/UI/StageInformation.cs
@@ -135,6 +135,7 @@ namespace Nekoyume.UI
             }
 
             base.Show(true);
+            HelpPopup.HelpMe(100003, true);
         }
 
         private void UpdateStageInformation(int stageId, int characterLevel)

--- a/nekoyume/Assets/_Scripts/UI/Tutorial/TutorialController.cs
+++ b/nekoyume/Assets/_Scripts/UI/Tutorial/TutorialController.cs
@@ -30,6 +30,8 @@ namespace Nekoyume.UI
 
         private readonly List<int> _mixpanelTargets = new List<int>() { 1, 2, 6, 11, 49 };
 
+        public bool IsPlaying => _tutorial.IsActive();
+
         public TutorialController(IEnumerable<Widget> widgets)
         {
             foreach (var widget in widgets)

--- a/nekoyume/Assets/_Scripts/UI/Tween/TransformLocalScaleTweener.cs
+++ b/nekoyume/Assets/_Scripts/UI/Tween/TransformLocalScaleTweener.cs
@@ -58,7 +58,7 @@ namespace Nekoyume.UI.Tween
 
         public Tweener PlayTween(float newDuration)
         {
-            KillTween();
+            ResetToOrigin();
 
             if (isFrom)
             {
@@ -104,7 +104,7 @@ namespace Nekoyume.UI.Tween
 
         public Tweener PlayReverse(float newDuration)
         {
-            KillTween();
+            ResetToOrigin();
 
             if (isFrom)
             {

--- a/nekoyume/Assets/_Scripts/UI/UpgradeEquipment.cs
+++ b/nekoyume/Assets/_Scripts/UI/UpgradeEquipment.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -80,6 +80,7 @@ namespace Nekoyume.UI
         {
             base.Show(ignoreShowAnimation);
             Clear();
+            HelpPopup.HelpMe(100017, true);
         }
 
         private bool DimFunc(InventoryItem inventoryItem)

--- a/nekoyume/Assets/_Scripts/UI/WorldMap.cs
+++ b/nekoyume/Assets/_Scripts/UI/WorldMap.cs
@@ -135,6 +135,7 @@ namespace Nekoyume.UI
             var status = Find<Status>();
             status.Close(true);
             Show(true);
+            HelpPopup.HelpMe(100002, true);
         }
 
         public void Show(int worldId, int stageId, bool showWorld, bool callByShow = false)


### PR DESCRIPTION
### Description

1. Restore and fix bug in `HelpPopup`.
2. Add `+` mark on additional option.

### How to test

1. Check if help popup of first entrance is working properly.
2. Check if `+` mark is added on additional option in item description popup.

### Required Reviewers

@planetarium/9c-dev @Namyujeong 