### PR TITLE
Fix issue that exiting to lobby with backspace in shop 

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Widget/ShopBuy.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/ShopBuy.cs
@@ -69,13 +69,8 @@ namespace Nekoyume.UI
             closeButton.onClick.AddListener(() =>
             {
                 CleanUpWishListAlertPopup(Close);
-                Game.Event.OnRoomEnter.Invoke(true);
             });
-            CloseWidget = () =>
-            {
-                Close();
-                Game.Event.OnRoomEnter.Invoke(true);
-            };
+            CloseWidget = () => CleanUpWishListAlertPopup(Close);
         }
 
         public override void Initialize()
@@ -145,6 +140,7 @@ namespace Nekoyume.UI
             _npc?.gameObject.SetActive(false);
             shopItems.Close();
             Find<ItemCountAndPricePopup>().Close();
+            Game.Event.OnRoomEnter.Invoke(true);
             Close(true);
         }
 


### PR DESCRIPTION
### Description

SSIA

### How to test

1. Try any action in shop with `backspace`.

### Related Links

[[마켓] 마켓 - 검색 입력 중 백스페이스 입력할 경우 메인로비 상단 UI가 노출되는 현상](https://app.asana.com/0/1133453747809944/1201392367298205/f)
[[마켓] 다중 구매중 마켓 뒤로가기 버튼을 클릭할 경우 메인 UI를 불러오게 되어 마켓에 갇히는 현상](https://app.asana.com/0/1133453747809944/1201392367298199/f)

### Screenshot

![GIF 2021-11-18 오후 6-35-28](https://user-images.githubusercontent.com/48484989/142390575-a9d84ce8-7918-4226-b5f7-78c703a1c034.gif)

