### PR TITLE
Fix arena avatar state sync bug

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Widget/ArenaBattlePreparation.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/ArenaBattlePreparation.cs
@@ -162,7 +162,7 @@ namespace Nekoyume.UI
             var stage = Game.Game.instance.Stage;
             stage.IsRepeatStage = false;
 
-            UpdateAvatarState();
+            UpdateArenaAvatarState();
             var avatarState = RxProps.PlayersArenaParticipant.Value.AvatarState;
             if (!_player)
             {
@@ -204,17 +204,16 @@ namespace Nekoyume.UI
 
         #endregion
 
-        private void UpdateAvatarState()
+        private void UpdateArenaAvatarState()
         {
             var avatarState = Game.Game.instance.States.CurrentAvatarState;
             var arenaAvatarState = RxProps.PlayersArenaParticipant.Value.AvatarState;
             var currentBlockIndex = Game.Game.instance.Agent.BlockIndex;
 
-            var arenaItems = arenaAvatarState.inventory.Items;
-            for (int i = arenaItems.Count - 1; i > 0; i--)
+            for (int i = arenaAvatarState.inventory.Items.Count - 1; i > 0; i--)
             {
                 Nekoyume.Model.Item.Inventory.Item existItem;
-                switch (arenaItems[i].item)
+                switch (arenaAvatarState.inventory.Items[i].item)
                 {
                     case Equipment arenaEquipment:
                     {
@@ -236,16 +235,19 @@ namespace Nekoyume.UI
 
                 if (existItem is null)
                 {
-                    arenaAvatarState.inventory.RemoveItem(arenaItems[i]);
+                    // It cause modifying arenaAvatarState.inventory collection in a loop
+                    arenaAvatarState.inventory.RemoveItem(arenaAvatarState.inventory.Items[i]);
                 }
-
-                var isValid = existItem is { Locked: false, item: ITradableItem tradableItem }
-                              && tradableItem.RequiredBlockIndex <= currentBlockIndex;
-
-                if (arenaItems[i] is { item: IEquippableItem { Equipped: true } equippedItem }
-                    && !isValid)
+                else
                 {
-                    equippedItem.Unequip();
+                    var isValid = existItem is { Locked: false, item: ITradableItem tradableItem }
+                                  && tradableItem.RequiredBlockIndex <= currentBlockIndex;
+
+                    if (arenaAvatarState.inventory.Items[i] is { item: IEquippableItem { Equipped: true } equippedItem }
+                        && !isValid)
+                    {
+                        equippedItem.Unequip();
+                    }
                 }
             }
         }


### PR DESCRIPTION
### Description

- Fix arena avatar state sync bug

### How to test

1. After equipping the equipments or costumes in the arena preperaion, play Arena Battle.
2. Register equipped equipments or costumes in the shop.
3. Check the registered equipments or costumes are unquipped in the arena preperation.

### Related Links
[[아레나] 아레나 전투 준비에 등록된 장비를 상점에 등록할 경우 장착 해제가 되지 않고 출력되는 현상](https://app.asana.com/0/1133453747809944/1202610071912915/f)

### Screenshot
1. After equipping the equipments or costumes in the arena preperaion, play Arena Battle.
    ![image](https://user-images.githubusercontent.com/63496908/183858781-3d6bd3d7-e2c9-40a4-bcb2-b22d88120aee.png)

2. Register equipped equipments or costumes in the shop.
    ![image](https://user-images.githubusercontent.com/63496908/183859065-fb50dd3a-4667-4855-ba6a-b3bdb8a19098.png)

3. Check the registered equipments or costumes are unquipped in the arena preperation.
    ![image](https://user-images.githubusercontent.com/63496908/183859019-8e103cc9-5f3e-45a1-9d3c-d0d4e82cd879.png)
