### PR TITLE
Improve to be interact only when the `AnimationState` was 'Shown'.

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Combination.cs
+++ b/nekoyume/Assets/_Scripts/UI/Combination.cs
@@ -122,7 +122,7 @@ namespace Nekoyume.UI
         public bool HasNotification => itemRecipe.HasNotification;
 
         public override bool CanHandleInputEvent => State.Value == StateType.CombinationConfirm
-            ? AnimationState == AnimationStateType.Shown
+            ? AnimationState.Value == AnimationStateType.Shown
             : base.CanHandleInputEvent;
 
         #region Override
@@ -569,12 +569,12 @@ namespace Nekoyume.UI
 
         public void OnTweenRecipe()
         {
-            AnimationState = AnimationStateType.Showing;
+            AnimationState.Value = AnimationStateType.Showing;
         }
 
         public void OnTweenRecipeCompleted()
         {
-            AnimationState = AnimationStateType.Shown;
+            AnimationState.Value = AnimationStateType.Shown;
         }
 
         private void SubscribeSlotStates(Dictionary<Address, CombinationSlotState> states)

--- a/nekoyume/Assets/_Scripts/UI/Menu.cs
+++ b/nekoyume/Assets/_Scripts/UI/Menu.cs
@@ -480,7 +480,7 @@ namespace Nekoyume.UI
         {
             yield return new WaitForSeconds(2.0f);
 
-            while (AnimationState == AnimationStateType.Shown)
+            while (AnimationState.Value == AnimationStateType.Shown)
             {
                 var n = speechBubbles.Length;
                 while (n > 1)

--- a/nekoyume/Assets/_Scripts/UI/Widget.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget.cs
@@ -83,7 +83,7 @@ namespace Nekoyume.UI
             CloseWidget = () => Close();
             SubmitWidget = null;
 
-            AnimationState.Subscribe(type =>
+            AnimationState.Subscribe(stateType =>
             {
                 var fields = GetType().GetFields(System.Reflection.BindingFlags.NonPublic |
                                                  System.Reflection.BindingFlags.Instance);
@@ -91,7 +91,7 @@ namespace Nekoyume.UI
                     .Where(field => field is UnityEngine.UI.Selectable))
                 {
                     ((UnityEngine.UI.Selectable) selectable).interactable =
-                        type == AnimationStateType.Shown;
+                        stateType == AnimationStateType.Shown;
                 }
             }).AddTo(gameObject);
         }

--- a/nekoyume/Assets/_Scripts/UI/Widget.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget.cs
@@ -3,11 +3,11 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using Nekoyume.EnumType;
-using UniRx;
 using UnityEngine;
 
 namespace Nekoyume.UI
 {
+    using UniRx;
     public class Widget : MonoBehaviour
     {
         protected enum AnimationStateType
@@ -40,7 +40,8 @@ namespace Nekoyume.UI
         /// AnimationState 캡슐화가 깨지는 setter를 사용하지 않도록 한다.
         /// BottomMenu에서만 예외적으로 사용하고 있는데, 이를 Widget 안으로 옮긴 후에 setter를 private으로 변경한다.
         /// </summary>
-        protected AnimationStateType AnimationState { get; set; } = AnimationStateType.Closed;
+        protected ReactiveProperty<AnimationStateType> AnimationState { get; set; } =
+            new ReactiveProperty<AnimationStateType>(AnimationStateType.Closed);
 
         private readonly Subject<Widget> _onEnableSubject = new Subject<Widget>();
         private readonly Subject<Widget> _onDisableSubject = new Subject<Widget>();
@@ -68,7 +69,7 @@ namespace Nekoyume.UI
 
         public IObservable<Widget> OnDisableObservable => _onDisableSubject;
 
-        public virtual bool CanHandleInputEvent => AnimationState == AnimationStateType.Shown;
+        public virtual bool CanHandleInputEvent => AnimationState.Value == AnimationStateType.Shown;
 
         protected bool CanClose => CanHandleInputEvent;
 
@@ -81,6 +82,18 @@ namespace Nekoyume.UI
 
             CloseWidget = () => Close();
             SubmitWidget = null;
+
+            AnimationState.Subscribe(type =>
+            {
+                var fields = GetType().GetFields(System.Reflection.BindingFlags.NonPublic |
+                                                 System.Reflection.BindingFlags.Instance);
+                foreach (var selectable in fields.Select(field => field.GetValue(this))
+                    .Where(field => field is UnityEngine.UI.Selectable))
+                {
+                    ((UnityEngine.UI.Selectable) selectable).interactable =
+                        type == AnimationStateType.Shown;
+                }
+            }).AddTo(gameObject);
         }
 
         protected virtual void Update()
@@ -280,12 +293,12 @@ namespace Nekoyume.UI
                     WidgetType.Screen);
             }
 
-            AnimationState = AnimationStateType.Showing;
+            AnimationState.Value = AnimationStateType.Showing;
             gameObject.SetActive(true);
 
             if (!Animator || ignoreShowAnimation)
             {
-                AnimationState = AnimationStateType.Shown;
+                AnimationState.Value = AnimationStateType.Shown;
                 return;
             }
 
@@ -313,11 +326,11 @@ namespace Nekoyume.UI
             {
                 OnCompleteOfCloseAnimation();
                 gameObject.SetActive(false);
-                AnimationState = AnimationStateType.Closed;
+                AnimationState.Value = AnimationStateType.Closed;
                 return;
             }
 
-            AnimationState = AnimationStateType.Closing;
+            AnimationState.Value = AnimationStateType.Closing;
             // TODO : wait close animation
             if (!(_coClose is null))
             {
@@ -379,7 +392,7 @@ namespace Nekoyume.UI
             }
 
             gameObject.SetActive(false);
-            AnimationState = AnimationStateType.Closed;
+            AnimationState.Value = AnimationStateType.Closed;
         }
 
         private IEnumerator CoCompleteCloseAnimation()
@@ -388,7 +401,7 @@ namespace Nekoyume.UI
             if (!IsCloseAnimationCompleted)
             {
                 IsCloseAnimationCompleted = true;
-                AnimationState = AnimationStateType.Closed;
+                AnimationState.Value = AnimationStateType.Closed;
             }
         }
 
@@ -397,7 +410,7 @@ namespace Nekoyume.UI
         private void OnCompleteOfShowAnimation()
         {
             OnCompleteOfShowAnimationInternal();
-            AnimationState = AnimationStateType.Shown;
+            AnimationState.Value = AnimationStateType.Shown;
         }
 
         protected virtual void OnCompleteOfShowAnimationInternal()


### PR DESCRIPTION
### Description

1. Change type of `Widget.AnimationState` to `ReactiveProperty`.
2. Subscribe AnimationState, Can interact to `Selectable` objects when AnimationState equals `AnimationStateType.Shown`.

### Related Links

[UI 위젯 연출 주기 상 Shown일 때에만 버튼이 눌리게 하기](https://app.asana.com/0/1141562434100787/1172671756968572/f)


### Screenshot

before
![210910_selectable 0](https://user-images.githubusercontent.com/48484989/132821060-8e7e6c71-1c7a-4b54-aece-e44fa1ff52ec.gif)

after
![210910_selectable 1](https://user-images.githubusercontent.com/48484989/132821085-fa2e7098-c10c-45bf-92de-25cf0babac64.gif)

