### PR TITLE
change event banner mask

### DIFF
--- a/nekoyume/Assets/Resources/UI/Prefabs/UI_EventBanner.prefab
+++ b/nekoyume/Assets/Resources/UI/Prefabs/UI_EventBanner.prefab
@@ -234,7 +234,7 @@ GameObject:
   - component: {fileID: 6624773333797661091}
   - component: {fileID: 1151561548495012989}
   - component: {fileID: 3396223431738690305}
-  - component: {fileID: 5498914240941624325}
+  - component: {fileID: 1496028499539773310}
   m_Layer: 5
   m_Name: Mask
   m_TagString: Untagged
@@ -283,7 +283,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
@@ -300,7 +300,7 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
---- !u!114 &5498914240941624325
+--- !u!114 &1496028499539773310
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -309,10 +309,11 @@ MonoBehaviour:
   m_GameObject: {fileID: 9017770312433257000}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 31a19414c41e5ae4aae2af33fee712f6, type: 3}
+  m_Script: {fileID: 11500000, guid: 3312d7739989d2b4e91e6319e9a96d76, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_ShowMaskGraphic: 0
+  m_Padding: {x: 0, y: 0, z: 0, w: 0}
+  m_Softness: {x: 0, y: 0}
 --- !u!1 &9138334577487677069
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
### Description

In UI coordinate system, we requires the use of the Rect Mask 2D component.

### How to test

overlap the item information tooltip and event banner

### Related Links

[[UI] 10강 이상 장비 툴팁 상단 이펙트 일부가 깨져있는 현상](https://app.asana.com/0/1133453747809944/1202114534196917/f)

### Required Reviewers

@planetarium/9c-dev , @BBeom06 

### Screenshot

![change_mask_type](https://user-images.githubusercontent.com/40553495/164152292-d4e42843-958f-4bad-95cc-5ac2762ec08f.jpg)

