### PR TITLE
Fix shortcut for material items related with event dungeon rewards

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Widget/Tooltip/MaterialTooltip.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Tooltip/MaterialTooltip.cs
@@ -325,7 +325,8 @@ namespace Nekoyume.UI
                     !quest.Complete && quest.Reward.ItemMap.ContainsKey(itemBase.Id)))
                 {
                     acquisitionPlaceList.Add(
-                        MakeAcquisitionPlaceModelByType(AcquisitionPlaceButton.PlaceType.Quest,
+                        MakeAcquisitionPlaceModelByType(
+                            AcquisitionPlaceButton.PlaceType.Quest,
                             itemBase));
                 }
             }
@@ -363,7 +364,8 @@ namespace Nekoyume.UI
                             worldMap.SetWorldInformation(States.Instance.CurrentAvatarState.worldInformation);
                             worldMap.ShowEventDungeonStage(RxProps.EventDungeonRow, false);
 
-                            Find<HeaderMenuStatic>().UpdateAssets(HeaderMenuStatic.AssetVisibleState.EventDungeon);
+                            Find<HeaderMenuStatic>()
+                                .UpdateAssets(HeaderMenuStatic.AssetVisibleState.EventDungeon);
                             Find<HeaderMenuStatic>().Show(true);
                             Find<BattlePreparation>().Show(
                                 StageType.EventDungeon,
@@ -371,8 +373,6 @@ namespace Nekoyume.UI
                                 stageRow.Id,
                                 $"{RxProps.EventDungeonRow?.GetLocalizedName()} {stageRow.Id.ToEventDungeonStageNumber()}",
                                 true);
-                            Find<HeaderMenuStatic>()
-                                .UpdateAssets(HeaderMenuStatic.AssetVisibleState.Battle);
                         },
                         $"{RxProps.EventDungeonRow.GetLocalizedName()} {stageRow.Id.ToEventDungeonStageNumber()}",
                         itemBase,


### PR DESCRIPTION
Resolve [[이벤트 던전] 공방에서 이벤트 아이템 재료 획득처 숏컷으로 이동 시 헤더에 이벤트 티켓 표시가 되지 않습니다.](https://app.asana.com/0/1133453747809944/1202819929425860/f)