### PR TITLE
Edit equipment sorting in inventory

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Module/Inventory.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/Inventory.cs
@@ -381,7 +381,7 @@ namespace Nekoyume.UI.Module
                 .OrderByDescending(x => bestItems.Exists(y => y.Equals(x)))
                 .ThenBy(x => x.ItemBase.ItemSubType)
                 .ThenByDescending(x => Util.IsUsableItem(x.ItemBase))
-                .ThenBy(x => CPHelper.GetCP(x.ItemBase as Equipment))
+                .ThenByDescending(x => CPHelper.GetCP(x.ItemBase as Equipment))
                 .ToList();
 
             if (_elementalTypes.Any())

--- a/nekoyume/Assets/_Scripts/UI/Module/Inventory.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/Inventory.cs
@@ -377,9 +377,12 @@ namespace Nekoyume.UI.Module
                 result.AddRange(pair.Value);
             }
 
-            result = result.OrderByDescending(x => bestItems.Exists(y => y.Equals(x)))
+            result = result
+                .OrderByDescending(x => bestItems.Exists(y => y.Equals(x)))
                 .ThenBy(x => x.ItemBase.ItemSubType)
-                .ThenByDescending(x => Util.IsUsableItem(x.ItemBase)).ToList();
+                .ThenByDescending(x => Util.IsUsableItem(x.ItemBase))
+                .ThenBy(x => CPHelper.GetCP(x.ItemBase as Equipment))
+                .ToList();
 
             if (_elementalTypes.Any())
             {


### PR DESCRIPTION
### Description

- Edit equipment sorting in inventory
  - Default : Best item > item sub type (weapon, armer...) > usable (requirement level) > CP (descending)
  - Grinding : Revert to Default

### Related Links

[인벤토리&제작 그라인딩 정렬순서 조정](https://app.asana.com/0/0/1202656030952478/f)

### Screenshot

Default inventory
![image](https://user-images.githubusercontent.com/63496908/181417969-5bb74938-2951-4a23-99df-b273b454c0bc.png)

Grinding Inventory
![image](https://user-images.githubusercontent.com/63496908/181417949-dcdd7c64-d0b1-45e3-9eb8-a8b5ce7303ef.png)
