### PR TITLE
Block use booster in mimis brunnr with non-fire type equiments

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Widget/MimisbrunnrPreparation.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/MimisbrunnrPreparation.cs
@@ -209,6 +209,14 @@ namespace Nekoyume.UI
                 .Where(_ => EnoughActionPoint)
                 .Subscribe(_ =>
                 {
+                    if (!CheckEquipmentElementalType())
+                    {
+                        NotificationSystem.Push(
+                            MailType.System,
+                            L10nManager.Localize("UI_MIMISBRUNNR_START_FAIELD"));
+                        return;
+                    }
+
                     var costumes = _player.Costumes;
                     var equipments = equipmentSlots
                         .Where(slot => !slot.IsLock && !slot.IsEmpty)


### PR DESCRIPTION
### Description

SSIA

### How to test

1. Equip any equipment that not fire type.
2. Try to click booster button.

### Related Links

[[전투] 미미르의 샘 부스터 모드로 진입 시 불장비가 아니여도 진입 가능한 현상](https://app.asana.com/0/1133453747809944/1201283403176520/f)

### Screenshot
![GIF 2021-10-28 오후 3-28-57](https://user-images.githubusercontent.com/48484989/139200493-d08a9512-2cf8-4c0e-b93c-e6fde3b26e22.gif)


