### PR TITLE
Fix overlapping character spine

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Widget/Menu.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Menu.cs
@@ -434,6 +434,7 @@ namespace Nekoyume.UI
             StopSpeeches();
             Find<Status>().Close(true);
             Find<EventBanner>().Close(true);
+            Game.Game.instance.Stage.selectedPlayer.gameObject.SetActive(false);
             yield return new WaitForSeconds(duration);
             base.Close(ignoreCloseAnimation);
         }


### PR DESCRIPTION
### Description

SSIA

### How to test

1. Check character spine in `FriendInfoPopup` in selecting world/stage UI.

### Related Links

[[랭킹] 전투 준비 화면에서 랭킹 상세 정보 팝업 출력 시 다른 유저의 캐릭터와 플레이어의 캐릭터가 겹쳐서 노출되는 현상](https://app.asana.com/0/1133453747809944/1201425497955028/f)

### Required Reviewers

@planetarium/9c-dev @Namyujeong 

### Screenshot

![image](https://user-images.githubusercontent.com/48484989/146726466-e6d4992d-0cd9-41b4-b2c3-74572d96fb49.png)
![image](https://user-images.githubusercontent.com/48484989/146726475-0a0ebb61-0240-4da0-a5f7-d1ccba5a7103.png)
