### PR TITLE
Skip prologue with certain registry value.

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Widget/Synopsis.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Synopsis.cs
@@ -15,6 +15,7 @@ using UnityEngine.UI;
 using Nekoyume.L10n;
 using System.Threading.Tasks;
 using Nekoyume.Helper;
+using Microsoft.Win32;
 
 namespace Nekoyume.UI
 {
@@ -353,7 +354,9 @@ namespace Nekoyume.UI
             base.Show(ignoreShowAnimation);
             Analyzer.Instance.Track("Unity/Synopsis Start");
             AudioController.instance.PlayMusic(AudioController.MusicCode.Prologue);
-            var skipPrologue = States.Instance.AgentState.avatarAddresses.Any();
+            var skipPrologueReg = (int) Registry.CurrentUser.OpenSubKey("Software\\Planetarium\\9c")
+                .GetValue("SkipSynopsis") == 1;
+            var skipPrologue = States.Instance.AgentState.avatarAddresses.Any() || skipPrologueReg;
             skipButton.SetActive(skipPrologue);
             StartCoroutine(StartSynopsis(skipPrologue));
         }

--- a/nekoyume/Assets/_Scripts/UI/Widget/Synopsis.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Synopsis.cs
@@ -15,7 +15,10 @@ using UnityEngine.UI;
 using Nekoyume.L10n;
 using System.Threading.Tasks;
 using Nekoyume.Helper;
+
+#if UNITY_EDITOR_WIN || UNITY_STANDALONE_WIN
 using Microsoft.Win32;
+#endif
 
 namespace Nekoyume.UI
 {
@@ -354,9 +357,13 @@ namespace Nekoyume.UI
             base.Show(ignoreShowAnimation);
             Analyzer.Instance.Track("Unity/Synopsis Start");
             AudioController.instance.PlayMusic(AudioController.MusicCode.Prologue);
+#if UNITY_EDITOR_WIN || UNITY_STANDALONE_WIN
             var skipPrologueReg = (int) Registry.CurrentUser.OpenSubKey("Software\\Planetarium\\9c")
                 .GetValue("SkipSynopsis") == 1;
             var skipPrologue = States.Instance.AgentState.avatarAddresses.Any() || skipPrologueReg;
+#else
+            var skipPrologue = States.Instance.AgentState.avatarAddresses.Any();
+#endif
             skipButton.SetActive(skipPrologue);
             StartCoroutine(StartSynopsis(skipPrologue));
         }


### PR DESCRIPTION
## Supported only on Windows.

### Description

1. Implement skipping prologue with certain registry value.

### How to test
[skipsynopsis.txt](https://github.com/planetarium/NineChronicles/files/8859982/skipsynopsis.txt)
1. Download this file and change extension to `.reg` and open it.
3. Check if newly created account can skip prologue.