### PR TITLE
Add loading circle when use ap potion

### DIFF
--- a/nekoyume/Assets/_Scripts/BlockChain/ActionRenderHandler.cs
+++ b/nekoyume/Assets/_Scripts/BlockChain/ActionRenderHandler.cs
@@ -849,6 +849,12 @@ namespace Nekoyume.BlockChain
                 var row = Game.Game.instance.TableSheets.MaterialItemSheet.Values.First(r =>
                     r.ItemSubType == ItemSubType.ApStone);
                 LocalLayerModifier.AddItem(avatarAddress, row.ItemId, 1);
+
+                if (GameConfigStateSubject.ActionPointState.ContainsKey(eval.Action.avatarAddress))
+                {
+                    GameConfigStateSubject.ActionPointState.Remove(eval.Action.avatarAddress);
+                }
+
                 UpdateCurrentAvatarState(eval);
             }
         }

--- a/nekoyume/Assets/_Scripts/UI/AvatarInfo.cs
+++ b/nekoyume/Assets/_Scripts/UI/AvatarInfo.cs
@@ -12,6 +12,7 @@ using Nekoyume.Model.Item;
 using Nekoyume.Model.Stat;
 using Nekoyume.Model.State;
 using Nekoyume.State;
+using Nekoyume.State.Subjects;
 using Nekoyume.UI.Model;
 using Nekoyume.UI.Module;
 using Nekoyume.UI.Tween;
@@ -691,6 +692,14 @@ namespace Nekoyume.UI
                 Notification.Push(Nekoyume.Model.Mail.MailType.System,
                     L10nManager.Localize("UI_CHARGE_AP"));
                 Game.Game.instance.ActionManager.ChargeActionPoint();
+
+                var address = States.Instance.CurrentAvatarState.address;
+                if (GameConfigStateSubject.ActionPointState.ContainsKey(address))
+                {
+                    GameConfigStateSubject.ActionPointState.Remove(address);
+                }
+                GameConfigStateSubject.ActionPointState.Add(address, true);
+
                 LocalLayerModifier.RemoveItem(States.Instance.CurrentAvatarState.address,
                     material.ItemId, 1);
                 LocalLayerModifier.ModifyAvatarActionPoint(


### PR DESCRIPTION
### Description

SSIA

### How to test

1. Use AP-potion

### Related Links

[[UI] AP포션 사용하면 행동력 바에 번영도 클릭 충전시와 동일하게 로딩서클 그려주기](https://app.asana.com/0/958521740385861/1200888226950630/f)

### Screenshot
![210907 ap potion use](https://user-images.githubusercontent.com/48484989/132292989-69dab01d-50a4-4fcb-a8a9-a57b3e003efe.gif)
