### PR TITLE
Fixed battle start button to be clickable only once

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/MimisbrunnrPreparation.cs
+++ b/nekoyume/Assets/_Scripts/UI/MimisbrunnrPreparation.cs
@@ -476,6 +476,12 @@ namespace Nekoyume.UI
                 return;
             }
 
+            if (_stage.IsInStage)
+            {
+                startButton.interactable = false;
+                return;
+            }
+
             _stage.IsInStage = true;
             StartCoroutine(CoBattleClick(repeat));
             startButton.interactable = false;

--- a/nekoyume/Assets/_Scripts/UI/QuestPreparation.cs
+++ b/nekoyume/Assets/_Scripts/UI/QuestPreparation.cs
@@ -394,6 +394,12 @@ namespace Nekoyume.UI
 
         private void QuestClick(bool repeat)
         {
+            if (_stage.IsInStage)
+            {
+                questButton.interactable = false;
+                return;
+            }
+
             _stage.IsInStage = true;
             _stage.IsShowHud = true;
             StartCoroutine(CoQuestClick(repeat));


### PR DESCRIPTION
### Description

SSIA

### How to test

- Play Action (MimisbrunnrBattle , HackAndSlash)

### Related Links

- [[전투 준비 화면] 전투 준비화면에서 Start 버튼은 연속적으로 클릭할 시 AP가 사라짐](https://app.asana.com/0/1133453747809944/1200719401875914/f)

### Required Reviewers

@planetarium/9c-dev , @Namyujeong 
