### PR TITLE
Fix remaining time of event dungeon

### DIFF
--- a/nekoyume/Assets/_Scripts/State/RxProps.Event.cs
+++ b/nekoyume/Assets/_Scripts/State/RxProps.Event.cs
@@ -193,7 +193,7 @@ namespace Nekoyume.State
                 return;
             }
 
-            var value = _eventScheduleRowForDungeon.Value.RecipeEndBlockIndex - blockIndex;
+            var value = _eventScheduleRowForDungeon.Value.DungeonEndBlockIndex - blockIndex;
             var time = value.BlockRangeToTimeSpanString();
             _eventDungeonRemainingTimeText.SetValueAndForceNotify($"{value}({time})");
         }


### PR DESCRIPTION
Resolve [[이벤트던전] 월드 목록에서 남은 기간 표시가 제대로 되지 않는 현상](https://app.asana.com/0/1133453747809944/1202845469995708/f)