### PR TITLE
Introduce `ShowOnAttribute`.

### DIFF
--- a/nekoyume/Assets/_Scripts/Editor.meta
+++ b/nekoyume/Assets/_Scripts/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: aff7102ee3473634e854005a260801a9
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/nekoyume/Assets/_Scripts/Editor/ShowOnAttribute.cs
+++ b/nekoyume/Assets/_Scripts/Editor/ShowOnAttribute.cs
@@ -1,0 +1,27 @@
+#if UNITY_EDITOR
+using System;
+using UnityEngine;
+
+namespace Nekoyume.Editor
+{
+    [AttributeUsage(AttributeTargets.Field, AllowMultiple = false, Inherited = true)]
+    public class ShowOnAttribute : PropertyAttribute
+    {
+        public enum PropertyDrawOption
+        {
+            Disable = 0,
+            Hide,
+        }
+
+        public string Condition { get; private set; }
+
+        public PropertyDrawOption DrawOption { get; private set; }
+
+        public ShowOnAttribute(string condition, PropertyDrawOption drawOption = PropertyDrawOption.Disable)
+        {
+            Condition = condition;
+            DrawOption = drawOption;
+        }
+    }
+}
+#endif

--- a/nekoyume/Assets/_Scripts/Editor/ShowOnAttribute.cs.meta
+++ b/nekoyume/Assets/_Scripts/Editor/ShowOnAttribute.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1afed7fb0d741a14c9b8e1686adeb791
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/nekoyume/Assets/_Scripts/Editor/ShowOnAttributeDrawer.cs
+++ b/nekoyume/Assets/_Scripts/Editor/ShowOnAttributeDrawer.cs
@@ -1,0 +1,87 @@
+#if UNITY_EDITOR
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using UnityEditor;
+using UnityEngine;
+
+namespace Nekoyume.Editor
+{
+    [CustomPropertyDrawer(typeof(ShowOnAttribute), true)]
+    public class ShowOnAttributeDrawer : PropertyDrawer
+    {
+        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+        {
+            var attribute = this.attribute as ShowOnAttribute;
+            var show = GetCondition(property.serializedObject.targetObject);
+            if (show)
+            {
+                EditorGUI.PropertyField(position, property, label, true);
+                return;
+            }
+
+            if (attribute.DrawOption == ShowOnAttribute.PropertyDrawOption.Disable)
+            {
+                EditorGUI.BeginDisabledGroup(true);
+                EditorGUI.PropertyField(position, property, label, true);
+                EditorGUI.EndDisabledGroup();
+            }
+        }
+
+        private bool GetCondition(object target)
+        {
+            var attribute = this.attribute as ShowOnAttribute;
+            var field = GetField(target, x => x.Name.Equals(attribute.Condition));
+            return field == null || (bool) field.GetValue(target);
+        }
+
+        public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
+        {
+            var show = GetCondition(property.serializedObject.targetObject);
+            if (show)
+            {
+                return base.GetPropertyHeight(property, label);
+            }
+
+            var attribute = this.attribute as ShowOnAttribute;
+            return attribute.DrawOption == ShowOnAttribute.PropertyDrawOption.Disable
+                ? base.GetPropertyHeight(property, label) : 0;
+        }
+
+
+        private static FieldInfo GetField(
+            object target,
+            Func<FieldInfo, bool> predicate)
+        {
+            List<Type> types = new List<Type>()
+            {
+                target.GetType()
+            };
+
+            while (types.Last().BaseType != null)
+            {
+                types.Add(types.Last().BaseType);
+            }
+
+            for (int i = types.Count - 1; i >= 0; i--)
+            {
+                IEnumerable<FieldInfo> fieldInfos = types[i].GetFields(
+                    BindingFlags.Instance |
+                    BindingFlags.Static |
+                    BindingFlags.NonPublic |
+                    BindingFlags.Public |
+                    BindingFlags.DeclaredOnly)
+                    .Where(predicate);
+
+                if (fieldInfos.Any())
+                {
+                    return fieldInfos.First();
+                }
+            }
+            return null;
+        }
+
+    }
+}
+#endif

--- a/nekoyume/Assets/_Scripts/Editor/ShowOnAttributeDrawer.cs.meta
+++ b/nekoyume/Assets/_Scripts/Editor/ShowOnAttributeDrawer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 96f09498fc9f6f745872d94818aa8091
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/nekoyume/Assets/_Scripts/Game/Util/PositionConstraints/Editor/PositionConstraintToScreenEditor.cs
+++ b/nekoyume/Assets/_Scripts/Game/Util/PositionConstraints/Editor/PositionConstraintToScreenEditor.cs
@@ -5,7 +5,7 @@ namespace Nekoyume.Game.Util
 {
     [CanEditMultipleObjects,
      CustomEditor(typeof(PositionConstraintToScreen))]
-    public class PositionConstraintToScreenEditor : Editor
+    public class PositionConstraintToScreenEditor : UnityEditor.Editor
     {
         public override void OnInspectorGUI()
         {

--- a/nekoyume/Assets/_Scripts/UI/Module/Item/ItemView.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/Item/ItemView.cs
@@ -10,9 +10,12 @@ using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
 using Coffee.UIEffects;
-using Nekoyume.Game.ScriptableObject;
 using Nekoyume.Helper;
 using Nekoyume.Model.Item;
+
+#if UNITY_EDITOR
+using Nekoyume.Editor;
+#endif
 
 namespace Nekoyume.UI.Module
 {
@@ -21,7 +24,15 @@ namespace Nekoyume.UI.Module
     public class ItemView<TViewModel> : VanillaItemView
         where TViewModel : Model.Item
     {
+        [SerializeField]
+        private bool handleTouchEvent = true;
+
+
+#if UNITY_EDITOR
+        [ShowOn(nameof(handleTouchEvent))]
+#endif
         public TouchHandler touchHandler;
+
         public Button itemButton;
         public Image backgroundImage;
         public TextMeshProUGUI enhancementText;
@@ -69,24 +80,27 @@ namespace Nekoyume.UI.Module
         public readonly Subject<ItemView<TViewModel>> OnDoubleClick =
             new Subject<ItemView<TViewModel>>();
 
-        #region Mono
+#region Mono
 
         protected virtual void Awake()
         {
             RectTransform = GetComponent<RectTransform>();
 
-            touchHandler.OnClick.Subscribe(_ =>
+            if (handleTouchEvent)
             {
-                AudioController.PlayClick();
-                OnClick.OnNext(this);
-                Model?.OnClick.OnNext(Model);
-            }).AddTo(gameObject);
-            touchHandler.OnDoubleClick.Subscribe(_ =>
-            {
-                AudioController.PlayClick();
-                OnDoubleClick.OnNext(this);
-                Model?.OnDoubleClick.OnNext(Model);
-            }).AddTo(gameObject);
+                touchHandler.OnClick.Subscribe(_ =>
+                {
+                    AudioController.PlayClick();
+                    OnClick.OnNext(this);
+                    Model?.OnClick.OnNext(Model);
+                }).AddTo(gameObject);
+                touchHandler.OnDoubleClick.Subscribe(_ =>
+                {
+                    AudioController.PlayClick();
+                    OnDoubleClick.OnNext(this);
+                    Model?.OnDoubleClick.OnNext(Model);
+                }).AddTo(gameObject);
+            }
 
             selection.transform.SetAsLastSibling();
             disable.transform.SetAsLastSibling();
@@ -99,7 +113,7 @@ namespace Nekoyume.UI.Module
             OnDoubleClick.Dispose();
         }
 
-        #endregion
+#endregion
 
         public virtual void SetData(TViewModel model, System.Action onClick = null)
         {


### PR DESCRIPTION
### Description

1. Introduce new editor attribute which controls visibility of property in inspector.

### Example & Screenshot

```csharp
[SerializeField]
private bool handleTouchEvent = true;


#if UNITY_EDITOR
[ShowOn(nameof(handleTouchEvent), ShowOnAttribute.PropertyDrawOption.Disable)]
#endif
public TouchHandler touchHandler;
```
![GIF 2022-05-10 오후 6-42-16](https://user-images.githubusercontent.com/26648527/167599680-7081e4be-6bed-4fba-a56b-dc09230b5e27.gif)

Also, you can hide a property completely.
```csharp
[ShowOn(nameof(handleTouchEvent), ShowOnAttribute.PropertyDrawOption.Hide)]
```


### Required Reviewers
@boscohyun @hskim881028 @sonohoshi 
