### PR TITLE
Fix stats does not updated bug related to consumable

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Widget/BattlePreparation.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/BattlePreparation.cs
@@ -520,11 +520,13 @@ namespace Nekoyume.UI
                 var selectedPlayer = Game.Game.instance.Stage.GetPlayer();
                 switch (slotItem)
                 {
-                    default:
-                        return;
+                    case Consumable _:
+                        Game.Event.OnUpdatePlayerEquip.OnNext(selectedPlayer);
+                        break;
                     case Costume costume:
                         selectedPlayer.UnequipCostume(costume, true);
-                        selectedPlayer.EquipEquipmentsAndUpdateCustomize((Armor)_armorSlot.Item,
+                        selectedPlayer.EquipEquipmentsAndUpdateCustomize(
+                            (Armor)_armorSlot.Item,
                             (Weapon)_weaponSlot.Item);
                         Game.Event.OnUpdatePlayerEquip.OnNext(selectedPlayer);
 
@@ -551,6 +553,8 @@ namespace Nekoyume.UI
 
                         Game.Event.OnUpdatePlayerEquip.OnNext(selectedPlayer);
                         break;
+                    default:
+                        return;
                 }
             }
 


### PR DESCRIPTION
Resolve [[전투] 전투 준비화면에서 음식을 등록 후 해제할 경우 증가한 능력치가 남아있는 현상](https://app.asana.com/0/1133453747809944/1202827628141703/f)