### PR TITLE
Prevent enumerating modifiable container in `Rank`.

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Model/Rank.cs
+++ b/nekoyume/Assets/_Scripts/UI/Model/Rank.cs
@@ -107,7 +107,8 @@ namespace Nekoyume.UI.Model
                 .ToList();
             AbilityRankingInfos.ForEach(i => i.Rank = rankOffset++);
 
-            foreach (var pair in States.Instance.AvatarStates)
+            var avatarStates = States.Instance.AvatarStates.ToList();
+            foreach (var pair in avatarStates)
             {
                 var avatarState = pair.Value;
                 var avatarAddress = avatarState.address;
@@ -177,7 +178,8 @@ namespace Nekoyume.UI.Model
                 .Where(e => e != null)
                 .ToList();
 
-            foreach (var pair in States.Instance.AvatarStates)
+            var avatarStates = States.Instance.AvatarStates.ToList();
+            foreach (var pair in avatarStates)
             {
                 var myInfoQuery =
                     $@"query {{
@@ -259,7 +261,8 @@ namespace Nekoyume.UI.Model
                 .Where(e => e != null)
                 .ToList();
 
-            foreach (var pair in States.Instance.AvatarStates)
+            var avatarStates = States.Instance.AvatarStates.ToList();
+            foreach (var pair in avatarStates)
             {
                 var myInfoQuery =
                     $@"query {{
@@ -339,7 +342,8 @@ namespace Nekoyume.UI.Model
                 .Where(e => e != null)
                 .ToList();
 
-            foreach (var pair in States.Instance.AvatarStates)
+            var avatarStates = States.Instance.AvatarStates.ToList();
+            foreach (var pair in avatarStates)
             {
                 var myInfoQuery =
                     $@"query {{
@@ -428,7 +432,8 @@ namespace Nekoyume.UI.Model
                     .Where(e => e != null)
                     .ToList();
 
-                foreach (var pair in States.Instance.AvatarStates)
+                var avatarStates = States.Instance.AvatarStates.ToList();
+                foreach (var pair in avatarStates)
                 {
                     var myInfoQuery =
                         $@"query {{


### PR DESCRIPTION
### Description

1. `States.AvatarStates` can be updated while loading ranking.
2. So prevented using direct reference of `States.AvatarState` while loading ranking.

### How to test

1. Check if `System.InvalidOperationException: Collection was modified; enumeration operation may not execute.` not occur any more while loading ranking.

### Related Links
1. https://app.asana.com/0/1141562434100787/1200991298498462

### Required Reviewers
@planetarium/9c-dev 
