### PR TITLE
Fix different alert message

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Combination/SubRecipeView.cs
+++ b/nekoyume/Assets/_Scripts/UI/Combination/SubRecipeView.cs
@@ -416,7 +416,7 @@ namespace Nekoyume.UI
 
             if (States.Instance.CurrentAvatarState.actionPoint < _selectedRecipeInfo.CostAP)
             {
-                errorMessage = L10nManager.Localize("UI_NOT_ENOUGH_AP");
+                errorMessage = L10nManager.Localize("ERROR_ACTION_POINT");
                 return false;
             }
 

--- a/nekoyume/Assets/_Scripts/UI/Module/Button/ConditionalCostButton.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/Button/ConditionalCostButton.cs
@@ -107,7 +107,7 @@ namespace Nekoyume.UI.Module
                     {
                         OneLineSystem.Push(
                             MailType.System,
-                            L10nManager.Localize("UI_NOT_ENOUGH_AP"),
+                            L10nManager.Localize("ERROR_ACTION_POINT"),
                             NotificationCell.NotificationType.Alert);
                         return;
                     }


### PR DESCRIPTION
### Description

- Edit to unify difference key names
- Other key was not deleted

### Related Links

[AP가 부족할 때 부스터 버튼과 스타트 버튼을 눌렀을 때 나오는 메시지가 다릅니다.](https://app.asana.com/0/1141562434100787/1201890796390902/f)

