### PR TITLE
Fix shop page refresh logic

### DIFF
--- a/nekoyume/Assets/_Scripts/State/ReactiveShopState.cs
+++ b/nekoyume/Assets/_Scripts/State/ReactiveShopState.cs
@@ -61,8 +61,10 @@ namespace Nekoyume.State
         private static ConcurrentDictionary<Guid, ItemBase> CachedShopItems { get; } =
             new ConcurrentDictionary<Guid, ItemBase>();
 
+
         private static readonly Dictionary<ItemSubType, List<OrderDigest>> _buyDigest =
             new Dictionary<ItemSubType, List<OrderDigest>>();
+        private static List<Guid> _removedOrderIds { get; } = new List<Guid>();
 
         public static OrderDigest GetSellDigest(Guid tradableId,
             long requiredBlockIndex,
@@ -94,6 +96,8 @@ namespace Nekoyume.State
         {
             await UniTask.Run(async () =>
             {
+                _removedOrderIds.Clear();
+
                 foreach (var itemSubType in list)
                 {
                     var digests = await GetBuyOrderDigests(itemSubType);
@@ -119,13 +123,19 @@ namespace Nekoyume.State
 
             _buyDigest[itemSubType] = d;
 
-            var r = new List<OrderDigest>();
+            var buyDigests = new List<OrderDigest>();
             foreach (var pair in _buyDigest)
             {
-                r.AddRange(pair.Value);
+                buyDigests.AddRange(pair.Value);
             }
 
-            BuyDigest.Value = r;
+            var removeList = buyDigests.Where(digest => _removedOrderIds.Contains(digest.OrderId)).ToList();
+            foreach (var orderDigest in removeList)
+            {
+                buyDigests.Remove(orderDigest);
+            }
+
+            BuyDigest.Value = buyDigests;
         }
 
         public static async Task UpdateSellDigests()
@@ -143,6 +153,11 @@ namespace Nekoyume.State
             var item = BuyDigest.Value.FirstOrDefault(x => x.OrderId.Equals(orderId));
             if (item != null)
             {
+                if (!_removedOrderIds.Contains(orderId))
+                {
+                    _removedOrderIds.Add(orderId);
+                }
+
                 BuyDigest.Value.Remove(item);
                 BuyDigest.SetValueAndForceNotify(BuyDigest.Value);
             }

--- a/nekoyume/Assets/_Scripts/UI/Shop/BuyView.cs
+++ b/nekoyume/Assets/_Scripts/UI/Shop/BuyView.cs
@@ -249,7 +249,6 @@ namespace Nekoyume
                         }
 
                         _selectedSubTypeFilter.Value = subToggleType;
-                        UpdateView();
                     });
                     item.onClickToggle.AddListener(AudioController.PlayClick);
                 }
@@ -457,7 +456,7 @@ namespace Nekoyume
             return loading.activeSelf;
         }
 
-        protected override void UpdateView(bool resetPage = true)
+        protected override void UpdateView(bool resetPage = true, int page = 0)
         {
             var expiredItems = _selectedItems.Where(x => x.Expired.Value).ToList();
             foreach (var item in expiredItems)
@@ -475,7 +474,8 @@ namespace Nekoyume
                 default:
                     throw new ArgumentOutOfRangeException();
             }
-            base.UpdateView(resetPage);
+
+            base.UpdateView(resetPage, page);
         }
 
         private void OnSearch()

--- a/nekoyume/Assets/_Scripts/UI/Shop/ShopView.cs
+++ b/nekoyume/Assets/_Scripts/UI/Shop/ShopView.cs
@@ -65,17 +65,16 @@ namespace Nekoyume.UI.Module
         protected abstract IEnumerable<ShopItem> GetSortedModels(
             Dictionary<ItemSubTypeFilter, List<ShopItem>> items);
 
-        protected virtual void UpdateView(bool resetPage = true)
+        protected virtual void UpdateView(bool resetPage = true, int page = 0)
         {
             _selectedModels.Clear();
             _selectedModels.AddRange(GetSortedModels(_items));
             _pageCount = _selectedModels.Any()
                 ? (_selectedModels.Count() / (_column * _row)) + 1
                 : 1;
-
             if (resetPage)
             {
-                _page.SetValueAndForceNotify(0);
+                _page.SetValueAndForceNotify(page);
             }
 
             UpdateExpired(Game.Game.instance.Agent.BlockIndex);
@@ -214,7 +213,7 @@ namespace Nekoyume.UI.Module
                     AddItem(digest, itemSheet);
                 }
 
-                UpdateView();
+                UpdateView(page:_page.Value);
             }).AddTo(_disposables);
             Game.Game.instance.Agent.BlockIndexSubject.Subscribe(UpdateExpired).AddTo(_disposables);
         }


### PR DESCRIPTION
### Description

- Fix shop page refresh logic
- Create  `_removedOrderIds` list for refresh logic

### How to test

go to the store. and click on a category

### Related Links

[상점 페이지가 자동으로 1페이지로 돌아가는 현상](https://app.asana.com/0/1141562434100787/1202077560125799/f)

### Required Reviewers

@planetarium/9c-dev 

