### PR TITLE
Remove filtering inventory on caching skeleton objects.

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Module/Item/TooltipItemView.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/Item/TooltipItemView.cs
@@ -137,11 +137,6 @@ namespace Nekoyume.UI.Module
 
             foreach (var data in tooltipDataScriptableObject.Datas)
             {
-                if (!inventory.HasItem(data.ResourceID))
-                {
-                    continue;
-                }
-
                 var go = Instantiate(data.Prefab, baseItemView.SpineItemImage.transform);
                 _skeletonPool.Add(data.ResourceID, go);
                 go.SetActive(false);

--- a/nekoyume/Assets/_Scripts/UI/Module/Item/TooltipItemView.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/Item/TooltipItemView.cs
@@ -102,16 +102,20 @@ namespace Nekoyume.UI.Module
                     {
                         CreateSkeletonPool();
                     }
-                    _costumeSpineObject = _skeletonPool[tooltipData.ResourceID];
-                    _costumeSpineObject.transform.localPosition = tooltipData.Position;
-                    _costumeSpineObject.transform.localScale = tooltipData.Scale;
-                    _costumeSpineObject.transform.rotation = Quaternion.Euler(tooltipData.Rotation);
-                    var particle = gradeEffect.main;
-                    particle.startColor = tooltipData.GradeColor;
-                    _costumeSpineObject.SetActive(true);
 
-                    baseItemView.ItemImage.gameObject.SetActive(false);
-                    baseItemView.SpineItemImage.gameObject.SetActive(true);
+                    if (_skeletonPool.TryGetValue(tooltipData.ResourceID, out var skeleton))
+                    {
+                        _costumeSpineObject = skeleton;
+                        _costumeSpineObject.transform.localPosition = tooltipData.Position;
+                        _costumeSpineObject.transform.localScale = tooltipData.Scale;
+                        _costumeSpineObject.transform.rotation = Quaternion.Euler(tooltipData.Rotation);
+                        var particle = gradeEffect.main;
+                        particle.startColor = tooltipData.GradeColor;
+                        _costumeSpineObject.SetActive(true);
+
+                        baseItemView.ItemImage.gameObject.SetActive(false);
+                        baseItemView.SpineItemImage.gameObject.SetActive(true);
+                    }
                 }
             }
             else
@@ -133,7 +137,6 @@ namespace Nekoyume.UI.Module
         private void CreateSkeletonPool()
         {
             _skeletonPool = new Dictionary<int, GameObject>();
-            var inventory = States.Instance.CurrentAvatarState.inventory;
 
             foreach (var data in tooltipDataScriptableObject.Datas)
             {
@@ -143,4 +146,4 @@ namespace Nekoyume.UI.Module
             }
         }
     }
-}
+}   


### PR DESCRIPTION
### Description

1. Fixed bug on caching fullcostume tooltip.

### How to test

1. Go to shop and try to view costume tooltip.
2. Check if it's appearing.

### Related Links
https://app.asana.com/0/1133453747809944/1202098904856159/f

### Required Reviewers
@planetarium/9c-dev 

