### PR TITLE
Fix minor bugs about UI

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Widget/EventBanner.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/EventBanner.cs
@@ -33,9 +33,9 @@ namespace Nekoyume.UI.Module
             //     .Subscribe(_ => GoToArenaEventPage())
             //     .AddTo(gameObject);
 
-            bigCatYearEventButton.onClick.AsObservable()
-                .Subscribe(_ => GoTobigCatYearEventPage())
-                .AddTo(gameObject);
+            // bigCatYearEventButton.onClick.AsObservable()
+            //     .Subscribe(_ => GoTobigCatYearEventPage())
+            //     .AddTo(gameObject);
 
             playToEarnGoldEventButton.onClick.AsObservable()
                 .Subscribe(_ => GoToGoldEventPage())

--- a/nekoyume/Assets/_Scripts/UI/Widget/MimisbrunnrPreparation.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/MimisbrunnrPreparation.cs
@@ -29,7 +29,7 @@ namespace Nekoyume.UI
 
     public class MimisbrunnrPreparation : Widget
     {
-        private const int BoostMaxCount = 6;
+        private const int BoostMaxCount = 12;
 
         [SerializeField]
         private Module.Inventory inventory = null;

--- a/nekoyume/Assets/_Scripts/UI/Widget/Screen/DimmedLoadingScreen.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Screen/DimmedLoadingScreen.cs
@@ -16,8 +16,9 @@ namespace Nekoyume.UI
 
         private static string _defaultBlockSyncingMessage;
 
-        public void Start()
+        protected override void Awake()
         {
+            base.Awake();
             _defaultBlockSyncingMessage = L10nManager.Localize("UI_SYNCING_BLOCKS");
         }
 


### PR DESCRIPTION
### Description

1. Fix banner that doesn't work.
2. Fix max boost count in mimis brunnr. (6 to 12)
3. Add missing Block syncing message.

### How to test

1. Try to click event banner.
2. Try to mimis brunnr battle with booster.

### Related Links

[[UI] 로비 베너가 작동하지 않습니다.](https://app.asana.com/0/1133453747809944/1201824497981370/f)
[[전투] 미미르의 샘 Booster 전투 시 MaxAP 사용량이 월드 스테이지와 다르게 60AP로 설정되어 있는 현상](https://app.asana.com/0/1133453747809944/1201797611190199/f)
[블록 싱크 텍스트가 나오지 않음](https://app.asana.com/0/1141562434100787/1201856647592880/f)

### Screenshot

![image](https://user-images.githubusercontent.com/48484989/154954332-4efed815-9b17-4666-8bad-8023f3fb6de7.png)
![image](https://user-images.githubusercontent.com/48484989/155068250-da56730e-3282-47c5-a41c-c89fb088148d.png)
