### PR TITLE
Fix bug in item information tooltip position.

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Combination/SubRecipeView.cs
+++ b/nekoyume/Assets/_Scripts/UI/Combination/SubRecipeView.cs
@@ -99,7 +99,7 @@ namespace Nekoyume.UI
             if (recipeRow is EquipmentItemRecipeSheet.Row equipmentRow)
             {
                 var resultItem = equipmentRow.GetResultEquipmentItemRow();
-                title = resultItem.GetLocalizedName();
+                title = resultItem.GetLocalizedName(true, false);
 
                 var stat = resultItem.GetUniqueStat();
                 statText.text = string.Format(StatTextFormat, stat.Type, stat.ValueAsInt);

--- a/nekoyume/Assets/_Scripts/UI/ItemInformationTooltip.cs
+++ b/nekoyume/Assets/_Scripts/UI/ItemInformationTooltip.cs
@@ -262,6 +262,7 @@ namespace Nekoyume.UI
 
         private void SubscribeTargetItem(RectTransform target)
         {
+            LayoutRebuilder.ForceRebuildLayoutImmediate(panel);
             panel.SetAnchorAndPivot(AnchorPresetType.TopLeft, PivotPresetType.TopLeft);
             base.SubscribeTarget(target);
 


### PR DESCRIPTION
### Description

SSIA

### How to test

1. Check if item information tooltip's position is right on first open.
2. Check if there's no elemental icon on `SubRecipeView`'s item name.

### Related Links

https://app.asana.com/0/958521740385861/1200676985132223
https://app.asana.com/0/958521740385861/1200799644540996

### Required Reviewers

@Namyujeong @planetarium/9c-dev 
