### PR TITLE
Improve battle result popup

### DIFF
--- a/nekoyume/Assets/Resources/UI/Animations/UIBattleResultController@Show.anim
+++ b/nekoyume/Assets/Resources/UI/Animations/UIBattleResultController@Show.anim
@@ -1415,6 +1415,117 @@ AnimationClip:
     path: Panel/DefeatImageContainer/DefeatImage
     classID: 225
     script: {fileID: 0}
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: Infinity
+        outSlope: Infinity
+        tangentMode: 103
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      - serializedVersion: 3
+        time: 2.75
+        value: 1
+        inSlope: Infinity
+        outSlope: Infinity
+        tangentMode: 103
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      - serializedVersion: 3
+        time: 3.0166667
+        value: 1
+        inSlope: Infinity
+        outSlope: Infinity
+        tangentMode: 103
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_Enabled
+    path: Panel/ButtonsArea/StageButton
+    classID: 114
+    script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: Infinity
+        outSlope: Infinity
+        tangentMode: 103
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      - serializedVersion: 3
+        time: 2.75
+        value: 1
+        inSlope: Infinity
+        outSlope: Infinity
+        tangentMode: 103
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      - serializedVersion: 3
+        time: 3.0166667
+        value: 1
+        inSlope: Infinity
+        outSlope: Infinity
+        tangentMode: 103
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_Enabled
+    path: Panel/ButtonsArea/StageButton
+    classID: 114
+    script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: Infinity
+        outSlope: Infinity
+        tangentMode: 103
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      - serializedVersion: 3
+        time: 2.75
+        value: 1
+        inSlope: Infinity
+        outSlope: Infinity
+        tangentMode: 103
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      - serializedVersion: 3
+        time: 3.0166667
+        value: 1
+        inSlope: Infinity
+        outSlope: Infinity
+        tangentMode: 103
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_Enabled
+    path: Panel/ButtonsArea/StageButton/Text
+    classID: 114
+    script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
   m_PPtrCurves: []
   m_SampleRate: 60
   m_WrapMode: 0
@@ -1660,6 +1771,27 @@ AnimationClip:
       script: {fileID: 0}
       typeID: 225
       customType: 0
+      isPPtrCurve: 0
+    - serializedVersion: 2
+      path: 3512086349
+      attribute: 3305885265
+      script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+      typeID: 114
+      customType: 24
+      isPPtrCurve: 0
+    - serializedVersion: 2
+      path: 3512086349
+      attribute: 3305885265
+      script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+      typeID: 114
+      customType: 24
+      isPPtrCurve: 0
+    - serializedVersion: 2
+      path: 2540576225
+      attribute: 3305885265
+      script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+      typeID: 114
+      customType: 24
       isPPtrCurve: 0
     - serializedVersion: 2
       path: 2549930618
@@ -3116,6 +3248,117 @@ AnimationClip:
     path: Panel/DefeatImageContainer/DefeatImage
     classID: 225
     script: {fileID: 0}
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: Infinity
+        outSlope: Infinity
+        tangentMode: 103
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      - serializedVersion: 3
+        time: 2.75
+        value: 1
+        inSlope: Infinity
+        outSlope: Infinity
+        tangentMode: 103
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      - serializedVersion: 3
+        time: 3.0166667
+        value: 1
+        inSlope: Infinity
+        outSlope: Infinity
+        tangentMode: 103
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_Enabled
+    path: Panel/ButtonsArea/StageButton
+    classID: 114
+    script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: Infinity
+        outSlope: Infinity
+        tangentMode: 103
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      - serializedVersion: 3
+        time: 2.75
+        value: 1
+        inSlope: Infinity
+        outSlope: Infinity
+        tangentMode: 103
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      - serializedVersion: 3
+        time: 3.0166667
+        value: 1
+        inSlope: Infinity
+        outSlope: Infinity
+        tangentMode: 103
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_Enabled
+    path: Panel/ButtonsArea/StageButton
+    classID: 114
+    script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: Infinity
+        outSlope: Infinity
+        tangentMode: 103
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      - serializedVersion: 3
+        time: 2.75
+        value: 1
+        inSlope: Infinity
+        outSlope: Infinity
+        tangentMode: 103
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      - serializedVersion: 3
+        time: 3.0166667
+        value: 1
+        inSlope: Infinity
+        outSlope: Infinity
+        tangentMode: 103
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_Enabled
+    path: Panel/ButtonsArea/StageButton/Text
+    classID: 114
+    script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
   m_EulerEditorCurves: []
   m_HasGenericRootTransform: 0
   m_HasMotionFloatCurves: 0

--- a/nekoyume/Assets/Resources/UI/Animations/UIBattleResultController@Show.anim
+++ b/nekoyume/Assets/Resources/UI/Animations/UIBattleResultController@Show.anim
@@ -1449,44 +1449,7 @@ AnimationClip:
       m_PostInfinity: 2
       m_RotationOrder: 4
     attribute: m_Enabled
-    path: Panel/ButtonsArea/StageButton
-    classID: 114
-    script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
-  - curve:
-      serializedVersion: 2
-      m_Curve:
-      - serializedVersion: 3
-        time: 0
-        value: 0
-        inSlope: Infinity
-        outSlope: Infinity
-        tangentMode: 103
-        weightedMode: 0
-        inWeight: 0
-        outWeight: 0
-      - serializedVersion: 3
-        time: 2.75
-        value: 1
-        inSlope: Infinity
-        outSlope: Infinity
-        tangentMode: 103
-        weightedMode: 0
-        inWeight: 0
-        outWeight: 0
-      - serializedVersion: 3
-        time: 3.0166667
-        value: 1
-        inSlope: Infinity
-        outSlope: Infinity
-        tangentMode: 103
-        weightedMode: 0
-        inWeight: 0
-        outWeight: 0
-      m_PreInfinity: 2
-      m_PostInfinity: 2
-      m_RotationOrder: 4
-    attribute: m_Enabled
-    path: Panel/ButtonsArea/StageButton
+    path: Panel/ButtonsArea/StagePreparationButton
     classID: 114
     script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   - curve:
@@ -1523,7 +1486,44 @@ AnimationClip:
       m_PostInfinity: 2
       m_RotationOrder: 4
     attribute: m_Enabled
-    path: Panel/ButtonsArea/StageButton/Text
+    path: Panel/ButtonsArea/StagePreparationButton
+    classID: 114
+    script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: Infinity
+        outSlope: Infinity
+        tangentMode: 103
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      - serializedVersion: 3
+        time: 2.75
+        value: 1
+        inSlope: Infinity
+        outSlope: Infinity
+        tangentMode: 103
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      - serializedVersion: 3
+        time: 3.0166667
+        value: 1
+        inSlope: Infinity
+        outSlope: Infinity
+        tangentMode: 103
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_Enabled
+    path: Panel/ButtonsArea/StagePreparationButton/Text
     classID: 114
     script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
   m_PPtrCurves: []
@@ -1773,21 +1773,21 @@ AnimationClip:
       customType: 0
       isPPtrCurve: 0
     - serializedVersion: 2
-      path: 3512086349
-      attribute: 3305885265
-      script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
-      typeID: 114
-      customType: 24
-      isPPtrCurve: 0
-    - serializedVersion: 2
-      path: 3512086349
+      path: 3937776507
       attribute: 3305885265
       script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
       typeID: 114
       customType: 24
       isPPtrCurve: 0
     - serializedVersion: 2
-      path: 2540576225
+      path: 3937776507
+      attribute: 3305885265
+      script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+      typeID: 114
+      customType: 24
+      isPPtrCurve: 0
+    - serializedVersion: 2
+      path: 3650064154
       attribute: 3305885265
       script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
       typeID: 114
@@ -3282,44 +3282,7 @@ AnimationClip:
       m_PostInfinity: 2
       m_RotationOrder: 4
     attribute: m_Enabled
-    path: Panel/ButtonsArea/StageButton
-    classID: 114
-    script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
-  - curve:
-      serializedVersion: 2
-      m_Curve:
-      - serializedVersion: 3
-        time: 0
-        value: 0
-        inSlope: Infinity
-        outSlope: Infinity
-        tangentMode: 103
-        weightedMode: 0
-        inWeight: 0
-        outWeight: 0
-      - serializedVersion: 3
-        time: 2.75
-        value: 1
-        inSlope: Infinity
-        outSlope: Infinity
-        tangentMode: 103
-        weightedMode: 0
-        inWeight: 0
-        outWeight: 0
-      - serializedVersion: 3
-        time: 3.0166667
-        value: 1
-        inSlope: Infinity
-        outSlope: Infinity
-        tangentMode: 103
-        weightedMode: 0
-        inWeight: 0
-        outWeight: 0
-      m_PreInfinity: 2
-      m_PostInfinity: 2
-      m_RotationOrder: 4
-    attribute: m_Enabled
-    path: Panel/ButtonsArea/StageButton
+    path: Panel/ButtonsArea/StagePreparationButton
     classID: 114
     script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   - curve:
@@ -3356,7 +3319,44 @@ AnimationClip:
       m_PostInfinity: 2
       m_RotationOrder: 4
     attribute: m_Enabled
-    path: Panel/ButtonsArea/StageButton/Text
+    path: Panel/ButtonsArea/StagePreparationButton
+    classID: 114
+    script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: Infinity
+        outSlope: Infinity
+        tangentMode: 103
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      - serializedVersion: 3
+        time: 2.75
+        value: 1
+        inSlope: Infinity
+        outSlope: Infinity
+        tangentMode: 103
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      - serializedVersion: 3
+        time: 3.0166667
+        value: 1
+        inSlope: Infinity
+        outSlope: Infinity
+        tangentMode: 103
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_Enabled
+    path: Panel/ButtonsArea/StagePreparationButton/Text
     classID: 114
     script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
   m_EulerEditorCurves: []

--- a/nekoyume/Assets/Resources/UI/Prefabs/UI_BattleResultPopup.prefab
+++ b/nekoyume/Assets/Resources/UI/Prefabs/UI_BattleResultPopup.prefab
@@ -113,7 +113,7 @@ MonoBehaviour:
     - {fileID: 8798553346396364796}
   bottomText: {fileID: 673694281534015466}
   closeButton: {fileID: 5478299572133443444}
-  stageButton: {fileID: 3326781521486410000}
+  stagePreparationButton: {fileID: 3326781521486410000}
   nextButton: {fileID: 7074026571992738424}
   repeatButton: {fileID: 7118180269659475256}
   stageProgressBar: {fileID: 6990079336486425012}
@@ -742,7 +742,7 @@ GameObject:
   - component: {fileID: 3326781521486410000}
   - component: {fileID: 303410148727924028}
   m_Layer: 5
-  m_Name: StageButton
+  m_Name: StagePreparationButton
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0

--- a/nekoyume/Assets/Resources/UI/Prefabs/UI_BattleResultPopup.prefab
+++ b/nekoyume/Assets/Resources/UI/Prefabs/UI_BattleResultPopup.prefab
@@ -31,6 +31,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 3644358395928438811}
   - {fileID: 2498277699267993728}
@@ -112,6 +113,7 @@ MonoBehaviour:
     - {fileID: 8798553346396364796}
   bottomText: {fileID: 673694281534015466}
   closeButton: {fileID: 5478299572133443444}
+  stageButton: {fileID: 3326781521486410000}
   nextButton: {fileID: 7074026571992738424}
   repeatButton: {fileID: 7118180269659475256}
   stageProgressBar: {fileID: 6990079336486425012}
@@ -135,7 +137,7 @@ CanvasGroup:
   m_IgnoreParentGroups: 0
 --- !u!95 &6624583594159216111
 Animator:
-  serializedVersion: 3
+  serializedVersion: 4
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -148,6 +150,7 @@ Animator:
   m_UpdateMode: 0
   m_ApplyRootMotion: 0
   m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
   m_WarningMessage: 
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
@@ -181,6 +184,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 9098095879202206802}
   m_RootOrder: 0
@@ -347,6 +351,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: -1, z: 0, w: 0}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 6344477898592055316}
   m_RootOrder: 5
@@ -423,6 +428,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 3564522988600145851}
   m_RootOrder: 0
@@ -588,6 +594,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1906097335064649534}
   - {fileID: 940688545004970720}
@@ -673,6 +680,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0.0000012732}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 6344477898592055316}
   m_RootOrder: 2
@@ -720,6 +728,149 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &674039359932961466
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1445891526390732352}
+  - component: {fileID: 7105336373012893026}
+  - component: {fileID: 697931539572665386}
+  - component: {fileID: 3326781521486410000}
+  - component: {fileID: 303410148727924028}
+  m_Layer: 5
+  m_Name: StageButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1445891526390732352
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 674039359932961466}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3103299559879931418}
+  m_Father: {fileID: 8667842284378718185}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 200, y: 46}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7105336373012893026
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 674039359932961466}
+  m_CullTransparentMesh: 0
+--- !u!114 &697931539572665386
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 674039359932961466}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: d2e596a6e4f454d439b735a988b14318, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &3326781521486410000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 674039359932961466}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 3
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 697931539572665386}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!95 &303410148727924028
+Animator:
+  serializedVersion: 4
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 674039359932961466}
+  m_Enabled: 1
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 22100000, guid: 2db93b3f45b9c144f9d5d985f2a95adf, type: 2}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorControllerStateOnDisable: 0
 --- !u!1 &865112724783262840
 GameObject:
   m_ObjectHideFlags: 0
@@ -748,6 +899,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: -1, z: 0, w: 0}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 6344477898592055316}
   m_RootOrder: 9
@@ -822,6 +974,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4130395854787017805}
   - {fileID: 8953487430738571312}
@@ -891,10 +1044,11 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1944761634606585864}
   m_Father: {fileID: 8667842284378718185}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -985,7 +1139,7 @@ MonoBehaviour:
       m_Calls: []
 --- !u!95 &8839678601797738841
 Animator:
-  serializedVersion: 3
+  serializedVersion: 4
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -998,6 +1152,7 @@ Animator:
   m_UpdateMode: 0
   m_ApplyRootMotion: 0
   m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
   m_WarningMessage: 
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
@@ -1030,6 +1185,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 5573215429139007309}
   m_RootOrder: 0
@@ -1105,6 +1261,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1.2, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 7254075308520482385}
   m_RootOrder: 0
@@ -1241,6 +1398,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2777567741082144336}
   m_RootOrder: 0
@@ -1316,6 +1474,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1.2, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 9086271449867102218}
   m_RootOrder: 0
@@ -1451,6 +1610,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2700280700426422}
   m_Father: {fileID: 2777567741082144336}
@@ -1540,6 +1700,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 343956993360879734}
   m_RootOrder: 0
@@ -1706,6 +1867,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 6344477898592055316}
   m_RootOrder: 0
@@ -1781,6 +1943,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 6344477898592055316}
   m_RootOrder: 4
@@ -1857,6 +2020,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 941226756191808757}
   m_RootOrder: 0
@@ -2024,6 +2188,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 6344477898592055316}
   - {fileID: 2777567741082144336}
@@ -2129,6 +2294,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 222187614159366176}
   - {fileID: 791257638064409715}
@@ -2218,6 +2384,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 6344477898592055316}
   m_RootOrder: 11
@@ -2294,6 +2461,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0.75, y: 0.75, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 7160814001809470773}
   - {fileID: 11638741825513172}
@@ -2341,7 +2509,7 @@ MonoBehaviour:
   m_LayoutPriority: 1
 --- !u!95 &8280459435808002684
 Animator:
-  serializedVersion: 3
+  serializedVersion: 4
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -2354,6 +2522,7 @@ Animator:
   m_UpdateMode: 0
   m_ApplyRootMotion: 0
   m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
   m_WarningMessage: 
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
@@ -2398,6 +2567,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: -1, z: 0, w: 0}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1.03, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 6344477898592055316}
   m_RootOrder: 7
@@ -2474,6 +2644,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 325480898893169324}
   - {fileID: 1696694796370377440}
@@ -2571,6 +2742,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 988915962447364565}
   - {fileID: 1834716781572988933}
@@ -2630,6 +2802,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1.2, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4484624942204044274}
   m_RootOrder: 0
@@ -2764,8 +2937,10 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 9098095879202206802}
+  - {fileID: 1445891526390732352}
   - {fileID: 343956993360879734}
   - {fileID: 3564522988600145851}
   m_Father: {fileID: 2498277699267993728}
@@ -2852,6 +3027,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 7448754269099346562}
   m_Father: {fileID: 8667842284378718185}
@@ -2946,7 +3122,7 @@ MonoBehaviour:
       m_Calls: []
 --- !u!95 &9165775328144018973
 Animator:
-  serializedVersion: 3
+  serializedVersion: 4
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -2959,6 +3135,7 @@ Animator:
   m_UpdateMode: 0
   m_ApplyRootMotion: 0
   m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
   m_WarningMessage: 
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
@@ -2991,6 +3168,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 1, z: 0, w: 0}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2777567741082144336}
   m_RootOrder: 2
@@ -3066,6 +3244,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 169728420031577121}
   - {fileID: 6806555385163114133}
@@ -3127,6 +3306,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1044800107307305612}
   m_Father: {fileID: 9101350551897634300}
@@ -3134,7 +3314,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 326, y: 0}
+  m_AnchoredPosition: {x: 415, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &7953334354609671252
@@ -3306,6 +3486,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 3613044234188380673}
   - {fileID: 5056943068067875922}
@@ -3338,6 +3519,174 @@ MonoBehaviour:
   m_FlexibleWidth: 1
   m_FlexibleHeight: -1
   m_LayoutPriority: 1
+--- !u!1 &5665970719312373228
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3103299559879931418}
+  - component: {fileID: 4050284526343904574}
+  - component: {fileID: 2151160873387009261}
+  - component: {fileID: 6111529460527341731}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3103299559879931418
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5665970719312373228}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1445891526390732352}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4050284526343904574
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5665970719312373228}
+  m_CullTransparentMesh: 0
+--- !u!114 &2151160873387009261
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5665970719312373228}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: UI_STAGE
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8a682b7747d4a664089b7b1065aa0035, type: 2}
+  m_sharedMaterial: {fileID: -2364689171920820918, guid: 8a682b7747d4a664089b7b1065aa0035,
+    type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4292146175
+  m_fontColor: {r: 1, g: 0.9529412, b: 0.83137256, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 20
+  m_fontSizeBase: 20
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 8
+  m_fontSizeMax: 32
+  m_fontStyle: 1
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 1
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!114 &6111529460527341731
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5665970719312373228}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6d668203cf6645c0bb09a4991d4bbe06, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  fixedFontAsset: 0
+  fixedFontStyle: 0
+  fixedFontSizeOffset: 0
+  fixedSpacingOption: 0
+  fixedMarginOption: 0
+  fontMaterialType: 0
+  l10nKey: UI_STAGE
+  fontMaterialIndexInitialized: 0
+  fontMaterialIndex: 0
+  defaultFontStylesInitialized: 0
+  defaultFontStyles: 0
+  defaultFontSizeInitialized: 0
+  defaultFontSize: 0
+  defaultCharacterSpacingInitialized: 0
+  defaultCharacterSpacing: 0
+  defaultWordSpacingInitialized: 0
+  defaultWordSpacing: 0
+  defaultLineSpacingInitialized: 0
+  defaultLineSpacing: 0
 --- !u!1 &5912916574049871624
 GameObject:
   m_ObjectHideFlags: 0
@@ -3366,6 +3715,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 6344477898592055316}
   m_RootOrder: 10
@@ -3441,6 +3791,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1.2, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 6636549610587828772}
   m_RootOrder: 0
@@ -3575,6 +3926,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: -1, z: 0, w: 0}
   m_LocalPosition: {x: 0, y: 0, z: 0.0000012732}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 6344477898592055316}
   m_RootOrder: 1
@@ -3652,6 +4004,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2498277699267993728}
   m_RootOrder: 5
@@ -3838,6 +4191,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: -0.078459024, w: 0.99691737}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 6344477898592055316}
   m_RootOrder: 6
@@ -3914,6 +4268,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2946634846980001026}
   - {fileID: 5755516607873999722}
@@ -4012,6 +4367,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 6344477898592055316}
   m_RootOrder: 8
@@ -4087,6 +4443,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 5056943068067875922}
   m_RootOrder: 0
@@ -4222,6 +4579,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 941226756191808757}
   m_RootOrder: 1
@@ -4388,6 +4746,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: -1, z: 0, w: 0}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 6344477898592055316}
   m_RootOrder: 3
@@ -4463,6 +4822,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1112777214307556813}
   - {fileID: 6245551836980613832}
@@ -4524,10 +4884,11 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1002688660130668841}
   m_Father: {fileID: 8667842284378718185}
-  m_RootOrder: 2
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -4618,7 +4979,7 @@ MonoBehaviour:
       m_Calls: []
 --- !u!95 &8594928801218447186
 Animator:
-  serializedVersion: 3
+  serializedVersion: 4
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -4631,6 +4992,7 @@ Animator:
   m_UpdateMode: 0
   m_ApplyRootMotion: 0
   m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
   m_WarningMessage: 
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
@@ -6495,6 +6857,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 0c75875ee6d9a724ab977f6af0c747ab, type: 3}
+--- !u!224 &2946634846980001026 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 2855381624818415449, guid: 0c75875ee6d9a724ab977f6af0c747ab,
+    type: 3}
+  m_PrefabInstance: {fileID: 1100240318847875675}
+  m_PrefabAsset: {fileID: 0}
 --- !u!114 &8828973387584366379 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 8485351490845318512, guid: 0c75875ee6d9a724ab977f6af0c747ab,
@@ -6507,12 +6875,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0e4bc746f35a40a28d25e70e7d5307a5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!224 &2946634846980001026 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 2855381624818415449, guid: 0c75875ee6d9a724ab977f6af0c747ab,
-    type: 3}
-  m_PrefabInstance: {fileID: 1100240318847875675}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1141868800928187020
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -11792,9 +12154,9 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 0c75875ee6d9a724ab977f6af0c747ab, type: 3}
---- !u!224 &5755516607873999722 stripped
+--- !u!224 &2050333071573695959 stripped
 RectTransform:
-  m_CorrespondingSourceObject: {fileID: 2855381624818415449, guid: 0c75875ee6d9a724ab977f6af0c747ab,
+  m_CorrespondingSourceObject: {fileID: 8362013223337650660, guid: 0c75875ee6d9a724ab977f6af0c747ab,
     type: 3}
   m_PrefabInstance: {fileID: 7529994017439372339}
   m_PrefabAsset: {fileID: 0}
@@ -11810,9 +12172,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0e4bc746f35a40a28d25e70e7d5307a5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!224 &2050333071573695959 stripped
+--- !u!224 &5755516607873999722 stripped
 RectTransform:
-  m_CorrespondingSourceObject: {fileID: 8362013223337650660, guid: 0c75875ee6d9a724ab977f6af0c747ab,
+  m_CorrespondingSourceObject: {fileID: 2855381624818415449, guid: 0c75875ee6d9a724ab977f6af0c747ab,
     type: 3}
   m_PrefabInstance: {fileID: 7529994017439372339}
   m_PrefabAsset: {fileID: 0}

--- a/nekoyume/Assets/_Scripts/Game/Stage.cs
+++ b/nekoyume/Assets/_Scripts/Game/Stage.cs
@@ -548,17 +548,11 @@ namespace Nekoyume.Game
                             }
                         }
                     }
-                    else if (_battleResultModel.WorldID <= 10000)
-                    {
-                        _battleResultModel.NextState = IsRepeatStage
-                            ? BattleResultPopup.NextState.RepeatStage
-                            : BattleResultPopup.NextState.None;
-                    }
                     else
                     {
                         _battleResultModel.NextState = IsRepeatStage
                             ? BattleResultPopup.NextState.RepeatStage
-                            : BattleResultPopup.NextState.GoToMain;
+                            : BattleResultPopup.NextState.None;
                     }
                 }
             }

--- a/nekoyume/Assets/_Scripts/Game/Stage.cs
+++ b/nekoyume/Assets/_Scripts/Game/Stage.cs
@@ -548,11 +548,17 @@ namespace Nekoyume.Game
                             }
                         }
                     }
-                    else
+                    else if(_battleResultModel.WorldID <= 10000)
                     {
                         _battleResultModel.NextState = IsRepeatStage
                             ? BattleResultPopup.NextState.RepeatStage
                             : BattleResultPopup.NextState.None;
+                    }
+                    else
+                    {
+                        _battleResultModel.NextState = IsRepeatStage
+                            ? BattleResultPopup.NextState.RepeatStage
+                            : BattleResultPopup.NextState.GoToMain;
                     }
                 }
             }

--- a/nekoyume/Assets/_Scripts/Game/Stage.cs
+++ b/nekoyume/Assets/_Scripts/Game/Stage.cs
@@ -548,7 +548,7 @@ namespace Nekoyume.Game
                             }
                         }
                     }
-                    else if(_battleResultModel.WorldID <= 10000)
+                    else if (_battleResultModel.WorldID <= 10000)
                     {
                         _battleResultModel.NextState = IsRepeatStage
                             ? BattleResultPopup.NextState.RepeatStage

--- a/nekoyume/Assets/_Scripts/Game/Stage.cs
+++ b/nekoyume/Assets/_Scripts/Game/Stage.cs
@@ -552,7 +552,7 @@ namespace Nekoyume.Game
                     {
                         _battleResultModel.NextState = IsRepeatStage
                             ? BattleResultPopup.NextState.RepeatStage
-                            : BattleResultPopup.NextState.GoToMain;
+                            : BattleResultPopup.NextState.None;
                     }
                 }
             }

--- a/nekoyume/Assets/_Scripts/UI/Module/Inventory.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/Inventory.cs
@@ -136,7 +136,7 @@ namespace Nekoyume.UI.Module
         private void Set(
             Action<Inventory, Nekoyume.Model.Item.Inventory> onUpdateInventory = null,
             List<(ItemType type, Predicate<InventoryItem> predicate)> itemSetDimPredicates = null,
-            bool isArena = false)
+            bool isArena = false, bool useConsumable = false)
         {
             _disposablesOnSet.DisposeAllAndClear();
             foreach (var type in ItemTypes)
@@ -159,7 +159,14 @@ namespace Nekoyume.UI.Module
                     .AddTo(_disposablesOnSet);
             }
 
-            SetToggle(equipmentButton, ItemType.Equipment);
+            if (useConsumable && _consumables.Any())
+            {
+                SetToggle(consumableButton, ItemType.Consumable);
+            }
+            else
+            {
+                SetToggle(equipmentButton, ItemType.Equipment);
+            }
             scroll.OnClick.Subscribe(OnClickItem).AddTo(_disposablesOnSet);
             scroll.OnDoubleClick.Subscribe(OnDoubleClick).AddTo(_disposablesOnSet);
         }
@@ -489,7 +496,8 @@ namespace Nekoyume.UI.Module
             System.Action clickEquipmentToggle,
             System.Action clickCostumeToggle,
             IEnumerable<ElementalType> elementalTypes,
-            bool isArena = false)
+            bool isArena = false,
+            bool useConsumable = false)
         {
             _reverseOrder = false;
             SetAction(clickItem, doubleClickItem, clickEquipmentToggle, clickCostumeToggle);
@@ -501,7 +509,8 @@ namespace Nekoyume.UI.Module
                 : null;
             Set(
                 itemSetDimPredicates: predicateList,
-                isArena: isArena);
+                isArena: isArena,
+                useConsumable: useConsumable);
             _allowMoveTab = true;
         }
 

--- a/nekoyume/Assets/_Scripts/UI/Module/Inventory.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/Inventory.cs
@@ -159,14 +159,17 @@ namespace Nekoyume.UI.Module
                     .AddTo(_disposablesOnSet);
             }
 
-            if (useConsumable && _consumables.Any())
+            SetToggle(equipmentButton, ItemType.Equipment);
+            if (useConsumable)
             {
-                SetToggle(consumableButton, ItemType.Consumable);
+                ReactiveAvatarState.Inventory.First().Subscribe(e =>
+                    {
+                        SetInventory(e, onUpdateInventory);
+                        if (_consumables.Any()) SetToggle(consumableButton, ItemType.Consumable);
+                    })
+                    .AddTo(_disposablesOnSet);
             }
-            else
-            {
-                SetToggle(equipmentButton, ItemType.Equipment);
-            }
+
             scroll.OnClick.Subscribe(OnClickItem).AddTo(_disposablesOnSet);
             scroll.OnDoubleClick.Subscribe(OnDoubleClick).AddTo(_disposablesOnSet);
         }

--- a/nekoyume/Assets/_Scripts/UI/Module/Inventory.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/Inventory.cs
@@ -136,7 +136,8 @@ namespace Nekoyume.UI.Module
         private void Set(
             Action<Inventory, Nekoyume.Model.Item.Inventory> onUpdateInventory = null,
             List<(ItemType type, Predicate<InventoryItem> predicate)> itemSetDimPredicates = null,
-            bool isArena = false, bool useConsumable = false)
+            bool isArena = false,
+            bool useConsumable = false)
         {
             _disposablesOnSet.DisposeAllAndClear();
             foreach (var type in ItemTypes)
@@ -163,11 +164,10 @@ namespace Nekoyume.UI.Module
             if (useConsumable)
             {
                 ReactiveAvatarState.Inventory.First().Subscribe(e =>
-                    {
-                        SetInventory(e, onUpdateInventory);
-                        if (_consumables.Any()) SetToggle(consumableButton, ItemType.Consumable);
-                    })
-                    .AddTo(_disposablesOnSet);
+                {
+                    SetInventory(e, onUpdateInventory);
+                    if (_consumables.Any()) SetToggle(consumableButton, ItemType.Consumable);
+                });
             }
 
             scroll.OnClick.Subscribe(OnClickItem).AddTo(_disposablesOnSet);

--- a/nekoyume/Assets/_Scripts/UI/Widget/BattlePreparation.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/BattlePreparation.cs
@@ -237,7 +237,7 @@ namespace Nekoyume.UI
             _worldId = worldId;
             _stageId.Value = stageId;
 
-            UpdateInventory(stageType is StageType.HackAndSlash);
+            UpdateInventory(stageType is StageType.HackAndSlash or StageType.Mimisbrunnr);
             UpdateBackground(stageType);
             UpdateTitle();
             UpdateStat(currentAvatarState);

--- a/nekoyume/Assets/_Scripts/UI/Widget/BattlePreparation.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/BattlePreparation.cs
@@ -237,7 +237,7 @@ namespace Nekoyume.UI
             _worldId = worldId;
             _stageId.Value = stageId;
 
-            UpdateInventory(stageType == StageType.HackAndSlash);
+            UpdateInventory(stageType is StageType.HackAndSlash);
             UpdateBackground(stageType);
             UpdateTitle();
             UpdateStat(currentAvatarState);

--- a/nekoyume/Assets/_Scripts/UI/Widget/BattlePreparation.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/BattlePreparation.cs
@@ -237,7 +237,7 @@ namespace Nekoyume.UI
             _worldId = worldId;
             _stageId.Value = stageId;
 
-            UpdateInventory();
+            UpdateInventory(stageType == StageType.HackAndSlash);
             UpdateBackground(stageType);
             UpdateTitle();
             UpdateStat(currentAvatarState);
@@ -271,7 +271,7 @@ namespace Nekoyume.UI
 
         #endregion
 
-        private void UpdateInventory()
+        private void UpdateInventory(bool useConsumable)
         {
             inventory.SetAvatarInfo(
                 clickItem: ShowItemTooltip,
@@ -286,7 +286,8 @@ namespace Nekoyume.UI
                     costumeSlots.gameObject.SetActive(true);
                     equipmentSlots.gameObject.SetActive(false);
                 },
-                GetElementalTypes());
+                GetElementalTypes(),
+                useConsumable: useConsumable);
         }
 
         private void UpdateBackground(StageType stageType)

--- a/nekoyume/Assets/_Scripts/UI/Widget/Popup/BattleResultPopup.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Popup/BattleResultPopup.cs
@@ -112,6 +112,9 @@ namespace Nekoyume.UI
         private Button closeButton = null;
 
         [SerializeField]
+        private Button stageButton = null;
+
+        [SerializeField]
         private Button nextButton = null;
 
         [SerializeField]
@@ -164,6 +167,11 @@ namespace Nekoyume.UI
                     }
                 }).AddTo(gameObject);
 
+            stageButton.OnClickAsObservable().Subscribe(_ =>
+            {
+                OnClickStage();
+            }).AddTo(gameObject);
+
             nextButton.OnClickAsObservable().Subscribe(_ =>
                 {
                     StartCoroutine(OnClickNext());
@@ -190,6 +198,13 @@ namespace Nekoyume.UI
                 yield return CoDialog(SharedModel.StageID);
             }
             GoToMain();
+        }
+
+        private void OnClickStage()
+        {
+            _IsAlreadyOut = true;
+            AudioController.PlayClick();
+            GoToPreparation();
         }
 
         private IEnumerator OnClickNext()
@@ -251,6 +266,7 @@ namespace Nekoyume.UI
 
             base.Show();
             closeButton.gameObject.SetActive(model.StageID >= 3 || model.LastClearedStageId >= 3);
+            stageButton.gameObject.SetActive(false);
             repeatButton.gameObject.SetActive(false);
             nextButton.gameObject.SetActive(false);
 
@@ -411,6 +427,12 @@ namespace Nekoyume.UI
             string fullFormat = string.Empty;
             closeButton.interactable = true;
 
+            if (!SharedModel.IsClear)
+            {
+                stageButton.gameObject.SetActive(true);
+                stageButton.interactable = true;
+            }
+
             if (!SharedModel.ActionPointNotEnough)
             {
                 var value = SharedModel.StageID >= 3 || SharedModel.LastClearedStageId >= 3;
@@ -440,6 +462,9 @@ namespace Nekoyume.UI
                     SubmitWidget = nextButton.onClick.Invoke;
                     fullFormat = L10nManager.Localize("UI_BATTLE_RESULT_NEXT_STAGE_FORMAT");
                     break;
+                default:
+                    bottomText.text = string.Empty;
+                    yield break;
             }
 
             // for tutorial
@@ -447,6 +472,7 @@ namespace Nekoyume.UI
                 SharedModel.LastClearedStageId == 3 &&
                 SharedModel.State == BattleLog.Result.Win)
             {
+                stageButton.gameObject.SetActive(false);
                 nextButton.gameObject.SetActive(false);
                 repeatButton.gameObject.SetActive(false);
                 bottomText.text = string.Empty;
@@ -502,6 +528,7 @@ namespace Nekoyume.UI
             }
 
             closeButton.interactable = false;
+            stageButton.interactable = false;
             repeatButton.interactable = false;
             nextButton.interactable = false;
             actionPoint.SetEventTriggerEnabled(false);
@@ -556,6 +583,7 @@ namespace Nekoyume.UI
             }
 
             closeButton.interactable = false;
+            stageButton.interactable = false;
             repeatButton.interactable = false;
             nextButton.interactable = false;
             actionPoint.SetEventTriggerEnabled(false);
@@ -673,6 +701,12 @@ namespace Nekoyume.UI
                     });
                 }
             }
+        }
+
+        private void GoToPreparation()
+        {
+            // Todo : Fill
+            Debug.LogError("Go to preparation");
         }
 
         private void StopCoUpdateBottomText()

--- a/nekoyume/Assets/_Scripts/UI/Widget/Popup/BattleResultPopup.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Popup/BattleResultPopup.cs
@@ -113,7 +113,7 @@ namespace Nekoyume.UI
         private Button closeButton = null;
 
         [SerializeField]
-        private Button stageButton = null;
+        private Button stagePreparationButton = null;
 
         [SerializeField]
         private Button nextButton = null;
@@ -168,7 +168,7 @@ namespace Nekoyume.UI
                     }
                 }).AddTo(gameObject);
 
-            stageButton.OnClickAsObservable().Subscribe(_ =>
+            stagePreparationButton.OnClickAsObservable().Subscribe(_ =>
             {
                 OnClickStage();
             }).AddTo(gameObject);
@@ -267,7 +267,7 @@ namespace Nekoyume.UI
 
             base.Show();
             closeButton.gameObject.SetActive(model.StageID >= 3 || model.LastClearedStageId >= 3);
-            stageButton.gameObject.SetActive(false);
+            stagePreparationButton.gameObject.SetActive(false);
             repeatButton.gameObject.SetActive(false);
             nextButton.gameObject.SetActive(false);
 
@@ -430,8 +430,8 @@ namespace Nekoyume.UI
 
             if (!SharedModel.IsClear && SharedModel.WorldID <= 10000)
             {
-                stageButton.gameObject.SetActive(true);
-                stageButton.interactable = true;
+                stagePreparationButton.gameObject.SetActive(true);
+                stagePreparationButton.interactable = true;
             }
 
             if (!SharedModel.ActionPointNotEnough)
@@ -473,7 +473,7 @@ namespace Nekoyume.UI
                 SharedModel.LastClearedStageId == 3 &&
                 SharedModel.State == BattleLog.Result.Win)
             {
-                stageButton.gameObject.SetActive(false);
+                stagePreparationButton.gameObject.SetActive(false);
                 nextButton.gameObject.SetActive(false);
                 repeatButton.gameObject.SetActive(false);
                 bottomText.text = string.Empty;
@@ -529,7 +529,7 @@ namespace Nekoyume.UI
             }
 
             closeButton.interactable = false;
-            stageButton.interactable = false;
+            stagePreparationButton.interactable = false;
             repeatButton.interactable = false;
             nextButton.interactable = false;
             actionPoint.SetEventTriggerEnabled(false);
@@ -584,7 +584,7 @@ namespace Nekoyume.UI
             }
 
             closeButton.interactable = false;
-            stageButton.interactable = false;
+            stagePreparationButton.interactable = false;
             repeatButton.interactable = false;
             nextButton.interactable = false;
             actionPoint.SetEventTriggerEnabled(false);

--- a/nekoyume/Assets/_Scripts/UI/Widget/Popup/BattleResultPopup.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Popup/BattleResultPopup.cs
@@ -428,7 +428,7 @@ namespace Nekoyume.UI
             string fullFormat = string.Empty;
             closeButton.interactable = true;
 
-            if (!SharedModel.IsClear)
+            if (!SharedModel.IsClear && SharedModel.WorldID <= 10000)
             {
                 stageButton.gameObject.SetActive(true);
                 stageButton.interactable = true;
@@ -706,7 +706,8 @@ namespace Nekoyume.UI
 
         private void GoToPreparation()
         {
-            // Todo : Fill
+            if (SharedModel.WorldID > 10000) return;
+
             Find<Battle>().Close(true);
             Game.Game.instance.Stage.DestroyBackground();
             Game.Event.OnRoomEnter.Invoke(true);
@@ -718,38 +719,15 @@ namespace Nekoyume.UI
             {
                 CloseWithOtherWidgets();
                 Find<HeaderMenuStatic>().UpdateAssets(HeaderMenuStatic.AssetVisibleState.Battle);
+                Find<WorldMap>().Show(SharedModel.WorldID, SharedModel.StageID, false);
+                Find<BattlePreparation>().Show(
+                    StageType.HackAndSlash,
+                    SharedModel.WorldID,
+                    SharedModel.StageID,
+                    $"{SharedModel.WorldName.ToUpper()} {SharedModel.StageID}",
+                    true);
+
                 worldMapLoading.Close(true);
-
-                if (SharedModel.WorldID > 10000)
-                {
-                    var viewModel = new WorldMap.ViewModel
-                    {
-                        WorldInformation = States.Instance.CurrentAvatarState.worldInformation,
-                    };
-                    viewModel.SelectedStageId.SetValueAndForceNotify(SharedModel.WorldID);
-                    viewModel.SelectedStageId.SetValueAndForceNotify(SharedModel.StageID);
-                    Game.Game.instance.TableSheets.WorldSheet.TryGetValue(SharedModel.WorldID, out var worldRow);
-
-                    Find<StageInformation>().Show(viewModel, worldRow, StageType.Mimisbrunnr);
-
-                    Find<BattlePreparation>().Show(
-                        StageType.Mimisbrunnr,
-                        GameConfig.MimisbrunnrWorldId,
-                        SharedModel.StageID,
-                        $"{SharedModel.WorldName.ToUpper()} {SharedModel.StageID % 10000000}",
-                        true);
-                }
-                else
-                {
-                    Find<WorldMap>().Show(SharedModel.WorldID, SharedModel.StageID, false);
-
-                    Find<BattlePreparation>().Show(
-                        StageType.HackAndSlash,
-                        SharedModel.WorldID,
-                        SharedModel.StageID,
-                        $"{SharedModel.WorldName.ToUpper()} {SharedModel.StageID}",
-                        true);
-                }
             });
         }
 

--- a/nekoyume/Assets/_Scripts/UI/Widget/Popup/BattleResultPopup.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Popup/BattleResultPopup.cs
@@ -428,7 +428,7 @@ namespace Nekoyume.UI
             string fullFormat = string.Empty;
             closeButton.interactable = true;
 
-            if (!SharedModel.IsClear && SharedModel.WorldID <= 10000)
+            if (!SharedModel.IsClear)
             {
                 stagePreparationButton.gameObject.SetActive(true);
                 stagePreparationButton.interactable = true;
@@ -706,8 +706,6 @@ namespace Nekoyume.UI
 
         private void GoToPreparation()
         {
-            if (SharedModel.WorldID > 10000) return;
-
             Find<Battle>().Close(true);
             Game.Game.instance.Stage.DestroyBackground();
             Game.Event.OnRoomEnter.Invoke(true);
@@ -719,13 +717,38 @@ namespace Nekoyume.UI
             {
                 CloseWithOtherWidgets();
                 Find<HeaderMenuStatic>().UpdateAssets(HeaderMenuStatic.AssetVisibleState.Battle);
-                Find<WorldMap>().Show(SharedModel.WorldID, SharedModel.StageID, false);
-                Find<BattlePreparation>().Show(
-                    StageType.HackAndSlash,
-                    SharedModel.WorldID,
-                    SharedModel.StageID,
-                    $"{SharedModel.WorldName.ToUpper()} {SharedModel.StageID}",
-                    true);
+
+                if (SharedModel.WorldID > 10000)
+                {
+                    var viewModel = new WorldMap.ViewModel
+                    {
+                        WorldInformation = States.Instance.CurrentAvatarState.worldInformation,
+                    };
+                    viewModel.SelectedStageId.SetValueAndForceNotify(SharedModel.WorldID);
+                    viewModel.SelectedStageId.SetValueAndForceNotify(SharedModel.StageID);
+                    Game.Game.instance.TableSheets.WorldSheet.TryGetValue(SharedModel.WorldID,
+                        out var worldRow);
+
+                    Find<StageInformation>().Show(viewModel, worldRow, StageType.Mimisbrunnr);
+
+                    Find<BattlePreparation>().Show(
+                        StageType.Mimisbrunnr,
+                        GameConfig.MimisbrunnrWorldId,
+                        SharedModel.StageID,
+                        $"{SharedModel.WorldName.ToUpper()} {SharedModel.StageID % 10000000}",
+                        true);
+                }
+                else
+                {
+                    Find<WorldMap>().Show(SharedModel.WorldID, SharedModel.StageID, false);
+
+                    Find<BattlePreparation>().Show(
+                        StageType.HackAndSlash,
+                        SharedModel.WorldID,
+                        SharedModel.StageID,
+                        $"{SharedModel.WorldName.ToUpper()} {SharedModel.StageID}",
+                        true);
+                }
 
                 worldMapLoading.Close(true);
             });


### PR DESCRIPTION
### Description

- If the player didn't clear the HAS stage, 
  - Stage button will be appear in battle result popup.
    Stage button : move to Battle Preparation widget on same stage.
  - Disable automatic stage- process, repetition, return.
    except - reserved exit, ap not enough
- If the player has consumables, set inventory default tab to consumable tab in HAS Preparation.

\+ **apply this feature also to the Mimisbrunnr stage**

### Related Links

[스테이지 1회성 버프 개선 - 게임 결과 화면 고도화](https://app.asana.com/0/0/1202603085251653/f)

### Screenshot

Failed in HAS

![image](https://user-images.githubusercontent.com/63496908/180184692-8c11e199-ed8b-4b16-9b05-4e59a3f24836.png)
![stage_preparation](https://user-images.githubusercontent.com/63496908/180187352-d6631ca8-8852-4e9c-9e3a-04bffe5f2ae4.gif)

Failed in Mimisbrunnr

![image](https://user-images.githubusercontent.com/63496908/180385762-7594f58e-920e-40f6-a84f-c8f5900ecdb1.png)
![stage_preparation_mimir](https://user-images.githubusercontent.com/63496908/180385701-9f1e54e1-9567-4e53-b2c2-1b389abfd476.gif)



