### PR TITLE
Fix to be modified only when it matches the current avatar state

### DIFF
--- a/nekoyume/Assets/_Scripts/State/LocalLayerModifier.cs
+++ b/nekoyume/Assets/_Scripts/State/LocalLayerModifier.cs
@@ -81,13 +81,12 @@ namespace Nekoyume.State
                 return;
             }
 
-            outAvatarState = modifier.Modify(outAvatarState);
-
             if (!isCurrentAvatarState)
             {
                 return;
             }
 
+            outAvatarState = modifier.Modify(outAvatarState);
             ReactiveAvatarState.UpdateActionPoint(outAvatarState.actionPoint);
         }
 


### PR DESCRIPTION
### Description

Fix to be modified only when it matches the current avatar state

### Related Links

[[행동력] 행동력 리필 후 전투 진입 시도 시 행동력이 부족한 상태로 보임](https://app.asana.com/0/1133453747809944/1200937999314478/f)

### Required Reviewers

@planetarium/9c-dev 
