### PR TITLE
Support challenge stage sweep

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Widget/BattlePreparation.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/BattlePreparation.cs
@@ -126,8 +126,7 @@ namespace Nekoyume.UI
         private bool EnoughToPlay =>
             States.Instance.CurrentAvatarState.actionPoint >= _requiredCost;
 
-        private bool IsStageCleared =>
-            States.Instance.CurrentAvatarState.worldInformation.IsStageCleared(_stageId.Value);
+        private bool IsFirstStage => _stageId.Value == 1;
 
         #region override
 
@@ -183,6 +182,7 @@ namespace Nekoyume.UI
                 .AddTo(gameObject);
 
             sweepPopupButton.OnClickAsObservable()
+                .Where(_ => !IsFirstStage)
                 .Subscribe(_ => Find<SweepPopup>().Show(_worldId, _stageId.Value));
 
             boostPopupButton.OnClickAsObservable()
@@ -865,7 +865,7 @@ namespace Nekoyume.UI
             {
                 case StageType.HackAndSlash:
                     boostPopupButton.gameObject.SetActive(false);
-                    sweepPopupButton.gameObject.SetActive(true);
+                    sweepPopupButton.gameObject.SetActive(!IsFirstStage);
                     break;
                 case StageType.Mimisbrunnr:
                     boostPopupButton.gameObject.SetActive(canBattle);

--- a/nekoyume/Assets/_Scripts/UI/Widget/BattlePreparation.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/BattlePreparation.cs
@@ -183,17 +183,7 @@ namespace Nekoyume.UI
                 .AddTo(gameObject);
 
             sweepPopupButton.OnClickAsObservable()
-                .Where(_ => IsStageCleared)
                 .Subscribe(_ => Find<SweepPopup>().Show(_worldId, _stageId.Value));
-
-            sweepPopupButton.OnClickAsObservable().Where(_ => !IsStageCleared)
-                .ThrottleFirst(TimeSpan.FromSeconds(2f))
-                .Subscribe(_ =>
-                    OneLineSystem.Push(
-                        MailType.System,
-                        L10nManager.Localize("UI_SWEEP_UNLOCK_CONDITION"),
-                        NotificationCell.NotificationType.Alert))
-                .AddTo(gameObject);
 
             boostPopupButton.OnClickAsObservable()
                 .Where(_ => EnoughToPlay && !_stage.IsInStage)
@@ -875,7 +865,7 @@ namespace Nekoyume.UI
             {
                 case StageType.HackAndSlash:
                     boostPopupButton.gameObject.SetActive(false);
-                    sweepPopupButton.gameObject.SetActive(avatarState.worldInformation.IsStageCleared(_stageId.Value));
+                    sweepPopupButton.gameObject.SetActive(true);
                     break;
                 case StageType.Mimisbrunnr:
                     boostPopupButton.gameObject.SetActive(canBattle);


### PR DESCRIPTION
### Description

- Apply updated Sweep action 
  - before : It can't sweep on challenging stage.
  - after : It support sweep on challenging stage. 
    without Yggdgrasil(1st world) and 1st stage

### Related Links

[스윕 개선 2차 UI 적용](https://app.asana.com/0/958521740385861/1202305628351985/f)
