### PR TITLE
Add booster-related mixpanel prop

### DIFF
--- a/nekoyume/Assets/_Scripts/BlockChain/ActionManager.cs
+++ b/nekoyume/Assets/_Scripts/BlockChain/ActionManager.cs
@@ -151,6 +151,13 @@ namespace Nekoyume.BlockChain
             int stageId,
             int playCount)
         {
+            Mixpanel.Track("Unity/HackAndSlash", new Value()
+            {
+                ["WorldId"] = worldId,
+                ["StageId"] = stageId,
+                ["PlayCount"] = playCount,
+            });
+
             var avatarAddress = States.Instance.CurrentAvatarState.address;
             costumes ??= new List<Costume>();
             equipments ??= new List<Equipment>();


### PR DESCRIPTION
### Description

Key : `Unity/HackAndSlash`
Prop : `WorldId`, `StageId`, `PlayCount`

### Related Links

[믹스패널 붙이기](https://app.asana.com/0/958521740385861/1201063060219329/f)

### Required Reviewers

@planetarium/9c-dev , @Namyujeong 