### PR TITLE
Fix SetCombinationSlotStatesAsync() to be called whenever an avatar is selected

### DIFF
--- a/nekoyume/Assets/_Scripts/State/States.cs
+++ b/nekoyume/Assets/_Scripts/State/States.cs
@@ -280,6 +280,9 @@ namespace Nekoyume.State
 
             if (isNew)
             {
+                // notee: commit c1b7f0dc2e8fd922556b83f0b9b2d2d2b2626603 에서 코드 수정이 생기면서
+                // SetCombinationSlotStatesAsync()가 호출이 안되는 이슈가 있어서
+                // SetCombinationSlotStatesAsync()가 isNew 상관없이 호출되도록 임시 수정해놨습니다. 재수정 필요
                 _combinationSlotStates.Clear();
                 await UniTask.Run(async () =>
                 {

--- a/nekoyume/Assets/_Scripts/State/States.cs
+++ b/nekoyume/Assets/_Scripts/State/States.cs
@@ -283,10 +283,14 @@ namespace Nekoyume.State
                 _combinationSlotStates.Clear();
                 await UniTask.Run(async () =>
                 {
-                    await SetCombinationSlotStatesAsync(avatarState);
                     await AddOrReplaceAvatarStateAsync(avatarState, CurrentAvatarKey);
                 });
             }
+
+            await UniTask.Run(async () =>
+            {
+                await SetCombinationSlotStatesAsync(avatarState);
+            });
 
             if (Game.Game.instance.Agent is RPCAgent agent)
             {


### PR DESCRIPTION
### Description

- Fix SetCombinationSlotStatesAsync() to be called whenever an avatar is selected


### Related Link

[[공방] 제작, 강화가 작동하지 않는 현상](https://app.asana.com/0/1133453747809944/1201540375240617/f)


### Required Reviewers

@planetarium/9c-dev 
