### PR TITLE
Clean up some of login logics

### DIFF
--- a/nekoyume/Assets/_Scripts/BlockChain/ActionHandler.cs
+++ b/nekoyume/Assets/_Scripts/BlockChain/ActionHandler.cs
@@ -95,9 +95,13 @@ namespace Nekoyume.BlockChain
             return (null, 0);
         }
 
-        protected async UniTask UpdateAgentStateAsync<T>(ActionBase.ActionEvaluation<T> evaluation) where T : ActionBase
+        protected async UniTask UpdateAgentStateAsync<T>(
+            ActionBase.ActionEvaluation<T> evaluation)
+            where T : ActionBase
         {
-            Debug.LogFormat("Called UpdateAgentState<{0}>. Updated Addresses : `{1}`", evaluation.Action,
+            Debug.LogFormat(
+                "Called UpdateAgentState<{0}>. Updated Addresses : `{1}`",
+                evaluation.Action,
                 string.Join(",", evaluation.OutputStates.UpdatedAddresses));
             await UpdateAgentStateAsync(GetAgentState(evaluation));
             try
@@ -110,10 +114,14 @@ namespace Nekoyume.BlockChain
             }
         }
 
-        protected static async UniTask UpdateAvatarState<T>(ActionBase.ActionEvaluation<T> evaluation, int index)
+        protected static async UniTask UpdateAvatarState<T>(
+            ActionBase.ActionEvaluation<T> evaluation,
+            int index)
             where T : ActionBase
         {
-            Debug.LogFormat("Called UpdateAvatarState<{0}>. Updated Addresses : `{1}`", evaluation.Action,
+            Debug.LogFormat(
+                "Called UpdateAvatarState<{0}>. Updated Addresses : `{1}`",
+                evaluation.Action,
                 string.Join(",", evaluation.OutputStates.UpdatedAddresses));
             if (!States.Instance.AgentState.avatarAddresses.ContainsKey(index))
             {
@@ -123,7 +131,11 @@ namespace Nekoyume.BlockChain
 
             var agentAddress = States.Instance.AgentState.address;
             var avatarAddress = States.Instance.AgentState.avatarAddresses[index];
-            if (evaluation.OutputStates.TryGetAvatarStateV2(agentAddress, avatarAddress, out var avatarState, out _))
+            if (evaluation.OutputStates.TryGetAvatarStateV2(
+                    agentAddress,
+                    avatarAddress,
+                    out var avatarState,
+                    out _))
             {
                 await UpdateAvatarState(avatarState, index);
             }
@@ -206,7 +218,7 @@ namespace Nekoyume.BlockChain
             States.Instance.SetGoldBalanceState(goldBalanceState);
         }
 
-        public static void UpdateCrystalBalance<T>(ActionBase.ActionEvaluation<T> evaluation) where T : ActionBase
+        protected static void UpdateCrystalBalance<T>(ActionBase.ActionEvaluation<T> evaluation) where T : ActionBase
         {
             var crystal = evaluation.OutputStates.GetBalance(evaluation.Signer, CrystalCalculator.CRYSTAL);
             var agentState = States.Instance.AgentState;

--- a/nekoyume/Assets/_Scripts/Game/Game.cs
+++ b/nekoyume/Assets/_Scripts/Game/Game.cs
@@ -331,7 +331,8 @@ namespace Nekoyume.Game
                 return;
             }
 
-            BackToMainAsync(new UnableToRenderWhenSyncingBlocksException(), showLoadingScreen);
+            BackToMainAsync(new UnableToRenderWhenSyncingBlocksException(), showLoadingScreen)
+                .Forget();
         }
 
         private static void OnRPCAgentPreloadEnded(RPCAgent rpcAgent)

--- a/nekoyume/Assets/_Scripts/State/LocalLayerModifier.cs
+++ b/nekoyume/Assets/_Scripts/State/LocalLayerModifier.cs
@@ -24,7 +24,7 @@ namespace Nekoyume.State
         /// </summary>
         /// <param name="agentAddress"></param>
         /// <param name="gold"></param>
-        public static async void ModifyAgentGold(Address agentAddress, FungibleAssetValue gold)
+        public static async UniTask ModifyAgentGoldAsync(Address agentAddress, FungibleAssetValue gold)
         {
             if (gold.Sign == 0)
             {
@@ -35,7 +35,9 @@ namespace Nekoyume.State
             LocalLayer.Instance.Add(agentAddress, modifier);
 
             //FIXME Avoid LocalLayer duplicate modify gold.
-            var state = new GoldBalanceState(agentAddress, await Game.Game.instance.Agent.GetBalanceAsync(agentAddress, gold.Currency));
+            var state = new GoldBalanceState(
+                agentAddress,
+                await Game.Game.instance.Agent.GetBalanceAsync(agentAddress, gold.Currency));
             if (!state.address.Equals(agentAddress))
             {
                 return;
@@ -51,26 +53,30 @@ namespace Nekoyume.State
                 return;
             }
 
-            ModifyAgentGold(agentAddress, new FungibleAssetValue(
+            var fav = new FungibleAssetValue(
                 States.Instance.GoldBalanceState.Gold.Currency,
                 gold,
-                0));
+                0);
+            ModifyAgentGoldAsync(agentAddress, fav).Forget();
         }
 
-        public static void ModifyAgentCrystal(Address agentAddress, BigInteger crystal) =>
-            ModifyAgentCrystalAsync(agentAddress, crystal).Forget();
-
-        public static async UniTaskVoid ModifyAgentCrystalAsync(Address agentAddress, BigInteger crystal)
+        public static async UniTask ModifyAgentCrystalAsync(Address agentAddress, BigInteger crystal)
         {
             if (crystal == 0)
             {
                 return;
             }
 
-            var fav = new FungibleAssetValue(CrystalCalculator.CRYSTAL, crystal, 0);
+            var fav = new FungibleAssetValue(
+                CrystalCalculator.CRYSTAL,
+                crystal,
+                0);
             var modifier = new AgentCrystalModifier(fav);
             LocalLayer.Instance.Add(agentAddress, modifier);
-            var crystalBalance = await Game.Game.instance.Agent.GetBalanceAsync(agentAddress, CrystalCalculator.CRYSTAL);
+            var crystalBalance
+                = await Game.Game.instance.Agent.GetBalanceAsync(
+                    agentAddress,
+                    CrystalCalculator.CRYSTAL);
             States.Instance.SetCrystalBalance(crystalBalance);
         }
 
@@ -597,7 +603,7 @@ namespace Nekoyume.State
         /// Therefore, there is no need to additionally update `ReactiveAvatarState` after using this function.
         /// </summary>
         /// <param name="avatarAddress"></param>
-        private static async Task TryResetLoadedAvatarState(Address avatarAddress)
+        private static async UniTask TryResetLoadedAvatarState(Address avatarAddress)
         {
             if (!TryGetLoadedAvatarState(avatarAddress, out _, out var outKey,
                 out var isCurrentAvatarState))

--- a/nekoyume/Assets/_Scripts/State/ReactiveShopState.cs
+++ b/nekoyume/Assets/_Scripts/State/ReactiveShopState.cs
@@ -92,7 +92,7 @@ namespace Nekoyume.State
             return true;
         }
 
-        public static async Task SetBuyDigests(List<ItemSubType> list)
+        public static async UniTask SetBuyDigestsAsync(List<ItemSubType> list)
         {
             await UniTask.Run(async () =>
             {
@@ -100,8 +100,8 @@ namespace Nekoyume.State
 
                 foreach (var itemSubType in list)
                 {
-                    var digests = await GetBuyOrderDigests(itemSubType);
-                    var result = await UpdateCachedShopItems(digests);
+                    var digests = await GetBuyOrderDigestsAsync(itemSubType);
+                    var result = await UpdateCachedShopItemsAsync(digests);
                     if (result)
                     {
                         AddBuyDigest(digests, itemSubType);
@@ -138,10 +138,10 @@ namespace Nekoyume.State
             BuyDigest.Value = buyDigests;
         }
 
-        public static async Task UpdateSellDigests()
+        public static async UniTask UpdateSellDigestsAsync()
         {
-            var digests = await GetSellOrderDigests();
-            var result = await UpdateCachedShopItems(digests);
+            var digests = await GetSellOrderDigestsAsync();
+            var result = await UpdateCachedShopItemsAsync(digests);
             if (result)
             {
                 SellDigest.Value = digests;
@@ -173,7 +173,7 @@ namespace Nekoyume.State
             }
         }
 
-        private static async Task<List<OrderDigest>> GetBuyOrderDigests(ItemSubType itemSubType)
+        private static async UniTask<List<OrderDigest>> GetBuyOrderDigestsAsync(ItemSubType itemSubType)
         {
             var orderDigests = new Dictionary<Address, List<OrderDigest>>();
             var addressList = new List<Address>();
@@ -210,7 +210,7 @@ namespace Nekoyume.State
             return digests;
         }
 
-        private static async Task<List<OrderDigest>> GetBuyOrderDigests()
+        private static async UniTask<List<OrderDigest>> GetBuyOrderDigestsAsync()
         {
             var orderDigests = new Dictionary<Address, List<OrderDigest>>();
             var addressList = new List<Address>();
@@ -272,7 +272,7 @@ namespace Nekoyume.State
             }
         }
 
-        private static async Task<List<OrderDigest>> GetSellOrderDigests()
+        private static async UniTask<List<OrderDigest>> GetSellOrderDigestsAsync()
         {
             var avatarAddress = States.Instance.CurrentAvatarState.address;
             var receiptAddress = OrderDigestListState.DeriveAddress(avatarAddress);
@@ -298,7 +298,7 @@ namespace Nekoyume.State
             return receipts;
         }
 
-        private static async Task<bool> UpdateCachedShopItems(IEnumerable<OrderDigest> digests)
+        private static async UniTask<bool> UpdateCachedShopItemsAsync(IEnumerable<OrderDigest> digests)
         {
             var selectedDigests = digests
                 .Where(orderDigest => !CachedShopItems.ContainsKey(orderDigest.OrderId)).ToList();

--- a/nekoyume/Assets/_Scripts/State/States.cs
+++ b/nekoyume/Assets/_Scripts/State/States.cs
@@ -172,11 +172,12 @@ namespace Nekoyume.State
             return null;
         }
 
-        public static async UniTask<(bool exist, AvatarState avatarState)> TryGetAvatarStateAsync(Address address,
+        public static async UniTask<(bool exist, AvatarState avatarState)> TryGetAvatarStateAsync(
+            Address address,
             bool allowBrokenState = false)
         {
             AvatarState avatarState = null;
-            bool exist = false;
+            var exist = false;
             try
             {
                 avatarState = await GetAvatarStateAsync(address, allowBrokenState);
@@ -302,7 +303,9 @@ namespace Nekoyume.State
         /// <param name="initializeReactiveState"></param>
         /// <returns></returns>
         /// <exception cref="KeyNotFoundException"></exception>
-        public async UniTask<AvatarState> SelectAvatarAsync(int index, bool initializeReactiveState = true)
+        public async UniTask<AvatarState> SelectAvatarAsync(
+            int index,
+            bool initializeReactiveState = true)
         {
             if (!_avatarStates.ContainsKey(index))
             {
@@ -329,7 +332,7 @@ namespace Nekoyume.State
 
             if (isNew)
             {
-                // notee: commit c1b7f0dc2e8fd922556b83f0b9b2d2d2b2626603 에서 코드 수정이 생기면서
+                // NOTE: commit c1b7f0dc2e8fd922556b83f0b9b2d2d2b2626603 에서 코드 수정이 생기면서
                 // SetCombinationSlotStatesAsync()가 호출이 안되는 이슈가 있어서 revert했습니다. 재수정 필요
                 _combinationSlotStates.Clear();
                 await UniTask.Run(async () =>

--- a/nekoyume/Assets/_Scripts/UI/Widget/Menu.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Menu.cs
@@ -149,7 +149,7 @@ namespace Nekoyume.UI
             CombinationClickInternal(() => Find<Craft>().Show(recipeId));
         }
 
-        private async void UpdateButtons()
+        private void UpdateButtons()
         {
             btnQuest.Update();
             btnCombination.Update();
@@ -158,27 +158,34 @@ namespace Nekoyume.UI
             btnMimisbrunnr.Update();
 
             var addressHex = States.Instance.CurrentAvatarState.address.ToHex();
-            var firstOpenCombinationKey = string.Format(FirstOpenCombinationKeyFormat, addressHex);
-            var firstOpenShopKey = string.Format(FirstOpenShopKeyFormat, addressHex);
-            var firstOpenQuestKey = string.Format(FirstOpenQuestKeyFormat, addressHex);
-            var firstOpenMimisbrunnrKey = string.Format(FirstOpenMimisbrunnrKeyFormat, addressHex);
+            var firstOpenCombinationKey
+                = string.Format(FirstOpenCombinationKeyFormat, addressHex);
+            var firstOpenShopKey
+                = string.Format(FirstOpenShopKeyFormat, addressHex);
+            var firstOpenQuestKey
+                = string.Format(FirstOpenQuestKeyFormat, addressHex);
+            var firstOpenMimisbrunnrKey
+                = string.Format(FirstOpenMimisbrunnrKeyFormat, addressHex);
 
             combinationExclamationMark.gameObject.SetActive(
-                btnCombination.IsUnlocked &&
-                (PlayerPrefs.GetInt(firstOpenCombinationKey, 0) == 0 ||
-                 Craft.SharedModel.HasNotification));
+                btnCombination.IsUnlocked
+                && (PlayerPrefs.GetInt(firstOpenCombinationKey, 0) == 0 ||
+                    Craft.SharedModel.HasNotification));
             shopExclamationMark.gameObject.SetActive(
-                btnShop.IsUnlocked &&
-                PlayerPrefs.GetInt(firstOpenShopKey, 0) == 0);
+                btnShop.IsUnlocked
+                && PlayerPrefs.GetInt(firstOpenShopKey, 0) == 0);
 
             var worldMap = Find<WorldMap>();
             worldMap.UpdateNotificationInfo();
             var hasNotificationInWorldMap = worldMap.HasNotification;
 
             questExclamationMark.gameObject.SetActive(
-                (btnQuest.IsUnlocked && PlayerPrefs.GetInt(firstOpenQuestKey, 0) == 0) || hasNotificationInWorldMap);
-            mimisbrunnrExclamationMark.gameObject.SetActive((btnMimisbrunnr.IsUnlocked &&
-                                                             PlayerPrefs.GetInt(firstOpenMimisbrunnrKey, 0) == 0));
+                (btnQuest.IsUnlocked
+                 && PlayerPrefs.GetInt(firstOpenQuestKey, 0) == 0)
+                || hasNotificationInWorldMap);
+            mimisbrunnrExclamationMark.gameObject.SetActive(
+                btnMimisbrunnr.IsUnlocked
+                && PlayerPrefs.GetInt(firstOpenMimisbrunnrKey, 0) == 0);
         }
 
         private void HideButtons()

--- a/nekoyume/Assets/_Scripts/UI/Widget/Popup/MailPopup.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Popup/MailPopup.cs
@@ -283,7 +283,7 @@ namespace Nekoyume.UI
             var agentAddress = States.Instance.AgentState.address;
             var order = await Util.GetOrder(orderSellerMail.OrderId);
             var taxedPrice = order.Price - order.GetTax();
-            LocalLayerModifier.ModifyAgentGold(agentAddress, taxedPrice);
+            LocalLayerModifier.ModifyAgentGoldAsync(agentAddress, taxedPrice).Forget();
             LocalLayerModifier.RemoveNewMail(avatarAddress, orderSellerMail.id);
         }
 
@@ -319,7 +319,7 @@ namespace Nekoyume.UI
                     LocalLayerModifier.AddItem(avatarAddress, order.TradableId,
                         order.ExpiredBlockIndex, 1);
                     LocalLayerModifier.RemoveNewMail(avatarAddress, cancelOrderMail.id);
-                    ReactiveShopState.UpdateSellDigests();
+                    ReactiveShopState.UpdateSellDigestsAsync().Forget();
                 });
         }
 
@@ -339,7 +339,9 @@ namespace Nekoyume.UI
             {
                 if (itemEnhanceMail.attachment is ItemEnhancement.ResultModel result)
                 {
-                    LocalLayerModifier.ModifyAgentCrystal(States.Instance.AgentState.address, result.CRYSTAL.MajorUnit);
+                    await LocalLayerModifier.ModifyAgentCrystalAsync(
+                        States.Instance.AgentState.address,
+                        result.CRYSTAL.MajorUnit);
                 }
 
                 LocalLayerModifier.AddItem(

--- a/nekoyume/Assets/_Scripts/UI/Widget/ShopBuy.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/ShopBuy.cs
@@ -91,7 +91,7 @@ namespace Nekoyume.UI
             var initWeaponTask = Task.Run(async () =>
             {
                 var list = new List<ItemSubType>() { ItemSubType.Weapon, };
-                await ReactiveShopState.SetBuyDigests(list);
+                await ReactiveShopState.SetBuyDigestsAsync(list);
                 return true;
             });
 
@@ -124,7 +124,7 @@ namespace Nekoyume.UI
                     ItemSubType.Hourglass,
                     ItemSubType.ApStone,
                 };
-                await ReactiveShopState.SetBuyDigests(list);
+                await ReactiveShopState.SetBuyDigestsAsync(list);
                 return true;
             }, _cancellationTokenSource.Token);
 

--- a/nekoyume/Assets/_Scripts/UI/Widget/ShopSell.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/ShopSell.cs
@@ -141,7 +141,7 @@ namespace Nekoyume.UI
 
             var task = Task.Run(async () =>
             {
-                await ReactiveShopState.UpdateSellDigests();
+                await ReactiveShopState.UpdateSellDigestsAsync();
                 return true;
             });
 


### PR DESCRIPTION
- `async void` -> `async UniTask` or `async UniTaskVoid`
- `async Task` -> `async UniTask`
- `async Tack<T>` -> `async UniTask<T>`
- Invoke `UniTask.Forget()` extension function when a async function which is not await.
- Rename async functions which suffix is not contains `Async`.
- Minor cleanup related to `CreateAvatar` action.
- Cover the failure case of `CreateAvatar` action in `LoginDetail` UI.
