### PR TITLE
Fix `ranking_battle` render

### DIFF
--- a/nekoyume/Assets/_Scripts/BlockChain/ActionRenderHandler.cs
+++ b/nekoyume/Assets/_Scripts/BlockChain/ActionRenderHandler.cs
@@ -1020,6 +1020,12 @@ namespace Nekoyume.BlockChain
                                 // ReSharper disable once ConvertClosureToMethodGroup
                                 .DoOnError(e => Debug.LogException(e));
                         });
+#if LIB9C_DEV_EXTENSIONS || UNITY_EDITOR
+                if (Widget.Find<ArenaBattleLoadingScreen>().IsActive())
+                {
+                    Widget.Find<RankingBoard>().GoToStage(eval.Action.Result);
+                }
+#else
                 var ead = (Dictionary)eval.Extra[nameof(Action.RankingBattle.EnemyAvatarState)];
                 var eid = (Dictionary)eval.Extra[nameof(Action.RankingBattle.EnemyArenaInfo)];
                 var aid = (Dictionary)eval.Extra[nameof(Action.RankingBattle.ArenaInfo)];
@@ -1045,6 +1051,7 @@ namespace Nekoyume.BlockChain
                 {
                     Widget.Find<RankingBoard>().GoToStage(log);
                 }
+#endif
             }
             else
             {


### PR DESCRIPTION
### Description

Fixed to use the log in the action result when rendering `ranking_battle10` action in single build

### How to test

action `ranking_battle10`

### Related Links

### Required Reviewers

@planetarium/9c-dev 

### Screenshot

<img width="693" alt="image" src="https://user-images.githubusercontent.com/40553495/156285348-de1a9d7b-3624-4679-b4d2-1ae2ec440b4a.png">

