### PR TITLE
Remove calling `Close` in `Confirm` of `IconAndButtonSystem`

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Widget/BattlePreparation.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/BattlePreparation.cs
@@ -812,7 +812,10 @@ namespace Nekoyume.UI
                 "UI_OK", "UI_CANCEL",
                 true, IconAndButtonSystem.SystemType.Information);
             confirm.ConfirmCallback = () =>
+            {
                 Game.Game.instance.ActionManager.ChargeActionPoint(material).Subscribe();
+                confirm.Close();
+            };
             confirm.CancelCallback = () => confirm.Close();
         }
 

--- a/nekoyume/Assets/_Scripts/UI/Widget/Popup/AvatarInfoPopup.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Popup/AvatarInfoPopup.cs
@@ -402,7 +402,11 @@ namespace Nekoyume.UI
             confirm.ShowWithTwoButton("UI_CONFIRM", "UI_AP_REFILL_CONFIRM_CONTENT",
                 "UI_OK", "UI_CANCEL",
                 true, IconAndButtonSystem.SystemType.Information);
-            confirm.ConfirmCallback = () => Game.Game.instance.ActionManager.ChargeActionPoint(material).Subscribe();
+            confirm.ConfirmCallback = () =>
+            {
+                Game.Game.instance.ActionManager.ChargeActionPoint(material).Subscribe();
+                confirm.Close();
+            };
             confirm.CancelCallback = () => confirm.Close();
         }
 

--- a/nekoyume/Assets/_Scripts/UI/Widget/System/IconAndButtonSystem.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/System/IconAndButtonSystem.cs
@@ -187,7 +187,6 @@ namespace Nekoyume.UI
         private void Confirm()
         {
             ConfirmCallback?.Invoke();
-            Close();
             AudioController.PlayClick();
         }
 


### PR DESCRIPTION
### Description

1. SSIA
2. In the past, can not `Show()` IconAndButtonSystem while activated by `Confirm()`.