### PR TITLE
Fix issue that turning on the booster effect in arena

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Widget/Battle.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Battle.cs
@@ -115,6 +115,7 @@ namespace Nekoyume.UI
             repeatToggle.gameObject.SetActive(false);
             exitToggle.gameObject.SetActive(false);
             helpButton.gameObject.SetActive(false);
+            boostEffectObject.SetActive(false);
             base.Show(ignoreShowAnimation);
         }
 


### PR DESCRIPTION
### Description

1. In the past, when you played on any stage with a booster and entered the arena, the booster effect object was displayed.
2. Fixed it.

### How to test

1. Play eny stage with booster.
2. Enter the arena and check booster effect object.

### Related Links

[아레나에 부스트 UI 없애기](https://app.asana.com/0/1133453747809944/1201211711899940/f)