### PR TITLE
Override CanHandleInputEvent to false in HeaderMenuStatic

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Widget/Static/HeaderMenuStatic.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Static/HeaderMenuStatic.cs
@@ -213,6 +213,7 @@ namespace Nekoyume.UI.Module
             Show(ignoreShowAnimation);
         }
 
+        // base.Update() works `CheckInput()`, but this widget unnecessary `CheckInput()`.
         protected override void Update()
         {
 

--- a/nekoyume/Assets/_Scripts/UI/Widget/Static/HeaderMenuStatic.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Static/HeaderMenuStatic.cs
@@ -95,6 +95,8 @@ namespace Nekoyume.UI.Module
 
         public bool ChargingAP => actionPoint.NowCharging;
 
+        public override bool CanHandleInputEvent => false;
+
         public override void Initialize()
         {
             base.Initialize();
@@ -211,12 +213,6 @@ namespace Nekoyume.UI.Module
         {
             UpdateAssets(assetVisibleState);
             Show(ignoreShowAnimation);
-        }
-
-        // base.Update() works `CheckInput()`, but this widget unnecessary `CheckInput()`.
-        protected override void Update()
-        {
-
         }
 
         public override void Close(bool ignoreCloseAnimation = false)

--- a/nekoyume/Assets/_Scripts/UI/Widget/Static/HeaderMenuStatic.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Static/HeaderMenuStatic.cs
@@ -213,6 +213,11 @@ namespace Nekoyume.UI.Module
             Show(ignoreShowAnimation);
         }
 
+        protected override void Update()
+        {
+
+        }
+
         public override void Close(bool ignoreCloseAnimation = false)
         {
             foreach (var toggleInfo in toggles)


### PR DESCRIPTION
### Description

1. There was a problem that the header HUD was turned off when the backspace key was pressed on any screen.

### How to test

1. In Any screen, Input `backspace`.
2. Check header HUD.

### Related Links

https://planetariumhq.slack.com/archives/CBU2JFAF3/p1647927892387849
https://discord.com/channels/539405872346955788/653951482395361301/955719466619121684

### Required Reviewers

@planetarium/9c-dev 