### PR TITLE
Fix a bug about overlapping UI by arena exitting

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Widget/Popup/RankingBattleResultPopup.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Popup/RankingBattleResultPopup.cs
@@ -75,7 +75,7 @@ namespace Nekoyume.UI
         public void BackToRanking()
         {
             Game.Game.instance.Stage.objectPool.ReleaseAll();
-            Game.Event.OnRoomEnter.Invoke(false);
+            Game.Game.instance.Stage.IsInStage = false;
             ActionCamera.instance.SetPosition(0f, 0f);
             ActionCamera.instance.Idle();
             Find<RankingBoard>().Show();


### PR DESCRIPTION
### Description

1. Even after the battle of Arena, there was a problem that the battle was not over. #1104 
2. As a result of fixing the problem, there was a problem that the UI of the Arena and the main lobby overlapped.
3. I fixed that.

### How to test

1. Try to any battle in arena

### Related Links

[(에디터에서 발생) 아레나 전투 시 간헐적으로 메인화면에서 전투함.](https://app.asana.com/0/1141562434100787/1201623508971434/f)

### Required Reviewers

@planetarium/9c-dev @Namyujeong 