### PR TITLE
Bugfix for v100078

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/CombinationSlots.cs
+++ b/nekoyume/Assets/_Scripts/UI/CombinationSlots.cs
@@ -54,14 +54,14 @@ namespace Nekoyume.UI
 
         public override void Show(bool ignoreShowAnimation = false)
         {
+            base.Show(ignoreShowAnimation);
+            UpdateSlots(Game.Game.instance.Agent.BlockIndex);
+            HelpPopup.HelpMe(100008, true);
+
             if (blur)
             {
                 blur.Show();
             }
-
-            base.Show(ignoreShowAnimation);
-            UpdateSlots(Game.Game.instance.Agent.BlockIndex);
-            HelpPopup.HelpMe(100008, true);
         }
 
         public void SetCaching(int slotIndex, bool value, long requiredBlockIndex = 0, ItemUsable itemUsable = null)

--- a/nekoyume/Assets/_Scripts/UI/Module/EquipmentInventory.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/EquipmentInventory.cs
@@ -130,12 +130,13 @@ namespace Nekoyume.UI.Module
 
         private void OnEnable()
         {
-            gradeFilter.SetValueWithoutNotify(0);
-            elementalFilter.SetValueWithoutNotify(0);
+            gradeFilter.value = 0;
+            elementalFilter.value = 0;
             ReactiveAvatarState.Inventory.Subscribe(inventoryState =>
             {
                 SharedModel.ResetItems(inventoryState);
                 _onResetItems.OnNext(this);
+                SortedData(_grade, _elemental);
             }).AddTo(_disposablesAtOnEnable);
         }
 


### PR DESCRIPTION
### Description

- Fixed to keep filtering even after upgrade item
- Change the timing of calling the blur.show()


### Related Links

[[development] 필터링 건 후 강화하면 인벤토리 필터가 자동으로 풀림](https://app.asana.com/0/1133453747809944/1200978734286987/f)
[[development] 강화 쪽에서 지속적으로 Coroutine 에러 잡힘](https://app.asana.com/0/1133453747809944/1200978734287003/f)

### Required Reviewers

@planetarium/9c-dev , @Namyujeong 
