### PR TITLE
Add new event value to Analyzer

### DIFF
--- a/.github/bin/inject-mixpanel-client-data.sh
+++ b/.github/bin/inject-mixpanel-client-data.sh
@@ -2,7 +2,9 @@
 set -e
 
 commit_hash="$1"
+target_network="$2"
 data_dir="$(dirname "$0")/../../nekoyume/Assets/PackageExtensions/Mixpanel/Resources"
 
 echo "planetarium" > "$data_dir/MixpanelClientHost.txt"
 echo "$commit_hash" > "$data_dir/MixpanelClientHash.txt"
+echo "$target_network" > "$data_dir/MixpanelTargetNetwork.txt"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,20 +41,24 @@ jobs:
           key: ${{ matrix.targetPlatform }}-${{ matrix.projectPath }}-Library-v4
 
       - name: inject mixpanel client data
+        env:
+          TARGET_NETWORK: |
+            ${{
+              if [ ${{ github.ref == 'refs/heads/main' }} ]; then
+                "mainnet"
+              elif [ ${{ startsWith(github.ref, 'refs/heads/rc-') }} ] then
+                "internal"
+              elif [ ${{ startsWith(github.ref, 'refs/heads/previewnet') }} ] then
+                "previewnet"
+              else
+                "unknown"
+              fi
+            }}
         run: |
-          target_network = "unknown"
-          if [ ${{ github.ref == 'refs/heads/main' }} ]; then
-            $target_network = "mainnet"
-          elif [ ${{ startsWith(github.ref, 'refs/heads/rc-') }} ] then
-            $target_network = "internal"
-          elif [ ${{ startsWith(github.ref, 'refs/heads/previewnet') }} ] then
-            $target_network = "previewnet"
-          fi
-
           chmod +x .github/bin/inject-mixpanel-client-data.sh
           .github/bin/inject-mixpanel-client-data.sh \
           "$GITHUB_SHA" \
-          "$target_network"
+          "$TARGET_NETWORK"
 
       - name: Build Unity Player using docker
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,9 +42,19 @@ jobs:
 
       - name: inject mixpanel client data
         run: |
+          target_network = "unknown"
+          if [ ${{ github.ref == 'refs/heads/main' }} ]; then
+            $target_network = "mainnet"
+          elif [ ${{ startsWith(github.ref, 'refs/heads/rc-') }} ] then
+            $target_network = "internal"
+          elif [ ${{ startsWith(github.ref, 'refs/heads/previewnet') }} ] then
+            $target_network = "previewnet"
+          fi
+
           chmod +x .github/bin/inject-mixpanel-client-data.sh
           .github/bin/inject-mixpanel-client-data.sh \
-          "$GITHUB_SHA"
+          "$GITHUB_SHA" \
+          "$target_network"
 
       - name: Build Unity Player using docker
         run: |

--- a/nekoyume/Assets/PackageExtensions/Mixpanel/MixpanelValueFactory.cs
+++ b/nekoyume/Assets/PackageExtensions/Mixpanel/MixpanelValueFactory.cs
@@ -7,16 +7,19 @@ namespace PackageExtensions.Mixpanel
     {
         private const string _clientHostKey = "client-host";
         private const string _clientHashKey = "client-hash";
+        private const string _targetNetworkKey = "target-network";
         private const string _rpcServerHostKey = "rpc-server-host";
 
         private readonly string _clientHost;
         private readonly string _clientHash;
+        private readonly string _targetNetwork;
         private readonly string _rpcServerHost;
 
         public MixpanelValueFactory(string rpcServerHost = null)
         {
             _clientHost = Resources.Load<TextAsset>("MixpanelClientHost")?.text ?? "no-host";
             _clientHash = Resources.Load<TextAsset>("MixpanelClientHash")?.text ?? "no-hash";
+            _targetNetwork = Resources.Load<TextAsset>("MixpanelTargetNetwork")?.text ?? "no-target";
             _rpcServerHost = rpcServerHost;
 
             Debug.Log(
@@ -29,6 +32,7 @@ namespace PackageExtensions.Mixpanel
             {
                 [_clientHostKey] = _clientHost,
                 [_clientHashKey] = _clientHash,
+                [_targetNetworkKey] = _targetNetwork,
             };
 
             if (_rpcServerHost is { })


### PR DESCRIPTION
We need to identify which network the client is targeting through the analyzer event.

- `MixpanelValueFactory` contains `target-network` value ref the `MixpanelTargetNetwork.txt` file.
- `inject-mixpanel-client-data.sh` make the `MixpanelTargetNetwork.txt` file on the unity project.
- Make `target_network` value when the GitHub action progress `build > inject mixpanel client data` step.

This pull request needs kind reviews because I'm beginner like these CI jobs.