### PR TITLE
Fix build/compile error

### DIFF
--- a/nekoyume/Assets/_Scripts/BlockChain/Agent.cs
+++ b/nekoyume/Assets/_Scripts/BlockChain/Agent.cs
@@ -707,7 +707,7 @@ namespace Nekoyume.BlockChain
                     var errorMsg = string.Format(L10nManager.Localize("UI_ERROR_FORMAT"),
                         L10nManager.Localize("BOOTSTRAP_FAIL"));
 
-                    Widget.Find<SystemPopup>().Show(
+                    Widget.Find<TitleOneButtonSystem>().Show(
                         L10nManager.Localize("UI_ERROR"),
                         errorMsg,
                         L10nManager.Localize("UI_QUIT"),


### PR DESCRIPTION
### Description

1. Recently, `SystemPopup` was renamed `TitleOneButtonSystem`.
2. However, `Agent` was still using `SystemPopup`. It was difficult to find because there was no problem in the Unity editor by the preprocessor.
3. Fixed it.

### How to test

1. Try to build.