### PR TITLE
Prevent avatar overlapping on displaying `FriendInfoPopup`.

### DIFF
--- a/nekoyume/Assets/_Scripts/Game/Character/Player.cs
+++ b/nekoyume/Assets/_Scripts/Game/Character/Player.cs
@@ -107,7 +107,7 @@ namespace Nekoyume.Game.Character
         protected override void OnDisable()
         {
             base.OnDisable();
-            DestroyImmediate(_cachedCharacterTitle);
+            Destroy(_cachedCharacterTitle);
         }
 
         private void OnDestroy()

--- a/nekoyume/Assets/_Scripts/UI/Scroller/ArenaRankCell.cs
+++ b/nekoyume/Assets/_Scripts/UI/Scroller/ArenaRankCell.cs
@@ -92,13 +92,13 @@ namespace Nekoyume.UI.Scroller
             characterView.OnClickCharacterIcon
                 .Subscribe(async avatarState =>
                 {
+                    if (IsLoadingAvatarState)
+                    {
+                        return;
+                    }
+
                     if (avatarState is null)
                     {
-                        if (IsLoadingAvatarState)
-                        {
-                            return;
-                        }
-
                         IsLoadingAvatarState = true;
                         var (exist, state) =
                             await States.TryGetAvatarStateAsync(ArenaInfo.AvatarAddress);

--- a/nekoyume/Assets/_Scripts/UI/Scroller/ArenaRankCell.cs
+++ b/nekoyume/Assets/_Scripts/UI/Scroller/ArenaRankCell.cs
@@ -85,6 +85,8 @@ namespace Nekoyume.UI.Scroller
 
         public IObservable<ArenaRankCell> OnClickChallenge => _onClickChallenge;
 
+        private static bool IsLoadingAvatarState = false;
+
         private void Awake()
         {
             characterView.OnClickCharacterIcon
@@ -92,9 +94,16 @@ namespace Nekoyume.UI.Scroller
                 {
                     if (avatarState is null)
                     {
+                        if (IsLoadingAvatarState)
+                        {
+                            return;
+                        }
+
+                        IsLoadingAvatarState = true;
                         var (exist, state) =
                             await States.TryGetAvatarStateAsync(ArenaInfo.AvatarAddress);
                         avatarState = exist ? state : null;
+                        IsLoadingAvatarState = false;
                         if (avatarState is null)
                         {
                             return;


### PR DESCRIPTION
### Description

1. SSIA

### How to test

1. Go to arena.
2. Try to open any player's avatar information and click on another one before previous one opens.
3. Check if character is not overlapping.

### Related Links
https://app.asana.com/0/1133453747809944/1201690393623287

### Required Reviewers
@planetarium/9c-dev 

