### PR TITLE
Show alert on exception thrown while creating spine prefab.

### DIFF
--- a/nekoyume/Assets/Planetarium/Nekoyume/Editor/SpineEditor.cs
+++ b/nekoyume/Assets/Planetarium/Nekoyume/Editor/SpineEditor.cs
@@ -57,7 +57,7 @@ namespace Planetarium.Nekoyume.Editor
                 return;
             }
 
-            CreateSpinePrefabInternal(skeletonDataAsset);
+            CreateSpinePrefab(skeletonDataAsset);
         }
 
         [MenuItem("Tools/9C/Create Spine Prefab(All FullCostume)", false, 0)]
@@ -567,7 +567,31 @@ namespace Planetarium.Nekoyume.Editor
                     continue;
                 }
 
+                try
+                {
+                    CreateSpinePrefab(skeletonDataAsset);
+                }
+                catch (Exception e)
+                {
+                    Debug.LogException(e);
+                    return;
+                }
+            }
+        }
+
+        private static void CreateSpinePrefab(SkeletonDataAsset skeletonDataAsset)
+        {
+            try
+            {
                 CreateSpinePrefabInternal(skeletonDataAsset);
+            }
+            catch (Exception e)
+            {
+                EditorUtility.DisplayDialog(
+                    "Error",
+                    $"Unexpected exception thrown while creating spine prefab.\n{e}",
+                    "OK");
+                throw e;
             }
         }
 


### PR DESCRIPTION
### Description

SSIA

### How to test

1. Throw any exception in `CreateSpinePrefabInternal` and try using it.

### Related Links
https://app.asana.com/0/958521740385861/1201200786778979

### Required Reviewers
@planetarium/9c-dev 

### Screenshot
![image](https://user-images.githubusercontent.com/26648527/146915401-497e2bd8-4459-41aa-8bf4-bddbee525bdb.png)
