### PR TITLE
Fix cost text when buying event dungeon tickets

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Widget/BattlePreparation.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/BattlePreparation.cs
@@ -754,7 +754,7 @@ namespace Nekoyume.UI
                     var ncgHas = States.Instance.GoldBalanceState.Gold;
                     var ncgCost = RxProps.EventScheduleRowForDungeon.Value
                         .GetDungeonTicketCost(
-                            RxProps.EventDungeonInfo.Value.NumberOfTicketPurchases) *
+                            RxProps.EventDungeonInfo.Value?.NumberOfTicketPurchases ?? 0) *
                                   States.Instance.GoldBalanceState.Gold.Currency;
                     if (ncgHas >= ncgCost)
                     {
@@ -765,7 +765,7 @@ namespace Nekoyume.UI
                             ncgCost.ToString());
                         Find<PaymentPopup>().ShowAttract(
                             CostType.EventDungeonTicket,
-                            ncgCost.ToString(),
+                            _requiredCost.ToString(),
                             notEnoughTicketMsg,
                             L10nManager.Localize("UI_YES"),
                             () => StartCoroutine(

--- a/nekoyume/Assets/_Scripts/UI/Widget/Menu.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Menu.cs
@@ -200,7 +200,7 @@ namespace Nekoyume.UI
                 var ncgCost =
                     RxProps.EventScheduleRowForDungeon.Value
                         .GetDungeonTicketCost(
-                            RxProps.EventDungeonInfo.Value.NumberOfTicketPurchases) *
+                            RxProps.EventDungeonInfo.Value?.NumberOfTicketPurchases ?? 0) *
                     States.Instance.GoldBalanceState.Gold.Currency;
                 if (ncgHas >= ncgCost)
                 {
@@ -211,7 +211,7 @@ namespace Nekoyume.UI
                         ncgCost.ToString());
                     Find<PaymentPopup>().ShowAttract(
                         CostType.EventDungeonTicket,
-                        ncgCost.ToString(),
+                        "1",
                         notEnoughTicketMsg,
                         L10nManager.Localize("UI_YES"),
                         () => SendEventDungeonBattleAction(


### PR DESCRIPTION
Resolve [[이벤트 던전] 이벤트 던전 티켓 구매 팝업의 티켓 이미지 옆 문구가 잘못 표시된 현상](https://app.asana.com/0/1133453747809944/1202819833912159/f)