### PR TITLE
Fix macOS build

### DIFF
--- a/.github/workflows/build-misc.yml
+++ b/.github/workflows/build-misc.yml
@@ -9,13 +9,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@master
-      if: github.event_name != 'pull_request'
       with:
-        submodules: recursive
-    - uses: actions/checkout@master
-      if: github.event_name == 'pull_request'
-      with:
-        ref: ${{ github.pull_request.head.sha }}
         submodules: recursive
     - run: hooks/pre-commit
     - uses: unsplash/comment-on-pr@master

--- a/nekoyume/Assets/Editor/Builder.cs
+++ b/nekoyume/Assets/Editor/Builder.cs
@@ -5,6 +5,9 @@ using UnityEngine;
 using UnityEditor;
 using UnityEditor.Build.Reporting;
 using UnityEditor.Callbacks;
+#if UNITY_STANDALONE_OSX
+using UnityEditor.OSXStandalone;
+#endif
 
 namespace Editor
 {
@@ -16,17 +19,50 @@ namespace Editor
         [MenuItem("Build/Standalone/Windows + macOS + Linux")]
         public static void BuildAll()
         {
+#if UNITY_STANDALONE_OSX
             BuildMacOS();
+            // BuildMacOSArm64();
+#endif
             BuildWindows();
             BuildLinux();
         }
 
-        [MenuItem("Build/Standalone/macOS")]
+#if UNITY_STANDALONE_OSX
+        [MenuItem("Build/Standalone/macOS (Intel)")]
         public static void BuildMacOS()
         {
-            Debug.Log("Build macOS");
-            Build(BuildTarget.StandaloneOSX, targetDirName: "macOS");
+            Debug.Log("Build macOS (Intel)");
+            var originalArchitecture = UserBuildSettings.architecture;
+            try
+            {
+                UserBuildSettings.architecture = MacOSArchitecture.x64;
+                Build(BuildTarget.StandaloneOSX, targetDirName: "macOS");
+            }
+            finally
+            {
+                UserBuildSettings.architecture = originalArchitecture;
+            }
         }
+
+        /*
+        // TODO: macOS Apple Silicon
+        [MenuItem("Build/Standalone/macOS (Apple Silicon)")]
+        public static void BuildMacOSArm64()
+        {
+            Debug.Log("Build macOS (Apple Silicon)");
+            var originalArchitecture = UserBuildSettings.architecture;
+            try
+            {
+                UserBuildSettings.architecture = MacOSArchitecture.ARM64;
+                Build(BuildTarget.StandaloneOSX, targetDirName: "macOS (Apple Silicon)");
+            }
+            finally
+            {
+                UserBuildSettings.architecture = originalArchitecture;
+            }
+        }
+        */
+#endif
 
         [MenuItem("Build/Standalone/Windows")]
         public static void BuildWindows()

--- a/nekoyume/Assets/Editor/SpineSettings.asset
+++ b/nekoyume/Assets/Editor/SpineSettings.asset
@@ -19,7 +19,7 @@ MonoBehaviour:
   defaultInstantiateLoop: 1
   showHierarchyIcons: 1
   setTextureImporterSettings: 1
-  textureSettingsReference: Assets/Spine/Editor/spine-unity/Editor/ImporterPresets/PMATexturePreset.preset
+  textureSettingsReference: 
   blendModeMaterialMultiply: {fileID: 0}
   blendModeMaterialScreen: {fileID: 0}
   blendModeMaterialAdditive: {fileID: 0}

--- a/nekoyume/Assets/Packages/runtimes/linux-x64/native/librocksdb.so.meta
+++ b/nekoyume/Assets/Packages/runtimes/linux-x64/native/librocksdb.so.meta
@@ -12,6 +12,16 @@ PluginImporter:
   validateReferences: 1
   platformData:
   - first:
+      : Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Editor: 0
+        Exclude Linux64: 0
+        Exclude OSXUniversal: 1
+        Exclude Win: 0
+        Exclude Win64: 0
+  - first:
       Any: 
     second:
       enabled: 1
@@ -19,9 +29,35 @@ PluginImporter:
   - first:
       Editor: Editor
     second:
+      enabled: 1
+      settings:
+        CPU: x86_64
+        DefaultValueInitialized: true
+        OS: Linux
+  - first:
+      Standalone: Linux64
+    second:
+      enabled: 1
+      settings:
+        CPU: None
+  - first:
+      Standalone: OSXUniversal
+    second:
       enabled: 0
       settings:
-        DefaultValueInitialized: true
+        CPU: None
+  - first:
+      Standalone: Win
+    second:
+      enabled: 1
+      settings:
+        CPU: x86
+  - first:
+      Standalone: Win64
+    second:
+      enabled: 1
+      settings:
+        CPU: x86_64
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/nekoyume/Assets/Packages/runtimes/linux-x64/native/libsecp256k1.so.meta
+++ b/nekoyume/Assets/Packages/runtimes/linux-x64/native/libsecp256k1.so.meta
@@ -12,6 +12,16 @@ PluginImporter:
   validateReferences: 1
   platformData:
   - first:
+      : Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Editor: 0
+        Exclude Linux64: 0
+        Exclude OSXUniversal: 1
+        Exclude Win: 0
+        Exclude Win64: 0
+  - first:
       Any: 
     second:
       enabled: 1
@@ -19,9 +29,35 @@ PluginImporter:
   - first:
       Editor: Editor
     second:
+      enabled: 1
+      settings:
+        CPU: x86_64
+        DefaultValueInitialized: true
+        OS: Linux
+  - first:
+      Standalone: Linux64
+    second:
+      enabled: 1
+      settings:
+        CPU: None
+  - first:
+      Standalone: OSXUniversal
+    second:
       enabled: 0
       settings:
-        DefaultValueInitialized: true
+        CPU: None
+  - first:
+      Standalone: Win
+    second:
+      enabled: 1
+      settings:
+        CPU: x86
+  - first:
+      Standalone: Win64
+    second:
+      enabled: 1
+      settings:
+        CPU: x86_64
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/nekoyume/Assets/Packages/runtimes/osx-arm64/native/libgflags.2.2.dylib.meta
+++ b/nekoyume/Assets/Packages/runtimes/osx-arm64/native/libgflags.2.2.dylib.meta
@@ -12,6 +12,16 @@ PluginImporter:
   validateReferences: 1
   platformData:
   - first:
+      : Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Editor: 1
+        Exclude Linux64: 1
+        Exclude OSXUniversal: 1
+        Exclude Win: 1
+        Exclude Win64: 1
+  - first:
       Any: 
     second:
       enabled: 0
@@ -19,15 +29,35 @@ PluginImporter:
   - first:
       Editor: Editor
     second:
-      enabled: 1
+      enabled: 0
       settings:
+        CPU: AnyCPU
         DefaultValueInitialized: true
+        OS: OSX
+  - first:
+      Standalone: Linux64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
   - first:
       Standalone: OSXUniversal
     second:
-      enabled: 1
+      enabled: 0
       settings:
-        CPU: AnyCPU
+        CPU: None
+  - first:
+      Standalone: Win
+    second:
+      enabled: 0
+      settings:
+        CPU: x86
+  - first:
+      Standalone: Win64
+    second:
+      enabled: 0
+      settings:
+        CPU: x86_64
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/nekoyume/Assets/Packages/runtimes/osx-arm64/native/liblz4.1.dylib.meta
+++ b/nekoyume/Assets/Packages/runtimes/osx-arm64/native/liblz4.1.dylib.meta
@@ -12,6 +12,16 @@ PluginImporter:
   validateReferences: 1
   platformData:
   - first:
+      : Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Editor: 1
+        Exclude Linux64: 1
+        Exclude OSXUniversal: 1
+        Exclude Win: 1
+        Exclude Win64: 1
+  - first:
       Any: 
     second:
       enabled: 0
@@ -19,15 +29,35 @@ PluginImporter:
   - first:
       Editor: Editor
     second:
-      enabled: 1
+      enabled: 0
       settings:
+        CPU: AnyCPU
         DefaultValueInitialized: true
+        OS: AnyOS
+  - first:
+      Standalone: Linux64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
   - first:
       Standalone: OSXUniversal
     second:
-      enabled: 1
+      enabled: 0
       settings:
-        CPU: AnyCPU
+        CPU: None
+  - first:
+      Standalone: Win
+    second:
+      enabled: 0
+      settings:
+        CPU: x86
+  - first:
+      Standalone: Win64
+    second:
+      enabled: 0
+      settings:
+        CPU: x86_64
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/nekoyume/Assets/Packages/runtimes/osx-arm64/native/librocksdb.dylib.meta
+++ b/nekoyume/Assets/Packages/runtimes/osx-arm64/native/librocksdb.dylib.meta
@@ -12,6 +12,16 @@ PluginImporter:
   validateReferences: 1
   platformData:
   - first:
+      : Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Editor: 1
+        Exclude Linux64: 1
+        Exclude OSXUniversal: 1
+        Exclude Win: 1
+        Exclude Win64: 1
+  - first:
       Any: 
     second:
       enabled: 0
@@ -19,15 +29,35 @@ PluginImporter:
   - first:
       Editor: Editor
     second:
-      enabled: 1
+      enabled: 0
       settings:
+        CPU: AnyCPU
         DefaultValueInitialized: true
+        OS: AnyOS
+  - first:
+      Standalone: Linux64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
   - first:
       Standalone: OSXUniversal
     second:
-      enabled: 1
+      enabled: 0
       settings:
-        CPU: AnyCPU
+        CPU: None
+  - first:
+      Standalone: Win
+    second:
+      enabled: 0
+      settings:
+        CPU: x86
+  - first:
+      Standalone: Win64
+    second:
+      enabled: 0
+      settings:
+        CPU: x86_64
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/nekoyume/Assets/Packages/runtimes/osx-arm64/native/libsnappy.1.dylib.meta
+++ b/nekoyume/Assets/Packages/runtimes/osx-arm64/native/libsnappy.1.dylib.meta
@@ -12,6 +12,16 @@ PluginImporter:
   validateReferences: 1
   platformData:
   - first:
+      : Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Editor: 1
+        Exclude Linux64: 1
+        Exclude OSXUniversal: 1
+        Exclude Win: 1
+        Exclude Win64: 1
+  - first:
       Any: 
     second:
       enabled: 0
@@ -19,15 +29,35 @@ PluginImporter:
   - first:
       Editor: Editor
     second:
-      enabled: 1
+      enabled: 0
       settings:
+        CPU: AnyCPU
         DefaultValueInitialized: true
+        OS: AnyOS
+  - first:
+      Standalone: Linux64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
   - first:
       Standalone: OSXUniversal
     second:
-      enabled: 1
+      enabled: 0
       settings:
-        CPU: AnyCPU
+        CPU: None
+  - first:
+      Standalone: Win
+    second:
+      enabled: 0
+      settings:
+        CPU: x86
+  - first:
+      Standalone: Win64
+    second:
+      enabled: 0
+      settings:
+        CPU: x86_64
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/nekoyume/Assets/Packages/runtimes/osx-arm64/native/libzstd.1.dylib.meta
+++ b/nekoyume/Assets/Packages/runtimes/osx-arm64/native/libzstd.1.dylib.meta
@@ -12,6 +12,16 @@ PluginImporter:
   validateReferences: 1
   platformData:
   - first:
+      : Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Editor: 1
+        Exclude Linux64: 1
+        Exclude OSXUniversal: 1
+        Exclude Win: 1
+        Exclude Win64: 1
+  - first:
       Any: 
     second:
       enabled: 0
@@ -19,15 +29,35 @@ PluginImporter:
   - first:
       Editor: Editor
     second:
-      enabled: 1
+      enabled: 0
       settings:
+        CPU: AnyCPU
         DefaultValueInitialized: true
+        OS: OSX
+  - first:
+      Standalone: Linux64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
   - first:
       Standalone: OSXUniversal
     second:
-      enabled: 1
+      enabled: 0
       settings:
-        CPU: AnyCPU
+        CPU: None
+  - first:
+      Standalone: Win
+    second:
+      enabled: 0
+      settings:
+        CPU: x86
+  - first:
+      Standalone: Win64
+    second:
+      enabled: 0
+      settings:
+        CPU: x86_64
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/nekoyume/Assets/Packages/runtimes/osx-x64/native/libgflags.2.2.dylib.meta
+++ b/nekoyume/Assets/Packages/runtimes/osx-x64/native/libgflags.2.2.dylib.meta
@@ -1,7 +1,63 @@
 fileFormatVersion: 2
 guid: 6a21f26f2e439405cbed327de33da2c6
-DefaultImporter:
+PluginImporter:
   externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      : Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Editor: 0
+        Exclude Linux64: 1
+        Exclude OSXUniversal: 0
+        Exclude Win: 1
+        Exclude Win64: 1
+  - first:
+      Any: 
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 1
+      settings:
+        CPU: x86_64
+        DefaultValueInitialized: true
+        OS: OSX
+  - first:
+      Standalone: Linux64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: OSXUniversal
+    second:
+      enabled: 1
+      settings:
+        CPU: x86_64
+  - first:
+      Standalone: Win
+    second:
+      enabled: 0
+      settings:
+        CPU: x86
+  - first:
+      Standalone: Win64
+    second:
+      enabled: 0
+      settings:
+        CPU: x86_64
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/nekoyume/Assets/Packages/runtimes/osx-x64/native/liblz4.1.dylib.meta
+++ b/nekoyume/Assets/Packages/runtimes/osx-x64/native/liblz4.1.dylib.meta
@@ -1,7 +1,63 @@
 fileFormatVersion: 2
 guid: a6e4db8299ac54501a9476846e715bdd
-DefaultImporter:
+PluginImporter:
   externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      : Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Editor: 0
+        Exclude Linux64: 1
+        Exclude OSXUniversal: 0
+        Exclude Win: 1
+        Exclude Win64: 1
+  - first:
+      Any: 
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 1
+      settings:
+        CPU: x86_64
+        DefaultValueInitialized: true
+        OS: OSX
+  - first:
+      Standalone: Linux64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: OSXUniversal
+    second:
+      enabled: 1
+      settings:
+        CPU: x86_64
+  - first:
+      Standalone: Win
+    second:
+      enabled: 0
+      settings:
+        CPU: x86
+  - first:
+      Standalone: Win64
+    second:
+      enabled: 0
+      settings:
+        CPU: x86_64
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/nekoyume/Assets/Packages/runtimes/osx-x64/native/librocksdb.dylib.meta
+++ b/nekoyume/Assets/Packages/runtimes/osx-x64/native/librocksdb.dylib.meta
@@ -1,7 +1,63 @@
 fileFormatVersion: 2
 guid: e3ff1ed8500484b86becbaaab2b2a7c1
-DefaultImporter:
+PluginImporter:
   externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      : Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Editor: 0
+        Exclude Linux64: 1
+        Exclude OSXUniversal: 0
+        Exclude Win: 1
+        Exclude Win64: 1
+  - first:
+      Any: 
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 1
+      settings:
+        CPU: x86_64
+        DefaultValueInitialized: true
+        OS: OSX
+  - first:
+      Standalone: Linux64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: OSXUniversal
+    second:
+      enabled: 1
+      settings:
+        CPU: x86_64
+  - first:
+      Standalone: Win
+    second:
+      enabled: 0
+      settings:
+        CPU: x86
+  - first:
+      Standalone: Win64
+    second:
+      enabled: 0
+      settings:
+        CPU: x86_64
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/nekoyume/Assets/Packages/runtimes/osx-x64/native/libsecp256k1.dylib.meta
+++ b/nekoyume/Assets/Packages/runtimes/osx-x64/native/libsecp256k1.dylib.meta
@@ -1,7 +1,63 @@
 fileFormatVersion: 2
 guid: 1d7d43e6127e54a319ed09302f040019
-DefaultImporter:
+PluginImporter:
   externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      : Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Editor: 0
+        Exclude Linux64: 1
+        Exclude OSXUniversal: 0
+        Exclude Win: 1
+        Exclude Win64: 1
+  - first:
+      Any: 
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 1
+      settings:
+        CPU: x86_64
+        DefaultValueInitialized: true
+        OS: OSX
+  - first:
+      Standalone: Linux64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: OSXUniversal
+    second:
+      enabled: 1
+      settings:
+        CPU: x86_64
+  - first:
+      Standalone: Win
+    second:
+      enabled: 0
+      settings:
+        CPU: x86
+  - first:
+      Standalone: Win64
+    second:
+      enabled: 0
+      settings:
+        CPU: x86_64
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/nekoyume/Assets/Packages/runtimes/osx-x64/native/libsnappy.1.dylib.meta
+++ b/nekoyume/Assets/Packages/runtimes/osx-x64/native/libsnappy.1.dylib.meta
@@ -1,7 +1,63 @@
 fileFormatVersion: 2
 guid: 2cf34da7663f14491ab46b8a0133432a
-DefaultImporter:
+PluginImporter:
   externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      : Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Editor: 0
+        Exclude Linux64: 1
+        Exclude OSXUniversal: 0
+        Exclude Win: 1
+        Exclude Win64: 1
+  - first:
+      Any: 
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 1
+      settings:
+        CPU: x86_64
+        DefaultValueInitialized: true
+        OS: OSX
+  - first:
+      Standalone: Linux64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: OSXUniversal
+    second:
+      enabled: 1
+      settings:
+        CPU: x86_64
+  - first:
+      Standalone: Win
+    second:
+      enabled: 0
+      settings:
+        CPU: x86
+  - first:
+      Standalone: Win64
+    second:
+      enabled: 0
+      settings:
+        CPU: x86_64
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/nekoyume/Assets/Packages/runtimes/osx-x64/native/libzstd.1.dylib.meta
+++ b/nekoyume/Assets/Packages/runtimes/osx-x64/native/libzstd.1.dylib.meta
@@ -1,7 +1,63 @@
 fileFormatVersion: 2
 guid: 94ab23ef871544dd2a695a81b2c1222f
-DefaultImporter:
+PluginImporter:
   externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      : Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Editor: 0
+        Exclude Linux64: 1
+        Exclude OSXUniversal: 0
+        Exclude Win: 1
+        Exclude Win64: 1
+  - first:
+      Any: 
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 1
+      settings:
+        CPU: x86_64
+        DefaultValueInitialized: true
+        OS: OSX
+  - first:
+      Standalone: Linux64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: OSXUniversal
+    second:
+      enabled: 1
+      settings:
+        CPU: x86_64
+  - first:
+      Standalone: Win
+    second:
+      enabled: 0
+      settings:
+        CPU: x86
+  - first:
+      Standalone: Win64
+    second:
+      enabled: 0
+      settings:
+        CPU: x86_64
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/nekoyume/Assets/Packages/runtimes/win-x64/native/rocksdb.dll.meta
+++ b/nekoyume/Assets/Packages/runtimes/win-x64/native/rocksdb.dll.meta
@@ -12,6 +12,16 @@ PluginImporter:
   validateReferences: 1
   platformData:
   - first:
+      : Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Editor: 0
+        Exclude Linux64: 0
+        Exclude OSXUniversal: 0
+        Exclude Win: 1
+        Exclude Win64: 0
+  - first:
       Any: 
     second:
       enabled: 1
@@ -19,9 +29,35 @@ PluginImporter:
   - first:
       Editor: Editor
     second:
+      enabled: 1
+      settings:
+        CPU: x86_64
+        DefaultValueInitialized: true
+        OS: Windows
+  - first:
+      Standalone: Linux64
+    second:
+      enabled: 1
+      settings:
+        CPU: None
+  - first:
+      Standalone: OSXUniversal
+    second:
+      enabled: 1
+      settings:
+        CPU: None
+  - first:
+      Standalone: Win
+    second:
       enabled: 0
       settings:
-        DefaultValueInitialized: true
+        CPU: None
+  - first:
+      Standalone: Win64
+    second:
+      enabled: 1
+      settings:
+        CPU: x86_64
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/nekoyume/Assets/Packages/runtimes/win-x64/native/secp256k1.dll.meta
+++ b/nekoyume/Assets/Packages/runtimes/win-x64/native/secp256k1.dll.meta
@@ -12,6 +12,16 @@ PluginImporter:
   validateReferences: 1
   platformData:
   - first:
+      : Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Editor: 0
+        Exclude Linux64: 0
+        Exclude OSXUniversal: 0
+        Exclude Win: 1
+        Exclude Win64: 0
+  - first:
       Any: 
     second:
       enabled: 1
@@ -19,9 +29,35 @@ PluginImporter:
   - first:
       Editor: Editor
     second:
+      enabled: 1
+      settings:
+        CPU: x86_64
+        DefaultValueInitialized: true
+        OS: Windows
+  - first:
+      Standalone: Linux64
+    second:
+      enabled: 1
+      settings:
+        CPU: None
+  - first:
+      Standalone: OSXUniversal
+    second:
+      enabled: 1
+      settings:
+        CPU: None
+  - first:
+      Standalone: Win
+    second:
       enabled: 0
       settings:
-        DefaultValueInitialized: true
+        CPU: None
+  - first:
+      Standalone: Win64
+    second:
+      enabled: 1
+      settings:
+        CPU: x86_64
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/nekoyume/Assets/Resources/SpriteAtlases/UI/Atlas_Common.spriteatlas
+++ b/nekoyume/Assets/Resources/SpriteAtlases/UI/Atlas_Common.spriteatlas
@@ -47,7 +47,7 @@ SpriteAtlas:
     - {fileID: 102900000, guid: f4ec4f8b49db5487fae145d395ec1611, type: 3}
     - {fileID: 102900000, guid: 9c67e02a967534297bd452ad80ca3261, type: 3}
     - {fileID: 102900000, guid: 77aad0043bc7d4ee3a9fda3a23e966a8, type: 3}
-    totalSpriteSurfaceArea: 663070
+    totalSpriteSurfaceArea: 821073
     bindAsDefault: 1
     isAtlasV2: 0
     cachedData: {fileID: 0}
@@ -62,6 +62,7 @@ SpriteAtlas:
   - {fileID: 21300000, guid: 67408a906b2fa4a70a373d337e76c56b, type: 3}
   - {fileID: 21300000, guid: 981b3fb0e216846e39571136f99c1c60, type: 3}
   - {fileID: 21300000, guid: 394623c0c45124e0cbc9a2158932e894, type: 3}
+  - {fileID: 21300000, guid: e3f4f6c0067de4aaf9d8e7a138a3c147, type: 3}
   - {fileID: 21300000, guid: 633313d0ff9414b49bd1914e1334107e, type: 3}
   - {fileID: 21300000, guid: 5cb3a1e068b394b1ba033ec945d1e7ba, type: 3}
   - {fileID: 21300000, guid: eb8ae001e201248ec82527da02ac7069, type: 3}
@@ -114,6 +115,7 @@ SpriteAtlas:
   - {fileID: 21300000, guid: 82ae1a54b2a0d4051807eaff117e5c4a, type: 3}
   - {fileID: 21300000, guid: 27f5c7643ad9ea2489ca76e7550f3cb0, type: 3}
   - {fileID: 21300000, guid: 80b9daa468e2f480b85e9fd95b10464f, type: 3}
+  - {fileID: 21300000, guid: 23d16fa48a0c1421ebe1ed94052dbff5, type: 3}
   - {fileID: 21300000, guid: 9aef99b4fc6a30e458f9ca5fcfb82fa7, type: 3}
   - {fileID: 21300000, guid: 7866f2c4f85f74b3b895838c9004d9d5, type: 3}
   - {fileID: 21300000, guid: 044e76c449acb47b2823633fcc529c04, type: 3}
@@ -129,8 +131,10 @@ SpriteAtlas:
   - {fileID: 21300000, guid: 79d7d7853a4c41446acb200afd5dbfa5, type: 3}
   - {fileID: 21300000, guid: c5cfbc852996246b2bf6b5e38308cfde, type: 3}
   - {fileID: 21300000, guid: e6a08395750dc4f058d8f5edf113f2ba, type: 3}
+  - {fileID: 21300000, guid: 070e16a528d8a4677ab39476e5be0dce, type: 3}
   - {fileID: 21300000, guid: 1a9e4fa58d6c21049bb913ef2ca612e6, type: 3}
   - {fileID: 21300000, guid: 30a478f5996bd4def816264c5de37758, type: 3}
+  - {fileID: 21300000, guid: 8b00ecf5590ff4124a931a3d1066af98, type: 3}
   - {fileID: 21300000, guid: df311ef54d18b4783b08992537b2c5a0, type: 3}
   - {fileID: 21300000, guid: 1aba2ef57edd943f59b1f0cf265907f9, type: 3}
   - {fileID: 21300000, guid: 64fc4326c7a86644797a22765b9fcff9, type: 3}
@@ -183,6 +187,7 @@ SpriteAtlas:
   - {fileID: 21300000, guid: 801939e9c8bca4fd480e1d967b397c57, type: 3}
   - {fileID: 21300000, guid: a94d2be9dc0ea43feb0f058c8287713c, type: 3}
   - {fileID: 21300000, guid: fbecd0f9ef95e4cc684ee965e927d8cb, type: 3}
+  - {fileID: 21300000, guid: 65eadbf987cc64261ad47abb6890e421, type: 3}
   - {fileID: 21300000, guid: 7a3e970aaad17cb4895deb2e92893e00, type: 3}
   - {fileID: 21300000, guid: 5c85a80a68239479da7866a9243cd434, type: 3}
   - {fileID: 21300000, guid: 2fd70c0a9f25243deadb000d02ad9de9, type: 3}
@@ -201,13 +206,13 @@ SpriteAtlas:
   - {fileID: 21300000, guid: 8acaca3b35c844ec8891beb27842c733, type: 3}
   - {fileID: 21300000, guid: 9e78384b0271b2047a97b43bce997cb3, type: 3}
   - {fileID: 21300000, guid: ba30455b041df4b29a44c5acdf38d5d6, type: 3}
+  - {fileID: 21300000, guid: 170f465bb851c494d943c069594a4712, type: 3}
   - {fileID: 21300000, guid: eeb0136b01a784e74a603928e640bb88, type: 3}
   - {fileID: 21300000, guid: bf1c4b7b7cb1f4261b99562ecec2cc1e, type: 3}
   - {fileID: 21300000, guid: 9e9b008bd39ec4fdda2ba2614e002eda, type: 3}
   - {fileID: 21300000, guid: fe24f69b6be404a25be81909a9d27f18, type: 3}
   - {fileID: 21300000, guid: cf3941ab6508d4ee7b66668948a7358e, type: 3}
   - {fileID: 21300000, guid: eae315ebbb3f0b34db0e5cbf2ae66102, type: 3}
-  - {fileID: 21300000, guid: 41e9a7fbea721435ea5ea29618fa9597, type: 3}
   - {fileID: 21300000, guid: b202830c8a3394ca89b0ebb5931d1969, type: 3}
   - {fileID: 21300000, guid: cb638a1c9a3d04d888d6f5ba2f046f4b, type: 3}
   - {fileID: 21300000, guid: 0f16b14c39a634b3685af8884ae4d70c, type: 3}
@@ -247,6 +252,7 @@ SpriteAtlas:
   - {fileID: 21300000, guid: d7bacb7e936ba449eb8822af80165bb3, type: 3}
   - {fileID: 21300000, guid: bd420e9e797da42e6b8f8a430b1a6037, type: 3}
   - {fileID: 21300000, guid: f0df8e9ec6a684a5081471dcccc78859, type: 3}
+  - {fileID: 21300000, guid: 9be9cf9e9ece64adab4730b2b725164b, type: 3}
   - {fileID: 21300000, guid: 2ba464ae5f5ed45099296cab22f6aea8, type: 3}
   - {fileID: 21300000, guid: 6f4c5dae54f1c4edeabee331a51c79bc, type: 3}
   - {fileID: 21300000, guid: 147893be357c14da0ac9a5a3078f56c1, type: 3}
@@ -280,6 +286,7 @@ SpriteAtlas:
   - button_gold_close
   - UI_Popup_bg_06
   - item_bg_Active
+  - UI_Popup_bg_02_1
   - item_bg_Plusbg
   - UI_icon_Speech_01
   - UI_icon_Mainmenu_main
@@ -332,6 +339,7 @@ SpriteAtlas:
   - Item_bg_Grade_03
   - UI_bar_quest
   - Ani_Workshop_07
+  - button_Orange_04
   - UI_bar_02_yellow
   - UI_Quest_bg_Select
   - UI_popup_title_bg_03
@@ -347,8 +355,10 @@ SpriteAtlas:
   - icon_Inventory_04
   - Item_bg_Grade_02
   - Ani_Workshop_13
+  - UI_bg_frame_10
   - UI_icon_login_id
   - Common_bg_Arrow
+  - UI_popup_title_bg_04
   - Ani_Workshop_11
   - UI_main_icon_silver
   - UI_bar_02_pink_effect
@@ -401,6 +411,7 @@ SpriteAtlas:
   - UI_Gradiant_bg_01
   - item_bg_Plus
   - Ani_Workshop_05
+  - UI_bg_frame_deco_02
   - UI_bar_quest_bg
   - UI_icon_equip
   - UI_icon_Popup_04
@@ -419,13 +430,13 @@ SpriteAtlas:
   - UI_icon_repeat
   - UI_bar_02_pink
   - UI_icon_option_stat
+  - UI_box_02
   - Common_bg_Outline
   - Icon_Retrieve
   - UI_popup_list_bg
   - Ani_Workshop_16
   - Item_Recipebg_02
   - UI_icon_item_star_02
-  - UI_slot_Select
   - icon_Inventory_02_black
   - UI_Popup_icon_09
   - icon_Rank
@@ -465,6 +476,7 @@ SpriteAtlas:
   - UI_icon_Popup_01
   - level_frame
   - Ani_Workshop_01
+  - UI_bg_frame_11
   - icon_Inventory_01_black
   - UI_icon_Mainmenu_01
   - UI_icon_Popup_02

--- a/nekoyume/Assets/Resources/SpriteAtlases/UI/Atlas_Shop.spriteatlas
+++ b/nekoyume/Assets/Resources/SpriteAtlases/UI/Atlas_Shop.spriteatlas
@@ -47,7 +47,7 @@ SpriteAtlas:
     - {fileID: 102900000, guid: f4ec4f8b49db5487fae145d395ec1611, type: 3}
     - {fileID: 102900000, guid: 85f7dc4e2285f4e8eaa1d5143ed311b2, type: 3}
     - {fileID: 102900000, guid: 77aad0043bc7d4ee3a9fda3a23e966a8, type: 3}
-    totalSpriteSurfaceArea: 670195
+    totalSpriteSurfaceArea: 1074355
     bindAsDefault: 1
     isAtlasV2: 0
     cachedData: {fileID: 0}
@@ -60,6 +60,8 @@ SpriteAtlas:
   - {fileID: 21300000, guid: 20cfb2802ede847b3bd7399ebb092084, type: 3}
   - {fileID: 21300000, guid: 67408a906b2fa4a70a373d337e76c56b, type: 3}
   - {fileID: 21300000, guid: 981b3fb0e216846e39571136f99c1c60, type: 3}
+  - {fileID: 21300000, guid: 394623c0c45124e0cbc9a2158932e894, type: 3}
+  - {fileID: 21300000, guid: e3f4f6c0067de4aaf9d8e7a138a3c147, type: 3}
   - {fileID: 21300000, guid: 633313d0ff9414b49bd1914e1334107e, type: 3}
   - {fileID: 21300000, guid: 5cb3a1e068b394b1ba033ec945d1e7ba, type: 3}
   - {fileID: 21300000, guid: ad8ee2e030fce49f8a63a747d715d34b, type: 3}
@@ -86,6 +88,7 @@ SpriteAtlas:
   - {fileID: 21300000, guid: 80648c32993e048ee9518f2def412f33, type: 3}
   - {fileID: 21300000, guid: 761ec1420ef95ae45bd6601b31b36db2, type: 3}
   - {fileID: 21300000, guid: 1455c052005334ab6aa8ab41881519d1, type: 3}
+  - {fileID: 21300000, guid: 8a64af5246a66451fb5873024699fc80, type: 3}
   - {fileID: 21300000, guid: 1dd52c625e931c8419bd680c998ec26b, type: 3}
   - {fileID: 21300000, guid: c4a70f7223f4542f8a7a694c4752a18e, type: 3}
   - {fileID: 21300000, guid: 3483b1826aa594389a7d7299dcab8151, type: 3}
@@ -118,10 +121,12 @@ SpriteAtlas:
   - {fileID: 21300000, guid: 27f5c7643ad9ea2489ca76e7550f3cb0, type: 3}
   - {fileID: 21300000, guid: f344b094a4f5941708975a61e3df3791, type: 3}
   - {fileID: 21300000, guid: 44fb82a492cfe4e29bd5b178e6774a76, type: 3}
+  - {fileID: 21300000, guid: 23d16fa48a0c1421ebe1ed94052dbff5, type: 3}
   - {fileID: 21300000, guid: 9aef99b4fc6a30e458f9ca5fcfb82fa7, type: 3}
   - {fileID: 21300000, guid: 7866f2c4f85f74b3b895838c9004d9d5, type: 3}
   - {fileID: 21300000, guid: 044e76c449acb47b2823633fcc529c04, type: 3}
   - {fileID: 21300000, guid: dc3a78c44d0fa4c168d2f7121ffe8f0f, type: 3}
+  - {fileID: 21300000, guid: 566c89d4a28fb4e40b551dafa334d523, type: 3}
   - {fileID: 21300000, guid: a99ef02502f3b4638a5e1d1813aa6327, type: 3}
   - {fileID: 21300000, guid: b266fa2581a0a6b4780e415020def0c7, type: 3}
   - {fileID: 21300000, guid: aa1fa6458568e40e7983241ea9d23893, type: 3}
@@ -130,8 +135,10 @@ SpriteAtlas:
   - {fileID: 21300000, guid: b53dd685a2b6c46f28710d1b5e4e59c7, type: 3}
   - {fileID: 21300000, guid: 79d7d7853a4c41446acb200afd5dbfa5, type: 3}
   - {fileID: 21300000, guid: c5cfbc852996246b2bf6b5e38308cfde, type: 3}
+  - {fileID: 21300000, guid: 070e16a528d8a4677ab39476e5be0dce, type: 3}
   - {fileID: 21300000, guid: 1a9e4fa58d6c21049bb913ef2ca612e6, type: 3}
   - {fileID: 21300000, guid: 30a478f5996bd4def816264c5de37758, type: 3}
+  - {fileID: 21300000, guid: 8b00ecf5590ff4124a931a3d1066af98, type: 3}
   - {fileID: 21300000, guid: 1aba2ef57edd943f59b1f0cf265907f9, type: 3}
   - {fileID: 21300000, guid: 64fc4326c7a86644797a22765b9fcff9, type: 3}
   - {fileID: 21300000, guid: 7bf3e44650dbc904684badbe312edb69, type: 3}
@@ -155,6 +162,7 @@ SpriteAtlas:
   - {fileID: 21300000, guid: 363d1fb713d3d7544bba7bd873af24d3, type: 3}
   - {fileID: 21300000, guid: 808104c7483594cdb8dcfbd83cf135d3, type: 3}
   - {fileID: 21300000, guid: 0c2ed0f79d8d543699b1c942e15eb8ea, type: 3}
+  - {fileID: 21300000, guid: c48e1ff7c8e3b4faa9c64fedd4677b03, type: 3}
   - {fileID: 21300000, guid: 52d66508027f740f0843704bd3996b6f, type: 3}
   - {fileID: 21300000, guid: 5778c038d0194430ba2d1a410dc5c114, type: 3}
   - {fileID: 21300000, guid: bc830538b252a8e4490045f567b4aca0, type: 3}
@@ -187,8 +195,10 @@ SpriteAtlas:
   - {fileID: 21300000, guid: 8b6e1fd9bd10048279d3f98091872831, type: 3}
   - {fileID: 21300000, guid: 801939e9c8bca4fd480e1d967b397c57, type: 3}
   - {fileID: 21300000, guid: a94d2be9dc0ea43feb0f058c8287713c, type: 3}
+  - {fileID: 21300000, guid: 65eadbf987cc64261ad47abb6890e421, type: 3}
   - {fileID: 21300000, guid: 7a3e970aaad17cb4895deb2e92893e00, type: 3}
   - {fileID: 21300000, guid: 5c85a80a68239479da7866a9243cd434, type: 3}
+  - {fileID: 21300000, guid: 2fd70c0a9f25243deadb000d02ad9de9, type: 3}
   - {fileID: 21300000, guid: 05124d1a9966e43d5b08d3098e210f0e, type: 3}
   - {fileID: 21300000, guid: 7e04113a8c2d747ed84df151ea45cc63, type: 3}
   - {fileID: 21300000, guid: d311e33a308856d40954d8042f64bdc7, type: 3}
@@ -206,6 +216,7 @@ SpriteAtlas:
   - {fileID: 21300000, guid: 8acaca3b35c844ec8891beb27842c733, type: 3}
   - {fileID: 21300000, guid: 9e78384b0271b2047a97b43bce997cb3, type: 3}
   - {fileID: 21300000, guid: ba30455b041df4b29a44c5acdf38d5d6, type: 3}
+  - {fileID: 21300000, guid: 170f465bb851c494d943c069594a4712, type: 3}
   - {fileID: 21300000, guid: eeb0136b01a784e74a603928e640bb88, type: 3}
   - {fileID: 21300000, guid: bf1c4b7b7cb1f4261b99562ecec2cc1e, type: 3}
   - {fileID: 21300000, guid: 9e9b008bd39ec4fdda2ba2614e002eda, type: 3}
@@ -219,7 +230,6 @@ SpriteAtlas:
   - {fileID: 21300000, guid: f1b26d5cf0d82406992c76377df80415, type: 3}
   - {fileID: 21300000, guid: e668fd6c2bb3f403ab1f092d1b798252, type: 3}
   - {fileID: 21300000, guid: 960dbe6cf8ca94e7b9072e6a385cbbf6, type: 3}
-  - {fileID: 21300000, guid: d39adb8c5ebb3496a914eb49255ff959, type: 3}
   - {fileID: 21300000, guid: 753e929c23b294119a5f10a26bd7f7ae, type: 3}
   - {fileID: 21300000, guid: b823399c8d4d5485c8b8fad9f1e170b3, type: 3}
   - {fileID: 21300000, guid: 1a1a06ace2d6f904b83ef5cb4e006d5b, type: 3}
@@ -235,6 +245,7 @@ SpriteAtlas:
   - {fileID: 21300000, guid: 00af165de156e4b30b6579a0171e735f, type: 3}
   - {fileID: 21300000, guid: e123146d88eb44a739883087e4b9967b, type: 3}
   - {fileID: 21300000, guid: 9900946d0fad7480694b2ff70a563b12, type: 3}
+  - {fileID: 21300000, guid: 1470686d8ff164522a4673c95d475e06, type: 3}
   - {fileID: 21300000, guid: 8066567d7c88c46f588f60730ad30239, type: 3}
   - {fileID: 21300000, guid: c465477d66b004179b3c01d8f0432f77, type: 3}
   - {fileID: 21300000, guid: 5c033e7db52c44756810280ff49ba340, type: 3}
@@ -259,9 +270,12 @@ SpriteAtlas:
   - {fileID: 21300000, guid: fef1c45ed1fc04fd38a148fb0d1d520f, type: 3}
   - {fileID: 21300000, guid: 3d392e6e9977e4bd2a4329a4a3a8cd00, type: 3}
   - {fileID: 21300000, guid: b7649e6edca75435ebf160f1674c7968, type: 3}
+  - {fileID: 21300000, guid: d7bacb7e936ba449eb8822af80165bb3, type: 3}
   - {fileID: 21300000, guid: bd420e9e797da42e6b8f8a430b1a6037, type: 3}
+  - {fileID: 21300000, guid: 9be9cf9e9ece64adab4730b2b725164b, type: 3}
   - {fileID: 21300000, guid: 2ba464ae5f5ed45099296cab22f6aea8, type: 3}
   - {fileID: 21300000, guid: 6f4c5dae54f1c4edeabee331a51c79bc, type: 3}
+  - {fileID: 21300000, guid: 147893be357c14da0ac9a5a3078f56c1, type: 3}
   - {fileID: 21300000, guid: b00134ceb6ddd49d9b26b011d12ffb4b, type: 3}
   - {fileID: 21300000, guid: 03fb94ce603b3fa4d83f90720bcf8959, type: 3}
   - {fileID: 21300000, guid: 387b03fec498c4d489213b20a9f8dc62, type: 3}
@@ -274,10 +288,12 @@ SpriteAtlas:
   - {fileID: 21300000, guid: 9a0d5a9f0b4744fd0a25f609e609c327, type: 3}
   - {fileID: 21300000, guid: ad058a9fb486047bb874a29989be4e86, type: 3}
   - {fileID: 21300000, guid: dc9903af726674721b0d8f9876af2e4c, type: 3}
+  - {fileID: 21300000, guid: 1a8824af3752c4de0988621cbc3e5123, type: 3}
   - {fileID: 21300000, guid: 436028afaccf743a099b26ef9243b944, type: 3}
   - {fileID: 21300000, guid: 88d9c0bf735aa40f7972be4c39220d36, type: 3}
   - {fileID: 21300000, guid: db9b79bf829d9468aad193cf366f3c88, type: 3}
   - {fileID: 21300000, guid: bab990cfa756e49299b6b288c502eaf3, type: 3}
+  - {fileID: 21300000, guid: 74e8e5cfd6eba45eda812b8314fb17ea, type: 3}
   - {fileID: 21300000, guid: 15052acf63e0441dfb12772fe4088003, type: 3}
   - {fileID: 21300000, guid: 50b47dcf505c34e4d86179b86adfd223, type: 3}
   - {fileID: 21300000, guid: 02433fcf8ea93034fb9055a7d5fcd06e, type: 3}
@@ -291,6 +307,8 @@ SpriteAtlas:
   - UI_icon_new
   - button_gold_close
   - UI_Popup_bg_06
+  - item_bg_Active
+  - UI_Popup_bg_02_1
   - item_bg_Plusbg
   - UI_icon_Speech_01
   - Shop_bg_00
@@ -317,6 +335,7 @@ SpriteAtlas:
   - UI_bg_frame_08
   - UI_bar_02_blue
   - UI_bg_frame_07
+  - UI_bg_frame_deco_01
   - icon_combination_01_black
   - UI_icon_Skilloption_Eff
   - button_Orange_03
@@ -349,10 +368,12 @@ SpriteAtlas:
   - UI_bar_quest
   - icon_Reset
   - Shop_bg_08
+  - button_Orange_04
   - UI_bar_02_yellow
   - UI_Quest_bg_Select
   - UI_popup_title_bg_03
   - UI_icon_Mainmenu_04
+  - UI_bg_frame_09_tooltip
   - icon_Quest_01_black
   - UI_bar_03_bg
   - item_bg_Normal
@@ -361,8 +382,10 @@ SpriteAtlas:
   - UI_QuestType_bg_normal
   - icon_Inventory_04
   - Item_bg_Grade_02
+  - UI_bg_frame_10
   - UI_icon_login_id
   - Common_bg_Arrow
+  - UI_popup_title_bg_04
   - UI_main_icon_silver
   - UI_bar_02_pink_effect
   - UI_arrow_03
@@ -386,6 +409,7 @@ SpriteAtlas:
   - UI_bg_chat_02
   - UI_page_normal
   - UI_Btn_bg_03
+  - UI_main_icon_gold_big
   - UI_bar_01_red
   - UI_icon_item_cp_b
   - UI_bar_02_red
@@ -418,8 +442,10 @@ SpriteAtlas:
   - UI_popup_title_bg
   - UI_Gradiant_bg_01
   - item_bg_Plus
+  - UI_bg_frame_deco_02
   - UI_bar_quest_bg
   - UI_icon_equip
+  - UI_icon_Popup_04
   - Common_TabSub_Select
   - UI_main_icon_Hourglass
   - UI_bar_02_bg
@@ -437,6 +463,7 @@ SpriteAtlas:
   - UI_icon_repeat
   - UI_bar_02_pink
   - UI_icon_option_stat
+  - UI_box_02
   - Common_bg_Outline
   - Icon_Retrieve
   - UI_popup_list_bg
@@ -450,7 +477,6 @@ SpriteAtlas:
   - Shop_bg_06
   - icon_Cancle
   - Shop_bg_16
-  - UI_bg_Warning
   - UI_bar_01_green
   - UI_icon_check_04
   - UI_icon_select_02
@@ -466,6 +492,7 @@ SpriteAtlas:
   - Shop_bg_22
   - Item_Recipebg_03
   - UI_Btn_bg_02
+  - UI_bg_frame_deco_00
   - Icon_menu_buy
   - UI_QuestType_bg_Select
   - Common_TabBtn_Select
@@ -490,9 +517,12 @@ SpriteAtlas:
   - icon_git_01_black
   - UI_bg_frame_04
   - Common_Btn_Press
+  - UI_icon_Popup_01
   - level_frame
+  - UI_bg_frame_11
   - icon_Inventory_01_black
   - UI_icon_Mainmenu_01
+  - UI_icon_Popup_02
   - button_Round_Press
   - button_page_02
   - Shop_bg_03
@@ -505,10 +535,12 @@ SpriteAtlas:
   - UI_icon_select_02
   - Common_Prrogressbar_Bg
   - UI_bg_chat_03
+  - UI_icon_Popup_00
   - UI_icon_Dice
   - Shop_bg_01
   - UI_Popup_Attbg
   - Item_Recipebg_05
+  - UI_icon_Popup_03
   - item_frame
   - button_tab_bg_normal
   - icon_combination_05_black

--- a/nekoyume/Assets/Resources/SpriteAtlases/UI/Atlas_Worldmap.spriteatlas
+++ b/nekoyume/Assets/Resources/SpriteAtlases/UI/Atlas_Worldmap.spriteatlas
@@ -44,7 +44,7 @@ SpriteAtlas:
     variantMultiplier: 1
     packables:
     - {fileID: 102900000, guid: 7a39de26a3fd14fed89585d6c0e6e3b9, type: 3}
-    totalSpriteSurfaceArea: 108188
+    totalSpriteSurfaceArea: 202908
     bindAsDefault: 1
     isAtlasV2: 0
     cachedData: {fileID: 0}


### PR DESCRIPTION
This fixes several build errors during plugins (_lib\*.dylib_ binaries) on macOS:

<img width="765" alt="Multiple plugins with the same name 'librocksdb' (found at 'Assets/Packages/runtimes/osx-arm64/native/librocksdb.dylib' and 'Assets/Packages/runtimes/osx-x64/native/librocksdb.dylib'). That means one or more plugins are set to be compatible with Editor. Only one plugin at the time can be used by Editor." src="https://user-images.githubusercontent.com/12431/150933314-ff7f7b23-67f6-4312-b918-a2ae26489de5.png">

It caused because there are pairs of the same libraries for both Intel (_osx-x64_) and Apple Silicon (_osx-arm64_).  I explicitly specified the architecture for Intel binaries (⬅️ _left_), and temporarily excluded Apple Silicon binaries (_right_ ➡️):

<img width="290" alt="Plugin settings for Intel binaries" src="https://user-images.githubusercontent.com/12431/150932148-b7e4a8fa-dd54-493f-bca0-a96adcb6b7a0.png"><img width="290" alt="Plugin settings for Apple Silicon binaries" src="https://user-images.githubusercontent.com/12431/150932546-4e594a39-2e50-4325-b56e-bbe89a907dc4.png">

I also added a build method for Apple Silicon, but it's commented out as of now.  We would be possible to re-enable the build method when we upgrade the Unity Editor to a recent version.