### PR TITLE
Ignore closing animation of battle UI when go to main lobby

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Widget/Popup/BattleResultPopup.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Popup/BattleResultPopup.cs
@@ -654,7 +654,7 @@ namespace Nekoyume.UI
             var eventName = $"Unity/Stage Exit {eventKey}";
             Analyzer.Instance.Track(eventName, props);
 
-            Find<Battle>().Close();
+            Find<Battle>().Close(true);
             Game.Event.OnRoomEnter.Invoke(true);
             Close();
         }


### PR DESCRIPTION
### Description

There is no separate animation that turns off in the battle UI, but it simply turns off after a certain period of time.
As a result, there was a problem that the UI overlapped, so the animation was ignored.

### How to test

1. Enter to any stage.
2. Back to main lobby.
3. Fastly click worldmap or mimis brunnr.

### Related Links

[[UI] 스테이지(월드맵, 미미르) 씬 진입 시 UI가 깨지는 현상](https://app.asana.com/0/1133453747809944/1201398508893244/f)

### Required Reviewers

@planetarium/9c-dev @Namyujeong 