### PR TITLE
Introcude `ToCurrencyNotation` extension method

### DIFF
--- a/nekoyume/Assets/_Scripts/Extension/BigIntegerExtensions.cs
+++ b/nekoyume/Assets/_Scripts/Extension/BigIntegerExtensions.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Numerics;
+
+namespace Nekoyume
+{
+    public static class BigIntegerExtensions
+    {
+        public static string ToCurrencyNotation(this BigInteger num)
+        {
+            var absoluteValue = BigInteger.Abs(num);
+            var exponent = BigInteger.Log10(BigInteger.Abs(num));
+            if (absoluteValue >= BigInteger.One)
+            {
+                switch ((long) Math.Floor(exponent))
+                {
+                    case 0:
+                    case 1:
+                    case 2:
+                    case 3:
+                        return num.ToString();
+                    case 4:
+                    case 5:
+                        return BigInteger.Divide(num, (BigInteger)1e3) + "K";
+                    case 6:
+                    case 7:
+                    case 8:
+                    case 9:
+                        return BigInteger.Divide(num, (BigInteger)1e6) + "M";
+                    default:
+                        return BigInteger.Divide(num, (BigInteger)1e9) + "B";
+                }
+            }
+
+            return num.ToString();
+        }
+    }
+}

--- a/nekoyume/Assets/_Scripts/Extension/BigIntegerExtensions.cs
+++ b/nekoyume/Assets/_Scripts/Extension/BigIntegerExtensions.cs
@@ -8,7 +8,7 @@ namespace Nekoyume
         public static string ToCurrencyNotation(this BigInteger num)
         {
             var absoluteValue = BigInteger.Abs(num);
-            var exponent = BigInteger.Log10(BigInteger.Abs(num));
+            var exponent = BigInteger.Log10(absoluteValue);
             if (absoluteValue >= BigInteger.One)
             {
                 switch ((long) Math.Floor(exponent))

--- a/nekoyume/Assets/_Scripts/Extension/BigIntegerExtensions.cs.meta
+++ b/nekoyume/Assets/_Scripts/Extension/BigIntegerExtensions.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: dca9b76979da45f9af53835eab01cc72
+timeCreated: 1656496121

--- a/nekoyume/Assets/_Scripts/Extension/FungibleAssetValueExtensions.cs
+++ b/nekoyume/Assets/_Scripts/Extension/FungibleAssetValueExtensions.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Numerics;
+using Libplanet.Assets;
+
+namespace Nekoyume
+{
+    public static class FungibleAssetValueExtensions
+    {
+        public static string ToCurrencyNotation(this FungibleAssetValue value)
+        {
+            return value.MajorUnit.ToCurrencyNotation();
+        }
+    }
+}

--- a/nekoyume/Assets/_Scripts/Extension/FungibleAssetValueExtensions.cs.meta
+++ b/nekoyume/Assets/_Scripts/Extension/FungibleAssetValueExtensions.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 8124dcf694f049cfa5ba22ff573018ab
+timeCreated: 1656495689

--- a/nekoyume/Assets/_Scripts/UI/Module/Crystal.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/Crystal.cs
@@ -76,7 +76,7 @@ namespace Nekoyume.UI.Module
 
         private void SetCrystal(FungibleAssetValue crystal)
         {
-            text.text = crystal.GetQuantityString();
+            text.text = crystal.ToCurrencyNotation();
         }
     }
 }


### PR DESCRIPTION
### Description

1. I made extension method of `BigInteger` and `FungibleAssetValue`.
2. It makes currency fixed string from number. It not surpports `1K`, `1M`, `1B`.
3. Apply to Crystal.

### Related Links

[헤더 재화 자릿수 줄임 기능 개발](https://app.asana.com/0/958521740385861/1202524314445279/f)

### Required Reviewers

@planetarium/9c-dev @jaeho0103 

### Screenshot

![image](https://user-images.githubusercontent.com/48484989/176580161-e0e1f32b-5c3c-4a04-b5b2-885baec17031.png)
![image](https://user-images.githubusercontent.com/48484989/176579766-085dfa83-bef2-412d-b46f-5316dda60ec7.png)
![image](https://user-images.githubusercontent.com/48484989/176580087-6e3eabd4-b947-4033-b2d1-15045cb99a79.png)
![image](https://user-images.githubusercontent.com/48484989/176580258-d74cd02b-2171-4ccb-a3c4-49b539db7b8f.png)
