### PR TITLE
Fix not closed loading screen in synopsis of new user

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Widget/Synopsis.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Synopsis.cs
@@ -402,6 +402,7 @@ namespace Nekoyume.UI
                 catch (KeyNotFoundException e)
                 {
                     Debug.LogWarning(e.Message);
+                    Find<DataLoadingScreen>().Close();
                     EnterLogin();
                 }
             }


### PR DESCRIPTION
### Description

1. SSIA

### How to test

1. Make new genesis block.
2. Set `GameConfig.IsEditor` to false.
3. Try to enter to synopsis.

### Related Links

[제네시스 새로 찍고 시놉시스를 넘어갈 수 없음](https://app.asana.com/0/1141562434100787/1201684868189284/f)

### Required Reviewers

@planetarium/9c-dev @ipdae @area363 
