### PR TITLE
Fix issue showing the Craft/Upgrade UI together when clicked on an empty combination slot

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Module/CombinationSlot.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/CombinationSlot.cs
@@ -227,6 +227,8 @@ namespace Nekoyume.UI.Module
                         return;
                     }
 
+                    Widget.Find<Craft>()?.gameObject.SetActive(false);
+                    Widget.Find<UpgradeEquipment>()?.gameObject.SetActive(false);
                     Widget.Find<HeaderMenu>().UpdateAssets(HeaderMenu.AssetVisibleState.Combination);
                     Widget.Find<CombinationMain>().Show();
                     Widget.Find<CombinationSlots>().Close();


### PR DESCRIPTION
### Description

SSIA

### How to test

1. Enter to Craft or Upgrade UI.
2. Click header menu-Combination slots-empty slot.

### Related Links

[[공방] 제작, 강화 씬에서 상단 워크샵 아이콘을 통해 공방진입 시 드베르그가 출력되는 현상](https://app.asana.com/0/0/1200859412957720/f)
[[제작] 제작에 진입한 상태에서는 워크샵 슬롯 + 링크 디저블 (전투와 같이)](https://app.asana.com/0/958521740385861/1200845618147511/f)

### Screenshot

![210826_combination](https://user-images.githubusercontent.com/48484989/130934501-58bca990-117c-43d4-a623-2bd88c9841b0.gif)
