### PR TITLE
React to ResultModel of old version in CombinationSlotPopup

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Module/CombinationSlot.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/CombinationSlot.cs
@@ -367,7 +367,7 @@ namespace Nekoyume.UI.Module
                     break;
 
                 case SlotType.Appraise:
-                    UI.NotificationSystem.Push(Nekoyume.Model.Mail.MailType.System,
+                    NotificationSystem.Push(Nekoyume.Model.Mail.MailType.System,
                         L10nManager.Localize("UI_COMBINATION_NOTIFY_IDENTIFYING"),
                         NotificationCell.NotificationType.Information);
                     break;

--- a/nekoyume/Assets/_Scripts/UI/Widget/Popup/CombinationSlotPopup.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Popup/CombinationSlotPopup.cs
@@ -359,6 +359,9 @@ namespace Nekoyume.UI
                         ? CraftType.CombineEquipment
                         : CraftType.CombineConsumable;
 
+                case ItemEnhancement7.ResultModel _:
+                case ItemEnhancement9.ResultModel _:
+                case ItemEnhancement10.ResultModel _:
                 case ItemEnhancement.ResultModel _:
                     return CraftType.Enhancement;
                 default:


### PR DESCRIPTION
### Description

SSIA

### Related Links

[[장비 강화] 현재 강화중인 아이템의 ResultModel 혹은 액션 버전이 현행과 일치하지 않을 때 데이터 가져올 때 깨지는 현상](https://app.asana.com/0/1133453747809944/1202516266356251/f)

### Required Reviewers

@planetarium/9c-dev 
