### PR TITLE
ci(gh-actions): fail step when failed to upload artifact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,6 +60,7 @@ jobs:
           name: 9c-${{ matrix.targetPlatform }}
           path: nekoyume/Build/${{ matrix.targetPlatform }}
           retention-days: 1
+          if-no-files-found: error
   publish:
     name: Publish Unity Player for ${{ matrix.targetPlatform }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Description

Currently, the failed step `Build for macOS on version 2020.3.4f1` seems successful with green light though its *macOS* builds were failed. It occurred because [`actions/upload-artifact`](https://github.com/actions/upload-artifact) action doesn't throw error. The action has `if-no-files-found` input and its default value is `warn` so it didn't throw an error but outputs as `warn` level.

So I think it can make people look illusion that the build for macOS was succeeded! Of course, it doesn't. I suggest making it fail when there are no files.

### How to test

Compare workflows' steps:

- Before this pull request: https://github.com/planetarium/NineChronicles/runs/4892388956?check_suite_focus=true 
![image](https://user-images.githubusercontent.com/26626194/150620313-b11f7681-ede9-4c18-a8a3-5734aa861d74.png)

- After this pull request: https://github.com/planetarium/NineChronicles/runs/4904160441?check_suite_focus=true 
![image](https://user-images.githubusercontent.com/26626194/150620321-27c71a7a-65bb-4a32-909d-26161671560c.png)


### Related Links

- https://github.com/actions/upload-artifact

### Required Reviewers

- @planetarium/9c-dev 