### PR TITLE
Improve AP potion use when Quest/Mimisbrunnr preparing 

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/AvatarInfo.cs
+++ b/nekoyume/Assets/_Scripts/UI/AvatarInfo.cs
@@ -647,7 +647,7 @@ namespace Nekoyume.UI
             return (submitEnabledFunc, submitText, onSubmit);
         }
 
-        private void ShowRefillConfirmPopup(CountableItem item)
+        public static void ShowRefillConfirmPopup(CountableItem item)
         {
             var confirm = Widget.Find<Confirm>();
             confirm.Show("UI_CONFIRM", "UI_AP_REFILL_CONFIRM_CONTENT");
@@ -662,7 +662,7 @@ namespace Nekoyume.UI
             };
         }
 
-        private bool DimmedFuncForChargeActionPoint(CountableItem item)
+        public static bool DimmedFuncForChargeActionPoint(CountableItem item)
         {
             if (item is null || item.Count.Value < 1)
             {
@@ -684,7 +684,7 @@ namespace Nekoyume.UI
             return !item.Dimmed.Value && !Game.Game.instance.Stage.IsInStage;
         }
 
-        private static void ChargeActionPoint(CountableItem item)
+        public static void ChargeActionPoint(CountableItem item)
         {
             if (item.ItemBase.Value is Nekoyume.Model.Item.Material material)
             {

--- a/nekoyume/Assets/_Scripts/UI/MimisbrunnrPreparation.cs
+++ b/nekoyume/Assets/_Scripts/UI/MimisbrunnrPreparation.cs
@@ -150,7 +150,8 @@ namespace Nekoyume.UI
             _weaponSlot = equipmentSlots.First(es => es.ItemSubType == ItemSubType.Weapon);
 
             inventory.SharedModel.DimmedFunc.Value = inventoryItem =>
-                inventoryItem.ItemBase.Value.ItemType == ItemType.Material;
+                inventoryItem.ItemBase.Value.ItemType == ItemType.Material &&
+                inventoryItem.ItemBase.Value.ItemSubType != ItemSubType.ApStone;
             inventory.SharedModel.SelectedItemView
                 .Subscribe(SubscribeInventorySelectedItem)
                 .AddTo(gameObject);
@@ -318,19 +319,59 @@ namespace Nekoyume.UI
                 return;
             }
 
-            tooltip.Show(
-                view.RectTransform,
-                view.Model,
-                value => !view.Model.Dimmed.Value,
-                view.Model.EquippedEnabled.Value
-                    ? L10nManager.Localize("UI_UNEQUIP")
-                    : L10nManager.Localize("UI_EQUIP"),
-                _ => Equip(tooltip.itemInformation.Model.item.Value),
-                _ =>
+            if (view.Model.ItemBase.Value.ItemType == ItemType.Material)
+            {
+                if (view.Model.ItemBase.Value.ItemSubType == ItemSubType.ApStone)
                 {
-                    equipSlotGlow.SetActive(false);
-                    inventory.SharedModel.DeselectItemView();
-                });
+                    tooltip.Show(
+                        view.RectTransform,
+                        view.Model,
+                        AvatarInfo.DimmedFuncForChargeActionPoint,
+                        L10nManager.Localize("UI_CHARGE_AP"),
+                         _ =>
+                         {
+                             if (States.Instance.CurrentAvatarState.actionPoint > 0)
+                             {
+                                 AvatarInfo.ShowRefillConfirmPopup(tooltip.itemInformation.Model
+                                     .item.Value);
+                             }
+                             else
+                             {
+                                 AvatarInfo.ChargeActionPoint(tooltip.itemInformation.Model.item
+                                     .Value);
+                             }
+                         }
+                        ,
+                        _ =>
+                        {
+                            equipSlotGlow.SetActive(false);
+                            inventory.SharedModel.DeselectItemView();
+                        });
+                }
+                else
+                {
+                    tooltip.Show(
+                        view.RectTransform,
+                        view.Model,
+                        _ => inventory.SharedModel.DeselectItemView());
+                }
+            }
+            else
+            {
+                tooltip.Show(
+                    view.RectTransform,
+                    view.Model,
+                    value => !view.Model.Dimmed.Value,
+                    view.Model.EquippedEnabled.Value
+                        ? L10nManager.Localize("UI_UNEQUIP")
+                        : L10nManager.Localize("UI_EQUIP"),
+                    _ => Equip(tooltip.itemInformation.Model.item.Value),
+                    _ =>
+                    {
+                        equipSlotGlow.SetActive(false);
+                        inventory.SharedModel.DeselectItemView();
+                    });
+            }
         }
 
         private void ShowTooltip(EquipmentSlot slot)
@@ -384,8 +425,10 @@ namespace Nekoyume.UI
             UpdateBattleStartButton();
 
             inventory.SharedModel.DimmedFunc.Value = inventoryItem =>
-                inventoryItem.ItemBase.Value.ItemType == ItemType.Material ||
-                (inventoryItem.ItemBase.Value.ItemType == ItemType.Equipment && !IsExistElementalType(inventoryItem.ItemBase.Value.ElementalType));
+                (inventoryItem.ItemBase.Value.ItemType == ItemType.Material &&
+                 inventoryItem.ItemBase.Value.ItemSubType != ItemSubType.ApStone) ||
+                (inventoryItem.ItemBase.Value.ItemType == ItemType.Equipment &&
+                 !IsExistElementalType(inventoryItem.ItemBase.Value.ElementalType));
 
             inventory.SharedModel.EquippedEnabledFunc.SetValueAndForceNotify(inventoryItem =>
             {

--- a/nekoyume/Assets/_Scripts/UI/QuestPreparation.cs
+++ b/nekoyume/Assets/_Scripts/UI/QuestPreparation.cs
@@ -135,7 +135,8 @@ namespace Nekoyume.UI
             _weaponSlot = equipmentSlots.First(es => es.ItemSubType == ItemSubType.Weapon);
 
             inventory.SharedModel.DimmedFunc.Value = inventoryItem =>
-                inventoryItem.ItemBase.Value.ItemType == ItemType.Material;
+                inventoryItem.ItemBase.Value.ItemType == ItemType.Material &&
+                inventoryItem.ItemBase.Value.ItemSubType != ItemSubType.ApStone;
             inventory.SharedModel.SelectedItemView
                 .Subscribe(SubscribeInventorySelectedItem)
                 .AddTo(gameObject);
@@ -306,19 +307,59 @@ namespace Nekoyume.UI
                 return;
             }
 
-            tooltip.Show(
-                view.RectTransform,
-                view.Model,
-                value => !view.Model.Dimmed.Value,
-                view.Model.EquippedEnabled.Value
-                    ? L10nManager.Localize("UI_UNEQUIP")
-                    : L10nManager.Localize("UI_EQUIP"),
-                _ => Equip(tooltip.itemInformation.Model.item.Value),
-                _ =>
+            if (view.Model.ItemBase.Value.ItemType == ItemType.Material)
+            {
+                if (view.Model.ItemBase.Value.ItemSubType == ItemSubType.ApStone)
                 {
-                    equipSlotGlow.SetActive(false);
-                    inventory.SharedModel.DeselectItemView();
-                });
+                    tooltip.Show(
+                        view.RectTransform,
+                        view.Model,
+                        AvatarInfo.DimmedFuncForChargeActionPoint,
+                        L10nManager.Localize("UI_CHARGE_AP"),
+                         _ =>
+                         {
+                             if (States.Instance.CurrentAvatarState.actionPoint > 0)
+                             {
+                                 AvatarInfo.ShowRefillConfirmPopup(tooltip.itemInformation.Model
+                                     .item.Value);
+                             }
+                             else
+                             {
+                                 AvatarInfo.ChargeActionPoint(tooltip.itemInformation.Model.item
+                                     .Value);
+                             }
+                         }
+                        ,
+                        _ =>
+                        {
+                            equipSlotGlow.SetActive(false);
+                            inventory.SharedModel.DeselectItemView();
+                        });
+                }
+                else
+                {
+                    tooltip.Show(
+                        view.RectTransform,
+                        view.Model,
+                        _ => inventory.SharedModel.DeselectItemView());
+                }
+            }
+            else
+            {
+                tooltip.Show(
+                    view.RectTransform,
+                    view.Model,
+                    value => !view.Model.Dimmed.Value,
+                    view.Model.EquippedEnabled.Value
+                        ? L10nManager.Localize("UI_UNEQUIP")
+                        : L10nManager.Localize("UI_EQUIP"),
+                    _ => Equip(tooltip.itemInformation.Model.item.Value),
+                    _ =>
+                    {
+                        equipSlotGlow.SetActive(false);
+                        inventory.SharedModel.DeselectItemView();
+                    });
+            }
         }
 
         private void ShowTooltip(EquipmentSlot slot)


### PR DESCRIPTION
### Description

1. In the past, can't use AP potion when Quest or Mimisbrunnr preparing.
2. Now, can use AP potion when Quest or Mimisbrunnr preparing.

### How to test

1. Enter to preparing UI of any stage(can Mimisbrunnr)
2. Check item information view of `AP potion`

### Related Links

[[전투] 전투 준비 씬에서 바로 AP포션을 사용](https://app.asana.com/0/958521740385861/1185991151192257/f)

### Screenshot
![20210823_use-ap-stone](https://user-images.githubusercontent.com/48484989/130389975-d5b2817b-14eb-4b3b-99d1-b713a688e728.gif)
