### PR TITLE
Fixed the skill name to be displayed correctly

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Widget/Popup/CombinationSlotPopup.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Popup/CombinationSlotPopup.cs
@@ -314,10 +314,10 @@ namespace Nekoyume.UI
                     continue;
                 }
 
-                var (skillName, _, _) = itemOptionInfo.SkillOptions[i];
+                var (skillRow, _, _) = itemOptionInfo.SkillOptions[i];
                 var text = string.Format(
                     format,
-                    skillName,
+                    skillRow.GetLocalizedName(),
                     row.ExtraSkillDamageGrowthMin.NormalizeFromTenThousandths() * 100,
                     row.ExtraSkillDamageGrowthMax.NormalizeFromTenThousandths() * 100,
                     row.ExtraSkillChanceGrowthMin.NormalizeFromTenThousandths() * 100,


### PR DESCRIPTION
### Description

- Fixed the skill name to be displayed correctly

### How to test

- Upgrade items with skill options

### Related Links

[[공방] 마나링(바람)의 스킬레이블이 깨지는 현상](https://app.asana.com/0/1133453747809944/1202517192622620/f)

### Required Reviewers

@planetarium/9c-dev 

### Screenshot

![image](https://user-images.githubusercontent.com/40553495/176649730-93eb3f7d-e121-47cc-af84-99c3a044b497.png)
