### PR TITLE
Fix one line popup bug in boost popup button

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/QuestPreparation.cs
+++ b/nekoyume/Assets/_Scripts/UI/QuestPreparation.cs
@@ -231,6 +231,7 @@ namespace Nekoyume.UI
             boostPopupButton.OnClickAsObservable()
                 .Where(_ =>
                     !Game.Game.instance.States.CurrentAvatarState.worldInformation.IsStageCleared(_stageId.Value))
+                .ThrottleFirst(TimeSpan.FromSeconds(2f))
                 .Subscribe(_ => OneLinePopup.Push(MailType.System, "UI_BOOSTER_CONDITIONS_GUIDE"))
                 .AddTo(gameObject);
 


### PR DESCRIPTION
### Description

SSIA

### How to test

1. Make AP to zero.
2. Try to enter to any stage.

### Related Links

[[UI] 행동력이 없는 상태에서 부스터 UI 실행 시 별3개 조건에 대한 노티가 나타남](https://app.asana.com/0/1133453747809944/1201172876194188/f)

### Screenshot

Before
![211012 oneline before](https://user-images.githubusercontent.com/48484989/136900482-760967d1-965a-41f6-9f17-a0728ca2d0bf.gif)
After
![211012 oneline after](https://user-images.githubusercontent.com/48484989/136900499-93852c58-eb20-4455-99c3-cc1aa8dfccc9.gif)
