### PR TITLE
Block button onClick by `enableObject.activeSelf` in `AcquisitionPlaceButton`

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Module/Button/AcquisitionPlaceButton.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/Button/AcquisitionPlaceButton.cs
@@ -74,7 +74,7 @@ namespace Nekoyume.UI.Module
             button.onClick.RemoveAllListeners();
             button.onClick.AddListener(() =>
             {
-                if (CanGoToAcquisitionPlace(model.Type))
+                if (CanGoToAcquisitionPlace(model.Type) && enableObject.activeSelf)
                 {
                     model.OnClick?.Invoke();
                 }


### PR DESCRIPTION
### Description

SSIA

### Related Links

[[신규 월드 오픈] 월드가 열리지 않은 상태에서 퀘스트를 클릭해 이동할 경우 에러가 뜨는 현상](https://app.asana.com/0/1133453747809944/1202492054765148/f)
