### PR TITLE
Check tutorial is complete safely

### DIFF
--- a/nekoyume/Assets/Resources/UI/Prefabs/UI_NoticePopup.prefab
+++ b/nekoyume/Assets/Resources/UI/Prefabs/UI_NoticePopup.prefab
@@ -85,6 +85,7 @@ MonoBehaviour:
   contentImage: {fileID: 7751381609379836820}
   detailButton: {fileID: 8915038191723940672}
   closeButton: {fileID: 9158407257095490729}
+  blur: {fileID: 4364962393925945222}
   noticeList:
   - name: ItemLevelRequirement
     contentImage: {fileID: 21300000, guid: b589945f0075e4edd97b91455a20dc3a, type: 3}
@@ -997,3 +998,15 @@ RectTransform:
     type: 3}
   m_PrefabInstance: {fileID: 1734889137708128112}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &4364962393925945222 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2630355418658099446, guid: 087d608eb50946b409525e83801de9d2,
+    type: 3}
+  m_PrefabInstance: {fileID: 1734889137708128112}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0398d8905be44004b803f2412d77ef52, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/nekoyume/Assets/_Scripts/UI/Tutorial/TutorialController.cs
+++ b/nekoyume/Assets/_Scripts/UI/Tutorial/TutorialController.cs
@@ -28,6 +28,19 @@ namespace Nekoyume.UI
 
         public bool IsPlaying => _tutorial.IsActive();
 
+        public bool IsCompleted
+        {
+            get
+            {
+                var worldInfo = Game.Game.instance.States.CurrentAvatarState.worldInformation;
+                if (worldInfo is null) return false;
+                var clearedStageId = worldInfo.TryGetLastClearedStageId(out var id) ? id : 1;
+                if (GetCheckPoint(clearedStageId) != 0) return false;
+
+                return !IsPlaying;
+            }
+        }
+
         public TutorialController(IEnumerable<Widget> widgets)
         {
             foreach (var widget in widgets)
@@ -158,7 +171,7 @@ namespace Nekoyume.UI
             return data;
         }
 
-        public static int GetCheckPoint(int clearedStageId)
+        private static int GetCheckPoint(int clearedStageId)
         {
             if(PlayerPrefs.HasKey(CheckPoint))
             {

--- a/nekoyume/Assets/_Scripts/UI/Widget/Popup/NoticePopup.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Popup/NoticePopup.cs
@@ -29,6 +29,9 @@ namespace Nekoyume.UI
 
         [SerializeField]
         private Button closeButton;
+        
+        [SerializeField]
+        private Blur blur;
 
         [SerializeField]
         private NoticeInfo[] noticeList =
@@ -77,6 +80,11 @@ namespace Nekoyume.UI
                 Close();
                 AudioController.PlayClick();
             });
+
+            blur.button.onClick.AddListener(() =>
+            {
+                Close();
+            });
         }
 
         public override void Show(bool ignoreStartAnimation = false)
@@ -89,6 +97,20 @@ namespace Nekoyume.UI
 
             contentImage.sprite = firstNotice.contentImage;
             base.Show(ignoreStartAnimation);
+            if (blur)
+            {
+                blur.Show();
+            }
+        }
+        
+        public override void Close(bool ignoreCloseAnimation = false)
+        {
+            if (blur && blur.isActiveAndEnabled)
+            {
+                blur.Close();
+            }
+
+            base.Close(ignoreCloseAnimation);
         }
 
         private void GoToNoticePage()

--- a/nekoyume/Assets/_Scripts/UI/Widget/Popup/NoticePopup.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Popup/NoticePopup.cs
@@ -47,29 +47,17 @@ namespace Nekoyume.UI
 
         private static bool CanShowNoticePopup(NoticeInfo notice)
         {
-            if (notice == null)
-            {
-                return false;
-            }
-
-            var worldInfo = Game.Game.instance.States.CurrentAvatarState.worldInformation;
-            if (worldInfo is null) return false;
-            var clearedStageId = worldInfo.TryGetLastClearedStageId(out var id) ? id : 1;
-            if (TutorialController.GetCheckPoint(clearedStageId) != 0) return false;
-
-            var tutorialControllerIsPlaying = Game.Game.instance.Stage.TutorialController.IsPlaying;
-            if (tutorialControllerIsPlaying) return false;
-
+            if (notice == null) return false;
+            
+            if (!Game.Game.instance.Stage.TutorialController.IsCompleted) return false;
+            
             if (!Util.IsInTime(notice.beginTime, notice.endTime, false)) return false;
 
             var lastNoticeDayKey = string.Format(LastNoticeDayKeyFormat, notice.name);
             var lastNoticeDay = DateTime.Parse(PlayerPrefs.GetString(lastNoticeDayKey, "2022/03/01 00:00:00"));
             var now = DateTime.UtcNow;
             var isNewDay = now.Year != lastNoticeDay.Year || now.Month != lastNoticeDay.Month || now.Day != lastNoticeDay.Day;
-            if (isNewDay)
-            {
-                PlayerPrefs.SetString(lastNoticeDayKey, now.ToString(CultureInfo.InvariantCulture));
-            }
+            if (isNewDay) PlayerPrefs.SetString(lastNoticeDayKey, now.ToString(CultureInfo.InvariantCulture));
 
             return isNewDay;
         }


### PR DESCRIPTION
### Description

- In previous PR(https://github.com/planetarium/NineChronicles/pull/1236), To Check the tutorial was completed, I edited `GetCheckPoint()` method public from private. But that change was Dangerous.
  So I Fixed it to make a new property to check `GetCheckPoint()` and `IsPlaying` internally.
- Fix the blur in NoticePopup, Because Blur's contents from `development` and `previewnet` branches are different.

### Related Links
Detail Description : [튜토리얼 진행 여부 안전하게 확인하기](https://app.asana.com/0/958521740385861/1201959332771026/f)
https://github.com/planetarium/NineChronicles/pull/1236#discussion_r825542225
