### PR TITLE
Fix missing `inputs` on `workflow_dispatch`

### DIFF
--- a/.github/workflows/activate-unity.yaml
+++ b/.github/workflows/activate-unity.yaml
@@ -1,15 +1,16 @@
 name: Acquire Unity license activation file
 on:
   workflow_dispatch:
-    unityVersion:
-      required: true
-      description: Version of Unity to use for building the project
-    customImage:
-      required: false
-      default: ""
-      description: >-
-        Specific Docker image that should be used to request license
-        activation file
+    inputs:
+      unityVersion:
+        required: true
+        description: Version of Unity to use for building the project
+      customImage:
+        required: false
+        default: ""
+        description: >-
+          Specific Docker image that should be used to request license
+          activation file
 
 jobs:
   activation:


### PR DESCRIPTION
Continued from <https://github.com/planetarium/NineChronicles/pull/1701>.

It was typo.