### PR TITLE
Fix not to update the purchase page per block

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Shop/BuyView.cs
+++ b/nekoyume/Assets/_Scripts/UI/Shop/BuyView.cs
@@ -201,7 +201,7 @@ namespace Nekoyume
                     }
                 });
 
-            Game.Game.instance.Agent.BlockIndexSubject.Subscribe(_ => UpdateView())
+            Game.Game.instance.Agent.BlockIndexSubject.Subscribe(_ => UpdateView(false))
                 .AddTo(gameObject);
         }
 
@@ -457,7 +457,7 @@ namespace Nekoyume
             return loading.activeSelf;
         }
 
-        protected override void UpdateView()
+        protected override void UpdateView(bool resetPage = true)
         {
             var expiredItems = _selectedItems.Where(x => x.Expired.Value).ToList();
             foreach (var item in expiredItems)
@@ -475,7 +475,7 @@ namespace Nekoyume
                 default:
                     throw new ArgumentOutOfRangeException();
             }
-            base.UpdateView();
+            base.UpdateView(resetPage);
         }
 
         private void OnSearch()

--- a/nekoyume/Assets/_Scripts/UI/Shop/ShopView.cs
+++ b/nekoyume/Assets/_Scripts/UI/Shop/ShopView.cs
@@ -65,14 +65,19 @@ namespace Nekoyume.UI.Module
         protected abstract IEnumerable<ShopItem> GetSortedModels(
             Dictionary<ItemSubTypeFilter, List<ShopItem>> items);
 
-        protected virtual void UpdateView()
+        protected virtual void UpdateView(bool resetPage = true)
         {
             _selectedModels.Clear();
             _selectedModels.AddRange(GetSortedModels(_items));
             _pageCount = _selectedModels.Any()
                 ? (_selectedModels.Count() / (_column * _row)) + 1
                 : 1;
-            _page.SetValueAndForceNotify(0);
+
+            if (resetPage)
+            {
+                _page.SetValueAndForceNotify(0);
+            }
+
             UpdateExpired(Game.Game.instance.Agent.BlockIndex);
         }
 


### PR DESCRIPTION
### How to test

Go to the shop. And then check purchase page index per block

### Related Links

[[Previewnet] 상점 페이지가 자동으로 1페이지로 돌아가는 현상](https://app.asana.com/0/1133453747809944/1202077560125799/f)

### Required Reviewers

@planetarium/9c-dev 
