### PR TITLE
Fix locking logic about acquisition place button

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Module/Button/AcquisitionPlaceButton.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/Button/AcquisitionPlaceButton.cs
@@ -122,11 +122,13 @@ namespace Nekoyume.UI.Module
 
         private void EnableSettingByPlaceType(PlaceType type, Model model)
         {
+            var successToGetUnlockedWorld = States.Instance.CurrentAvatarState.worldInformation
+                .TryGetUnlockedWorldByStageClearedBlockIndex(out var world);
+
             switch (type)
             {
                 case PlaceType.Stage:
-                    if (States.Instance.CurrentAvatarState.worldInformation
-                        .TryGetUnlockedWorldByStageClearedBlockIndex(out var world))
+                    if (successToGetUnlockedWorld)
                     {
                         if (model.StageRow.Id > world.StageClearedId + 1)
                         {
@@ -137,29 +139,47 @@ namespace Nekoyume.UI.Module
                             enableObject.SetActive(true);
                         }
                     }
-
-                    break;
-                case PlaceType.Shop:
-                    if (States.Instance.CurrentAvatarState.level <
-                        GameConfig.RequireClearedStageLevel.UIMainMenuShop)
+                    else
                     {
                         disableObject.SetActive(true);
                     }
+
+                    break;
+                case PlaceType.Shop:
+                    if (successToGetUnlockedWorld)
+                    {
+                        if (world.StageClearedId <
+                            GameConfig.RequireClearedStageLevel.UIMainMenuShop)
+                        {
+                            disableObject.SetActive(true);
+                        }
+                        else
+                        {
+                            enableObject.SetActive(true);
+                        }
+                    }
                     else
                     {
-                        enableObject.SetActive(true);
+                        disableObject.SetActive(true);
                     }
 
                     break;
                 case PlaceType.Arena:
-                    if (States.Instance.CurrentAvatarState.level <
-                        GameConfig.RequireClearedStageLevel.UIMainMenuRankingBoard)
+                    if (successToGetUnlockedWorld)
                     {
-                        disableObject.SetActive(true);
+                        if (world.StageClearedId <
+                            GameConfig.RequireClearedStageLevel.UIMainMenuRankingBoard)
+                        {
+                            disableObject.SetActive(true);
+                        }
+                        else
+                        {
+                            enableObject.SetActive(true);
+                        }
                     }
                     else
                     {
-                        enableObject.SetActive(true);
+                        disableObject.SetActive(true);
                     }
 
                     break;


### PR DESCRIPTION
### Description

1. change locking requirement to stage cleared id from avatar level

### How to test

1. Check Shop acquisition place button when stage cleared id is 20-21.
2. Check Arena acquisition place button when stage cleared id is 24-25.

### Related Links

[[Previewnet] 아레나가 개방이 되었음에도 획득처 화면 내 획득 경로 이동 버튼이 잠긴 상태로 노출되는 현상](https://app.asana.com/0/1133453747809944/1202023403019987/f)

### Required Reviewers

@planetarium/9c-dev 
