### PR TITLE
Disable acquisition place button about locked world

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Module/Button/AcquisitionPlaceButton.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/Button/AcquisitionPlaceButton.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using System.Linq;
-using Nekoyume.Model;
 using Nekoyume.Model.Item;
 using Nekoyume.State;
 using Nekoyume.TableData;
@@ -128,11 +127,13 @@ namespace Nekoyume.UI.Module
             switch (type)
             {
                 case PlaceType.Stage:
-                    var successToGetUnlockedWorld = States.Instance.CurrentAvatarState.worldInformation
+                    var sharedViewModel = Widget.Find<WorldMap>().SharedViewModel;
+                    var successToGetUnlockedWorld = sharedViewModel.WorldInformation
                         .TryGetWorldByStageId(model.StageRow.Id, out var world);
                     if (successToGetUnlockedWorld)
                     {
-                        if (model.StageRow.Id > world.StageClearedId + 1)
+                        if (model.StageRow.Id > world.StageClearedId + 1 ||
+                            !sharedViewModel.UnlockedWorldIds.Contains(world.Id))
                         {
                             disableObject.SetActive(true);
                         }

--- a/nekoyume/Assets/_Scripts/UI/Widget/WorldMap.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/WorldMap.cs
@@ -119,6 +119,11 @@ namespace Nekoyume.UI
                     worldButton.SetOpenCostTextColor(crystal.MajorUnit);
                 }
             }).AddTo(gameObject);
+
+            ReactiveAvatarState.WorldInformation.Subscribe(worldInformation =>
+            {
+                SharedViewModel.WorldInformation = worldInformation;
+            }).AddTo(gameObject);
         }
 
         #endregion


### PR DESCRIPTION
### Description

SSIA

### How to test

1. In unity editor, check material tooltip.

### Related Links

[재료 획득처에서 잠긴 월드 못가도록 막기](https://app.asana.com/0/958521740385861/1202296892181804/f)

### Required Reviewers

@planetarium/9c-dev 

### Screenshot
![image](https://user-images.githubusercontent.com/48484989/173269308-23dbdf50-6983-4c69-8f11-bcb0f3fbf8c6.png)
![image](https://user-images.githubusercontent.com/48484989/173269314-43190def-a262-4a0e-9637-b90cad33dce5.png)

