### PR TITLE
Remove settings folder at uninstall

### DIFF
--- a/tools/installer/installer.iss
+++ b/tools/installer/installer.iss
@@ -44,6 +44,9 @@ Name: "{autoprograms}\{#MyAppName}"; Filename: "{app}\{#GameExeName}"
 Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#GameExeName}"; Tasks: CreateDesktopIcon
 Name: "{userstartup}\{#MyAppName}"; Filename: "{app}\{#GameExeName}"; Tasks: RegisterStartup
 
+[UninstallDelete]
+Type: filesandordirs; Name: "{userappdata}\{#MyAppName}";
+
 [Code]
 var
   UUID: String;


### PR DESCRIPTION
### Description

1. Current uninstaller doesn't remove files at `%APPDATA%\Nine Chronicles` which has configuration and snapshot caches.
2. This PR removes them when running an uninstaller.

### How to test

1. Install Nine Chronicles using the newly built installer.
2. Launch the launcher at least once.
3. Try to uninstall.
4. Check if `%APPDATA%\Nine Chronicles` is gone.

### Related Links
* https://jrsoftware.org/ishelp/topic_uninstalldeletesection.htm

### Required Reviewers

### Screenshot
