### PR TITLE
Fix bugs about combination UI in header menu

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Module/CombinationSlot.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/CombinationSlot.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using Libplanet;
 using Nekoyume.Action;
@@ -16,7 +15,6 @@ using Nekoyume.UI.Model;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
-using Debug = UnityEngine.Debug;
 
 namespace Nekoyume.UI.Module
 {

--- a/nekoyume/Assets/_Scripts/UI/Module/CombinationSlot.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/CombinationSlot.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using Libplanet;
 using Nekoyume.Action;
@@ -15,6 +16,7 @@ using Nekoyume.UI.Model;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
+using Debug = UnityEngine.Debug;
 
 namespace Nekoyume.UI.Module
 {
@@ -342,6 +344,13 @@ namespace Nekoyume.UI.Module
                             L10nManager.Localize("UI_BLOCK_EXIT"),
                             NotificationCell.NotificationType.Alert);
                         return;
+                    }
+
+                    var widgetLayerRoot = MainCanvas.instance
+                        .GetLayerRootTransform(WidgetType.Widget);
+                    foreach (var widget in MainCanvas.instance.Widgets.Where(widget => widget.transform.parent.Equals(widgetLayerRoot)))
+                    {
+                        widget.Close(true);
                     }
 
                     Widget.Find<Craft>()?.gameObject.SetActive(false);

--- a/nekoyume/Assets/_Scripts/UI/Module/CombinationSlot.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/CombinationSlot.cs
@@ -348,7 +348,11 @@ namespace Nekoyume.UI.Module
 
                     var widgetLayerRoot = MainCanvas.instance
                         .GetLayerRootTransform(WidgetType.Widget);
-                    foreach (var widget in MainCanvas.instance.Widgets.Where(widget => widget.transform.parent.Equals(widgetLayerRoot)))
+                    var statusWidget = Widget.Find<Status>();
+                    foreach (var widget in MainCanvas.instance.Widgets.Where(widget =>
+                        widget.isActiveAndEnabled
+                        && widget.transform.parent.Equals(widgetLayerRoot)
+                        && !widget.Equals(statusWidget)))
                     {
                         widget.Close(true);
                     }


### PR DESCRIPTION
### Description

- Improve entering to combination UI by header menu.
- If enter to combination UI in header menu, close other widgets.

### How to test

1. Enter to combination UI in other UI.
2. Exit combination UI.
3. Check your screen and UI.

### Related Links

[[UI] 월드맵 씬에서 워크샵 슬롯으로 공방 진입 뒤 뒤로가기 버튼을 연타하여 다른 메뉴로 복귀할 경우 메인 로비 UI가 노출되는 현상](https://app.asana.com/0/1133453747809944/1201425663841552/f)
[특정 스텝을 통해 제작/강화를 시도하면 npc가 겹쳐보임](https://app.asana.com/0/1141562434100787/1201456475650182/f)

### Required Reviewers

@planetarium/9c-dev @Namyujeong 