### PR TITLE
Bug fix/render correct battle

### DIFF
--- a/nekoyume/Assets/_Scripts/BlockChain/ActionManager.cs
+++ b/nekoyume/Assets/_Scripts/BlockChain/ActionManager.cs
@@ -27,11 +27,10 @@ namespace Nekoyume.BlockChain
 
         private readonly ActionRenderer _renderer;
 
-        public Guid LastBattleActionId { get; private set; }
+        private Guid _lastBattleActionId;
 
-        public int LastBattleWorldId { get; private set; }
-
-        public int LastBattleStageId { get; private set; }
+        public static bool IsLastBattleActionId(Guid actionId) =>
+            actionId == Game.Game.instance.ActionManager._lastBattleActionId;
 
         private void ProcessAction(GameAction gameAction)
         {
@@ -125,9 +124,7 @@ namespace Nekoyume.BlockChain
             };
             ProcessAction(action);
 
-            LastBattleActionId = action.Id;
-            LastBattleWorldId = worldId;
-            LastBattleStageId = stageId;
+            _lastBattleActionId = action.Id;
 
             return _renderer.EveryRender<MimisbrunnrBattle>()
                 .SkipWhile(eval => !eval.Action.Id.Equals(action.Id))
@@ -180,9 +177,7 @@ namespace Nekoyume.BlockChain
             };
             ProcessAction(action);
 
-            LastBattleActionId = action.Id;
-            LastBattleWorldId = worldId;
-            LastBattleStageId = stageId;
+            _lastBattleActionId = action.Id;
 
             return _renderer.EveryRender<HackAndSlash>()
                 .SkipWhile(eval => !eval.Action.Id.Equals(action.Id))
@@ -391,7 +386,7 @@ namespace Nekoyume.BlockChain
             };
             ProcessAction(action);
 
-            LastBattleActionId = action.Id;
+            _lastBattleActionId = action.Id;
 
             return _renderer.EveryRender<RankingBattle>()
                 .Where(eval => eval.Action.Id.Equals(action.Id))

--- a/nekoyume/Assets/_Scripts/BlockChain/ActionManager.cs
+++ b/nekoyume/Assets/_Scripts/BlockChain/ActionManager.cs
@@ -27,6 +27,12 @@ namespace Nekoyume.BlockChain
 
         private readonly ActionRenderer _renderer;
 
+        public Guid LastBattleActionId { get; private set; }
+
+        public int LastBattleWorldId { get; private set; }
+
+        public int LastBattleStageId { get; private set; }
+
         private void ProcessAction(GameAction gameAction)
         {
             _agent.EnqueueAction(gameAction);
@@ -102,9 +108,9 @@ namespace Nekoyume.BlockChain
             }
 
             var avatarAddress = States.Instance.CurrentAvatarState.address;
-            costumes = costumes ?? new List<Costume>();
-            equipments = equipments ?? new List<Equipment>();
-            foods = foods ?? new List<Consumable>();
+            costumes ??= new List<Costume>();
+            equipments ??= new List<Equipment>();
+            foods ??= new List<Consumable>();
 
             var action = new MimisbrunnrBattle
             {
@@ -118,6 +124,10 @@ namespace Nekoyume.BlockChain
                 RankingMapAddress = States.Instance.CurrentAvatarState.RankingMapAddress,
             };
             ProcessAction(action);
+
+            LastBattleActionId = action.Id;
+            LastBattleWorldId = worldId;
+            LastBattleStageId = stageId;
 
             return _renderer.EveryRender<MimisbrunnrBattle>()
                 .SkipWhile(eval => !eval.Action.Id.Equals(action.Id))
@@ -169,6 +179,10 @@ namespace Nekoyume.BlockChain
                 RankingMapAddress = States.Instance.CurrentAvatarState.RankingMapAddress,
             };
             ProcessAction(action);
+
+            LastBattleActionId = action.Id;
+            LastBattleWorldId = worldId;
+            LastBattleStageId = stageId;
 
             return _renderer.EveryRender<HackAndSlash>()
                 .SkipWhile(eval => !eval.Action.Id.Equals(action.Id))
@@ -376,6 +390,8 @@ namespace Nekoyume.BlockChain
                 consumableIds = consumableIds
             };
             ProcessAction(action);
+
+            LastBattleActionId = action.Id;
 
             return _renderer.EveryRender<RankingBattle>()
                 .Where(eval => eval.Action.Id.Equals(action.Id))

--- a/nekoyume/Assets/_Scripts/BlockChain/ActionRenderHandler.cs
+++ b/nekoyume/Assets/_Scripts/BlockChain/ActionRenderHandler.cs
@@ -663,6 +663,13 @@ namespace Nekoyume.BlockChain
         {
             if (eval.Exception is null)
             {
+                if (eval.Action.Id != Game.Game.instance.ActionManager.LastBattleActionId ||
+                    eval.Action.worldId != Game.Game.instance.ActionManager.LastBattleWorldId ||
+                    eval.Action.stageId != Game.Game.instance.ActionManager.LastBattleStageId)
+                {
+                    return;
+                }
+
                 _disposableForBattleEnd?.Dispose();
                 _disposableForBattleEnd =
                     Game.Game.instance.Stage.onEnterToStageEnd
@@ -673,7 +680,6 @@ namespace Nekoyume.BlockChain
                             {
                                 UpdateCurrentAvatarState(eval);
                                 UpdateWeeklyArenaState(eval);
-                                Address agentAddress = States.Instance.AgentState.address;
                                 var avatarState = States.Instance.CurrentAvatarState;
                                 RenderQuest(eval.Action.avatarAddress,
                                     avatarState.questList.completedQuestIds);
@@ -697,7 +703,7 @@ namespace Nekoyume.BlockChain
                     StageSimulatorVersionV100025
                 );
                 simulator.SimulateV3();
-                BattleLog log = simulator.Log;
+                var log = simulator.Log;
 
                 if (Widget.Find<LoadingScreen>().IsActive())
                 {
@@ -738,6 +744,13 @@ namespace Nekoyume.BlockChain
         {
             if (eval.Exception is null)
             {
+                if (eval.Action.Id != Game.Game.instance.ActionManager.LastBattleActionId ||
+                    eval.Action.worldId != Game.Game.instance.ActionManager.LastBattleWorldId ||
+                    eval.Action.stageId != Game.Game.instance.ActionManager.LastBattleStageId)
+                {
+                    return;
+                }
+
                 _disposableForBattleEnd?.Dispose();
                 _disposableForBattleEnd =
                     Game.Game.instance.Stage.onEnterToStageEnd
@@ -748,7 +761,6 @@ namespace Nekoyume.BlockChain
                             {
                                 UpdateCurrentAvatarState(eval);
                                 UpdateWeeklyArenaState(eval);
-                                Address agentAddress = States.Instance.AgentState.address;
                                 var avatarState = States.Instance.CurrentAvatarState;
                                 RenderQuest(eval.Action.avatarAddress,
                                     avatarState.questList.completedQuestIds);
@@ -771,7 +783,7 @@ namespace Nekoyume.BlockChain
                     StageSimulatorVersionV100025
                 );
                 simulator.SimulateV2();
-                BattleLog log = simulator.Log;
+                var log = simulator.Log;
 
                 if (Widget.Find<LoadingScreen>().IsActive())
                 {
@@ -812,6 +824,11 @@ namespace Nekoyume.BlockChain
         {
             if (eval.Exception is null)
             {
+                if (eval.Action.Id != Game.Game.instance.ActionManager.LastBattleActionId)
+                {
+                    return;
+                }
+
                 _disposableForBattleEnd?.Dispose();
                 _disposableForBattleEnd =
                     Game.Game.instance.Stage.onEnterToStageEnd

--- a/nekoyume/Assets/_Scripts/BlockChain/ActionRenderHandler.cs
+++ b/nekoyume/Assets/_Scripts/BlockChain/ActionRenderHandler.cs
@@ -663,9 +663,7 @@ namespace Nekoyume.BlockChain
         {
             if (eval.Exception is null)
             {
-                if (eval.Action.Id != Game.Game.instance.ActionManager.LastBattleActionId ||
-                    eval.Action.worldId != Game.Game.instance.ActionManager.LastBattleWorldId ||
-                    eval.Action.stageId != Game.Game.instance.ActionManager.LastBattleStageId)
+                if (!ActionManager.IsLastBattleActionId(eval.Action.Id))
                 {
                     return;
                 }
@@ -744,9 +742,7 @@ namespace Nekoyume.BlockChain
         {
             if (eval.Exception is null)
             {
-                if (eval.Action.Id != Game.Game.instance.ActionManager.LastBattleActionId ||
-                    eval.Action.worldId != Game.Game.instance.ActionManager.LastBattleWorldId ||
-                    eval.Action.stageId != Game.Game.instance.ActionManager.LastBattleStageId)
+                if (!ActionManager.IsLastBattleActionId(eval.Action.Id))
                 {
                     return;
                 }
@@ -824,7 +820,7 @@ namespace Nekoyume.BlockChain
         {
             if (eval.Exception is null)
             {
-                if (eval.Action.Id != Game.Game.instance.ActionManager.LastBattleActionId)
+                if (!ActionManager.IsLastBattleActionId(eval.Action.Id))
                 {
                     return;
                 }

--- a/nekoyume/Assets/_Scripts/UI/RankingBoard.cs
+++ b/nekoyume/Assets/_Scripts/UI/RankingBoard.cs
@@ -488,8 +488,11 @@ namespace Nekoyume.UI
                     var characterSheet = Game.Game.instance.TableSheets.CharacterSheet;
                     var costumeStatSheet = Game.Game.instance.TableSheets.CostumeStatSheet;
                     var cp = CPHelper.GetCPV2(States.Instance.CurrentAvatarState, characterSheet, costumeStatSheet);
-                    var address = state.OrderedArenaInfos.First(i => i.CombatPoint <= cp).AvatarAddress;
-                    infos2 = state.GetArenaInfos(address, 20, 20);
+                    var targetInfo = state.OrderedArenaInfos.FirstOrDefault(i => i.CombatPoint <= cp);
+                    if (targetInfo != null)
+                    {
+                        infos2 = state.GetArenaInfos(targetInfo.AvatarAddress, 20, 20);   
+                    }
                 }
 
                 infos.AddRange(infos2);


### PR DESCRIPTION
### Description

1. Check rendered information of `HackAndSlash`, `MimisbrunnrBattle` and `RankingBattle` for render correct battle results.
2. Fix minor bug of `RankingBoard` UI

### Related Links

1. [[전투 랜더] HAS, 미미르의샘 로딩 중에 정확히 기다리고 있는 전투의 랜더만 동작시키기](https://app.asana.com/0/1141562434100787/1200814851909847/f)
2. [HAS Repeat 사용할 때 다른 아바타의 전투 스테이지 기록이 그대로 사용되어 전투하는 경우](https://app.asana.com/0/1141562434100787/1200867409730006/f)