### PR TITLE
Fix an issue about can not enter to workshop by header menu after arena battle

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Widget/Popup/RankingBattleResultPopup.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Popup/RankingBattleResultPopup.cs
@@ -75,6 +75,7 @@ namespace Nekoyume.UI
         public void BackToRanking()
         {
             Game.Game.instance.Stage.objectPool.ReleaseAll();
+            Game.Event.OnRoomEnter.Invoke(false);
             ActionCamera.instance.SetPosition(0f, 0f);
             ActionCamera.instance.Idle();
             Find<RankingBoard>().Show();


### PR DESCRIPTION
### Description

1. In the past, has an issue about can not enter to workshop by header menu after arena battle.
2. So, add invoking `OnRoomEnter` in closing arena result popup for `IsInStage = false;`

### How to test

1. Do ranking battle.
2. Try enter to workshop by header menu.

### Related Links

[[아레나] 아레나 전투 진행 후 워크샵 슬롯을 이용하여 공방 이동 시도 시 전투 중이라는 문구가 출력됨](https://app.asana.com/0/1133453747809944/1201530071102752/f)

### Required Reviewers

@planetarium/9c-dev @Namyujeong 