### PR TITLE
Unify working of guide quest with Shortcut

### DIFF
--- a/nekoyume/Assets/_Scripts/Analyzer.cs
+++ b/nekoyume/Assets/_Scripts/Analyzer.cs
@@ -12,8 +12,6 @@ namespace Nekoyume
 
         private readonly MixpanelValueFactory _mixpanelValueFactory;
 
-        public int GuideQuestStageId { get; set; }
-
         public Analyzer(
             string uniqueId = "none",
             string rpcServerHost = null,

--- a/nekoyume/Assets/_Scripts/Analyzer.cs
+++ b/nekoyume/Assets/_Scripts/Analyzer.cs
@@ -12,6 +12,8 @@ namespace Nekoyume
 
         private readonly MixpanelValueFactory _mixpanelValueFactory;
 
+        public int GuideQuestStageId { get; set; }
+
         public Analyzer(
             string uniqueId = "none",
             string rpcServerHost = null,

--- a/nekoyume/Assets/_Scripts/BlockChain/ActionManager.cs
+++ b/nekoyume/Assets/_Scripts/BlockChain/ActionManager.cs
@@ -220,6 +220,15 @@ namespace Nekoyume.BlockChain
             int? stageBuffId = null,
             int playCount = 1)
         {
+            if (Analyzer.Instance.GuideQuestStageId == stageId)
+            {
+                Analyzer.Instance.Track("Unity/Click Guided Quest Enter Dungeon", new Value
+                {
+                    ["StageID"] = stageId,
+                });
+                Analyzer.Instance.GuideQuestStageId = 0;
+            }
+
             Analyzer.Instance.Track("Unity/HackAndSlash", new Value
             {
                 ["WorldId"] = worldId,
@@ -288,6 +297,17 @@ namespace Nekoyume.BlockChain
             List<Consumable> foods,
             bool buyTicketIfNeeded)
         {
+            if (Analyzer.Instance.GuideQuestStageId == eventDungeonStageId)
+            {
+                Analyzer.Instance.Track("Unity/Click Guided Quest Enter Event Dungeon", new Value
+                {
+                    ["EventScheduleID"] = eventScheduleId,
+                    ["EventDungeonID"] = eventDungeonId,
+                    ["EventDungeonStageID"] = eventDungeonStageId,
+                });
+                Analyzer.Instance.GuideQuestStageId = 0;
+            }
+
             var numberOfTicketPurchases =
                 RxProps.EventDungeonInfo.Value?.NumberOfTicketPurchases ?? 0;
             Analyzer.Instance.Track("Unity/EventDungeonBattle", new Value

--- a/nekoyume/Assets/_Scripts/BlockChain/ActionManager.cs
+++ b/nekoyume/Assets/_Scripts/BlockChain/ActionManager.cs
@@ -218,15 +218,15 @@ namespace Nekoyume.BlockChain
             int worldId,
             int stageId,
             int? stageBuffId = null,
-            int playCount = 1)
+            int playCount = 1,
+            bool trackGuideQuest = false)
         {
-            if (Analyzer.Instance.GuideQuestStageId == stageId)
+            if (trackGuideQuest)
             {
                 Analyzer.Instance.Track("Unity/Click Guided Quest Enter Dungeon", new Value
                 {
                     ["StageID"] = stageId,
                 });
-                Analyzer.Instance.GuideQuestStageId = 0;
             }
 
             Analyzer.Instance.Track("Unity/HackAndSlash", new Value
@@ -295,9 +295,10 @@ namespace Nekoyume.BlockChain
             List<Equipment> equipments,
             List<Costume> costumes,
             List<Consumable> foods,
-            bool buyTicketIfNeeded)
+            bool buyTicketIfNeeded,
+            bool trackGuideQuest = false)
         {
-            if (Analyzer.Instance.GuideQuestStageId == eventDungeonStageId)
+            if (trackGuideQuest)
             {
                 Analyzer.Instance.Track("Unity/Click Guided Quest Enter Event Dungeon", new Value
                 {
@@ -305,7 +306,6 @@ namespace Nekoyume.BlockChain
                     ["EventDungeonID"] = eventDungeonId,
                     ["EventDungeonStageID"] = eventDungeonStageId,
                 });
-                Analyzer.Instance.GuideQuestStageId = 0;
             }
 
             var numberOfTicketPurchases =

--- a/nekoyume/Assets/_Scripts/Helper/ShortcutHelper.cs
+++ b/nekoyume/Assets/_Scripts/Helper/ShortcutHelper.cs
@@ -162,7 +162,7 @@ namespace Nekoyume.Helper
                         throw new Exception($"{nameof(stageRow)} is null");
                     }
 
-                    shortcutAction += () => ShortcutActionForEventStage(stageRow);
+                    shortcutAction += () => ShortcutActionForEventStage(stageRow.Id);
                     guideText =
                         $"{RxProps.EventDungeonRow.GetLocalizedName()} {stageRow.Id.ToEventDungeonStageNumber()}";
                     break;
@@ -236,7 +236,7 @@ namespace Nekoyume.Helper
         }
 
         public static void ShortcutActionForEventStage(
-            StageSheet.Row stageRow)
+            int eventDungeonStageId)
         {
             Game.Game.instance.Stage.GetPlayer().gameObject.SetActive(false);
             var worldMap = Widget.Find<WorldMap>();
@@ -248,8 +248,8 @@ namespace Nekoyume.Helper
                 .Show(
                     StageType.EventDungeon,
                     worldMap.SharedViewModel.SelectedWorldId.Value,
-                    stageRow.Id,
-                    $"{RxProps.EventDungeonRow?.GetLocalizedName()} {stageRow.Id.ToEventDungeonStageNumber()}",
+                    eventDungeonStageId,
+                    $"{RxProps.EventDungeonRow?.GetLocalizedName()} {eventDungeonStageId.ToEventDungeonStageNumber()}",
                     true);
             Widget.Find<HeaderMenuStatic>()
                 .UpdateAssets(HeaderMenuStatic.AssetVisibleState.EventDungeon);
@@ -271,6 +271,11 @@ namespace Nekoyume.Helper
 
                     return stageId.ToEventDungeonStageNumber() <= 1;
                 case PlaceType.Stage:
+                    if (stageId == 1)
+                    {
+                        return true;
+                    }
+
                     var sharedViewModel = Widget.Find<WorldMap>().SharedViewModel;
                     if (sharedViewModel.WorldInformation
                         .TryGetWorldByStageId(stageId, out var world))

--- a/nekoyume/Assets/_Scripts/Helper/ShortcutHelper.cs
+++ b/nekoyume/Assets/_Scripts/Helper/ShortcutHelper.cs
@@ -39,8 +39,7 @@ namespace Nekoyume.Helper
                 acquisitionPlaceList.Add(
                     MakeAcquisitionPlaceModelByPlaceType(
                         caller,
-                        PlaceType.Arena,
-                        itemBase)
+                        PlaceType.Arena)
                 );
             }
             else if (itemBase.ItemSubType is ItemSubType.EquipmentMaterial
@@ -62,7 +61,6 @@ namespace Nekoyume.Helper
                         return MakeAcquisitionPlaceModelByPlaceType(
                             caller,
                             PlaceType.Stage,
-                            itemBase,
                             worldRow.Id,
                             stage);
                     }));
@@ -88,7 +86,6 @@ namespace Nekoyume.Helper
                                 MakeAcquisitionPlaceModelByPlaceType(
                                     caller,
                                     PlaceType.EventDungeonStage,
-                                    itemBase,
                                     RxProps.EventDungeonRow.Id,
                                     stage))
                             );
@@ -109,16 +106,14 @@ namespace Nekoyume.Helper
                         }.Select(type =>
                             MakeAcquisitionPlaceModelByPlaceType(
                                 caller,
-                                type,
-                                itemBase))
+                                type))
                     );
                 }
                 else
                 {
                     acquisitionPlaceList.Add(
                         MakeAcquisitionPlaceModelByPlaceType(caller,
-                            PlaceType.Quest,
-                            itemBase)
+                            PlaceType.Quest)
                     );
                 }
             }
@@ -134,8 +129,7 @@ namespace Nekoyume.Helper
                     acquisitionPlaceList.Add(
                         MakeAcquisitionPlaceModelByPlaceType(
                             caller,
-                            PlaceType.Quest,
-                            itemBase));
+                            PlaceType.Quest));
                 }
             }
 
@@ -145,7 +139,6 @@ namespace Nekoyume.Helper
         public static AcquisitionPlaceButton.Model MakeAcquisitionPlaceModelByPlaceType(
             Widget caller,
             PlaceType type,
-            ItemBase itemBase,
             int worldId = 0,
             StageSheet.Row stageRow = null)
         {

--- a/nekoyume/Assets/_Scripts/Helper/ShortcutHelper.cs
+++ b/nekoyume/Assets/_Scripts/Helper/ShortcutHelper.cs
@@ -20,6 +20,8 @@ namespace Nekoyume.Helper
 
         public enum PlaceType
         {
+            // Assigned values are used to load sprites.
+            // Not used values: 1, 2, 6, etc.
             Stage,
             Shop = 3,
             Arena = 4,
@@ -263,13 +265,14 @@ namespace Nekoyume.Helper
             switch (type)
             {
                 case PlaceType.EventDungeonStage:
-                    if (RxProps.EventDungeonInfo.Value is not null)
-                    {
-                        return stageId <=
-                               RxProps.EventDungeonInfo.Value.ClearedStageId + 1;
-                    }
-
-                    return stageId.ToEventDungeonStageNumber() <= 1;
+                    var playableStageId =
+                        RxProps.EventDungeonInfo.Value is null ||
+                        RxProps.EventDungeonInfo.Value.ClearedStageId == 0
+                            ? RxProps.EventDungeonRow.StageBegin
+                            : Math.Min(
+                                RxProps.EventDungeonInfo.Value.ClearedStageId + 1,
+                                RxProps.EventDungeonRow.StageEnd);
+                    return stageId <= playableStageId;
                 case PlaceType.Stage:
                     if (stageId == 1)
                     {

--- a/nekoyume/Assets/_Scripts/Helper/ShortcutHelper.cs
+++ b/nekoyume/Assets/_Scripts/Helper/ShortcutHelper.cs
@@ -213,7 +213,8 @@ namespace Nekoyume.Helper
 
         public static void ShortcutActionForStage(
             int worldId,
-            int stageId)
+            int stageId,
+            bool showByGuideQuest = false)
         {
             Game.Game.instance.Stage.GetPlayer().gameObject.SetActive(false);
             var worldMap = Widget.Find<WorldMap>();
@@ -232,13 +233,15 @@ namespace Nekoyume.Helper
                     worldMap.SharedViewModel.SelectedWorldId.Value,
                     worldMap.SharedViewModel.SelectedStageId.Value,
                     $"{L10nManager.Localize($"WORLD_NAME_{worldModel.Name.ToUpper()}")} {stageNum}",
-                    true);
+                    true,
+                    showByGuideQuest);
             Widget.Find<HeaderMenuStatic>()
                 .UpdateAssets(HeaderMenuStatic.AssetVisibleState.Battle);
         }
 
         public static void ShortcutActionForEventStage(
-            int eventDungeonStageId)
+            int eventDungeonStageId,
+            bool showByGuideQuest = false)
         {
             Game.Game.instance.Stage.GetPlayer().gameObject.SetActive(false);
             var worldMap = Widget.Find<WorldMap>();
@@ -252,7 +255,8 @@ namespace Nekoyume.Helper
                     worldMap.SharedViewModel.SelectedWorldId.Value,
                     eventDungeonStageId,
                     $"{RxProps.EventDungeonRow?.GetLocalizedName()} {eventDungeonStageId.ToEventDungeonStageNumber()}",
-                    true);
+                    true,
+                    showByGuideQuest);
             Widget.Find<HeaderMenuStatic>()
                 .UpdateAssets(HeaderMenuStatic.AssetVisibleState.EventDungeon);
         }

--- a/nekoyume/Assets/_Scripts/UI/Widget/BattlePreparation.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/BattlePreparation.cs
@@ -129,6 +129,7 @@ namespace Nekoyume.UI
         private int _stageId;
         private int _requiredCost;
         private bool _shouldResetPlayer = true;
+        private bool _trackGuideQuest;
 
         private readonly List<IDisposable> _disposables = new();
 
@@ -227,8 +228,10 @@ namespace Nekoyume.UI
             int worldId,
             int stageId,
             string closeButtonName,
-            bool ignoreShowAnimation = false)
+            bool ignoreShowAnimation = false,
+            bool showByGuideQuest = false)
         {
+            _trackGuideQuest = showByGuideQuest;
             Analyzer.Instance.Track("Unity/Click Stage", new Value
             {
                 ["AvatarAddress"] = States.Instance.CurrentAvatarState.address.ToString(),
@@ -325,7 +328,6 @@ namespace Nekoyume.UI
             _shouldResetPlayer = true;
             consumableSlots.Clear();
             _disposables.DisposeAllAndClear();
-            Analyzer.Instance.GuideQuestStageId = 0;
             base.Close(ignoreCloseAnimation);
         }
 
@@ -982,7 +984,8 @@ namespace Nekoyume.UI
                                 consumables,
                                 _worldId,
                                 _stageId,
-                                playCount: playCount
+                                playCount: playCount,
+                                trackGuideQuest: _trackGuideQuest
                             ).Subscribe();
                             break;
                         }
@@ -1007,7 +1010,8 @@ namespace Nekoyume.UI
                         _worldId,
                         _stageId,
                         skillId,
-                        playCount
+                        playCount,
+                        _trackGuideQuest
                     ).Subscribe();
                     PlayerPrefs.SetInt("HackAndSlash.SelectedBonusSkillId", 0);
                     break;
@@ -1042,7 +1046,8 @@ namespace Nekoyume.UI
                             equipments,
                             costumes,
                             consumables,
-                            buyTicketIfNeeded)
+                            buyTicketIfNeeded,
+                            _trackGuideQuest)
                         .Subscribe();
                     break;
                 }

--- a/nekoyume/Assets/_Scripts/UI/Widget/BattlePreparation.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/BattlePreparation.cs
@@ -325,6 +325,7 @@ namespace Nekoyume.UI
             _shouldResetPlayer = true;
             consumableSlots.Clear();
             _disposables.DisposeAllAndClear();
+            Analyzer.Instance.GuideQuestStageId = 0;
             base.Close(ignoreCloseAnimation);
         }
 

--- a/nekoyume/Assets/_Scripts/UI/Widget/Menu.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Menu.cs
@@ -149,11 +149,7 @@ namespace Nekoyume.UI
             {
                 CloseWithOtherWidgets();
                 ShortcutHelper.ShortcutActionForStage(worldRow.Id, stageId);
-                var props = new Value
-                {
-                    ["StageID"] = stageId,
-                };
-                Analyzer.Instance.Track("Unity/Click Guided Quest Enter Dungeon", props);
+                Analyzer.Instance.GuideQuestStageId = stageId;
             }
             else if(ShortcutHelper.CheckUIStateForUsingShortcut(ShortcutHelper.PlaceType.Stage))
             {
@@ -177,13 +173,7 @@ namespace Nekoyume.UI
             {
                 CloseWithOtherWidgets();
                 ShortcutHelper.ShortcutActionForEventStage(eventDungeonStageId);
-                var props = new Value
-                {
-                    ["EventScheduleID"] = RxProps.EventScheduleRowForDungeon.Value.Id,
-                    ["EventDungeonID"] = RxProps.EventDungeonRow.Id,
-                    ["EventDungeonStageID"] = eventDungeonStageId,
-                };
-                Analyzer.Instance.Track("Unity/Click Guided Quest Enter Event Dungeon", props);
+                Analyzer.Instance.GuideQuestStageId = eventDungeonStageId;
             }
             else if (ShortcutHelper.CheckUIStateForUsingShortcut(ShortcutHelper.PlaceType
                          .EventDungeonStage))

--- a/nekoyume/Assets/_Scripts/UI/Widget/Menu.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Menu.cs
@@ -148,8 +148,7 @@ namespace Nekoyume.UI
                     stageId))
             {
                 CloseWithOtherWidgets();
-                ShortcutHelper.ShortcutActionForStage(worldRow.Id, stageId);
-                Analyzer.Instance.GuideQuestStageId = stageId;
+                ShortcutHelper.ShortcutActionForStage(worldRow.Id, stageId, true);
             }
             else if(ShortcutHelper.CheckUIStateForUsingShortcut(ShortcutHelper.PlaceType.Stage))
             {
@@ -172,8 +171,7 @@ namespace Nekoyume.UI
                     eventDungeonStageId))
             {
                 CloseWithOtherWidgets();
-                ShortcutHelper.ShortcutActionForEventStage(eventDungeonStageId);
-                Analyzer.Instance.GuideQuestStageId = eventDungeonStageId;
+                ShortcutHelper.ShortcutActionForEventStage(eventDungeonStageId, true);
             }
             else if (ShortcutHelper.CheckUIStateForUsingShortcut(ShortcutHelper.PlaceType
                          .EventDungeonStage))

--- a/nekoyume/Assets/_Scripts/UI/Widget/Menu.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Menu.cs
@@ -155,7 +155,7 @@ namespace Nekoyume.UI
                 };
                 Analyzer.Instance.Track("Unity/Click Guided Quest Enter Dungeon", props);
             }
-            else
+            else if(ShortcutHelper.CheckUIStateForUsingShortcut(ShortcutHelper.PlaceType.Stage))
             {
                 Find<Menu>().QuestClick();
             }
@@ -185,7 +185,8 @@ namespace Nekoyume.UI
                 };
                 Analyzer.Instance.Track("Unity/Click Guided Quest Enter Event Dungeon", props);
             }
-            else
+            else if (ShortcutHelper.CheckUIStateForUsingShortcut(ShortcutHelper.PlaceType
+                         .EventDungeonStage))
             {
                 Find<Menu>().QuestClick();
             }

--- a/nekoyume/Assets/_Scripts/UI/Widget/Menu.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Menu.cs
@@ -141,58 +141,26 @@ namespace Nekoyume.UI
                 .AddTo(gameObject);
         }
 
-        // TODO: QuestPreparation.Quest(bool repeat) 와 로직이 흡사하기 때문에 정리할 여지가 있습니다.
-        private static void HackAndSlash(int stageId)
+        private void HackAndSlash(int stageId)
         {
-            var sheets = Game.Game.instance.TableSheets;
-            var stageRow = sheets.StageSheet.OrderedList.FirstOrDefault(row => row.Id == stageId);
-            if (stageRow is null)
+            if (TableSheets.Instance.WorldSheet.TryGetByStageId(stageId, out var worldRow) &&
+                ShortcutHelper.CheckConditionOfShortcut(ShortcutHelper.PlaceType.Stage,
+                    stageId))
             {
-                return;
+                CloseWithOtherWidgets();
+                ShortcutHelper.ShortcutActionForStage(worldRow.Id, stageId);
+                var props = new Value
+                {
+                    ["StageID"] = stageId,
+                };
+                Analyzer.Instance.Track("Unity/Click Guided Quest Enter Dungeon", props);
             }
-
-            var requiredCost = stageRow.CostAP;
-            if (States.Instance.CurrentAvatarState.actionPoint < requiredCost)
+            else
             {
-                OneLineSystem.Push(
-                    MailType.System,
-                    L10nManager.Localize("ERROR_ACTION_POINT"),
-                    NotificationCell.NotificationType.Alert);
-                return;
+                Find<Menu>().QuestClick();
             }
-
-            if (!sheets.WorldSheet.TryGetByStageId(stageId, out var worldRow))
-            {
-                return;
-            }
-
-            var worldId = worldRow.Id;
-
-            Find<LoadingScreen>().Show();
-            Find<HeaderMenuStatic>().UpdateAssets(HeaderMenuStatic.AssetVisibleState.Battle);
-
-            var stage = Game.Game.instance.Stage;
-            stage.IsExitReserved = false;
-            var player = stage.GetPlayer();
-            player.StartRun();
-            ActionCamera.instance.ChaseX(player.transform);
-            ActionRenderHandler.Instance.Pending = true;
-            Game.Game.instance.ActionManager
-                .HackAndSlash(player, worldId, stageId)
-                .Subscribe();
-            LocalLayerModifier.ModifyAvatarActionPoint(
-                States.Instance.CurrentAvatarState.address,
-                -requiredCost);
-            var props = new Value
-            {
-                ["StageID"] = stageId,
-                ["AvatarAddress"] = States.Instance.CurrentAvatarState.address.ToString(),
-            };
-            Analyzer.Instance.Track("Unity/Click Guided Quest Enter Dungeon", props);
         }
 
-        // NOTE: This method is almost same with part of
-        //       the `BattlePreparation.OnClickBattle()` method.
         private void EventDungeonBattle(int eventDungeonStageId)
         {
             if (RxProps.EventScheduleRowForDungeon.Value is null)
@@ -204,80 +172,22 @@ namespace Nekoyume.UI
                 return;
             }
 
-            if (RxProps.EventDungeonTicketProgress.Value.currentTickets == 0)
+            if (ShortcutHelper.CheckConditionOfShortcut(ShortcutHelper.PlaceType.EventDungeonStage,
+                    eventDungeonStageId))
             {
-                var ncgHas = States.Instance.GoldBalanceState.Gold;
-                var ncgCost =
-                    RxProps.EventScheduleRowForDungeon.Value
-                        .GetDungeonTicketCost(
-                            RxProps.EventDungeonInfo.Value?.NumberOfTicketPurchases ?? 0,
-                            States.Instance.GoldBalanceState.Gold.Currency);
-                if (ncgHas >= ncgCost)
-                {
-                    // FIXME: `UI_CONFIRM_PAYMENT_CURRENCY_FORMAT_FOR_BATTLE_ARENA` key
-                    //        is temporary.
-                    var notEnoughTicketMsg = L10nManager.Localize(
-                        "UI_CONFIRM_PAYMENT_CURRENCY_FORMAT_FOR_BATTLE_ARENA",
-                        ncgCost.ToString());
-                    Find<PaymentPopup>().ShowAttract(
-                        CostType.EventDungeonTicket,
-                        "1",
-                        notEnoughTicketMsg,
-                        L10nManager.Localize("UI_YES"),
-                        () => SendEventDungeonBattleAction(
-                            eventDungeonStageId,
-                            true));
-
-                    return;
-                }
-
-                var notEnoughNCGMsg =
-                    L10nManager.Localize("UI_NOT_ENOUGH_NCG_WITH_SUPPLIER_INFO");
-                Find<PaymentPopup>().ShowAttract(
-                    CostType.NCG,
-                    ncgCost.GetQuantityString(),
-                    notEnoughNCGMsg,
-                    L10nManager.Localize("UI_GO_TO_MARKET"),
-                    () => GoToMarket(TradeType.Sell));
-
-                return;
-            }
-
-            SendEventDungeonBattleAction(
-                eventDungeonStageId,
-                false);
-
-            void SendEventDungeonBattleAction(
-                int eventDungeonStageId,
-                bool buyTicketIfNeeded)
-            {
-                Find<LoadingScreen>().Show();
-                Find<HeaderMenuStatic>().UpdateAssets(HeaderMenuStatic.AssetVisibleState.EventDungeon);
-
-                var stage = Game.Game.instance.Stage;
-                stage.IsExitReserved = false;
-                var player = stage.GetPlayer();
-                player.StartRun();
-                ActionCamera.instance.ChaseX(player.transform);
-                ActionRenderHandler.Instance.Pending = true;
-
-                var scheduleId = RxProps.EventScheduleRowForDungeon.Value.Id;
-                var eventDungeonId = RxProps.EventDungeonRow.Id;
-                Game.Game.instance.ActionManager
-                    .EventDungeonBattle(
-                        scheduleId,
-                        eventDungeonId,
-                        eventDungeonStageId,
-                        player,
-                        buyTicketIfNeeded)
-                    .Subscribe();
+                CloseWithOtherWidgets();
+                ShortcutHelper.ShortcutActionForEventStage(eventDungeonStageId);
                 var props = new Value
                 {
-                    ["EventScheduleID"] = scheduleId,
-                    ["EventDungeonID"] = eventDungeonId,
+                    ["EventScheduleID"] = RxProps.EventScheduleRowForDungeon.Value.Id,
+                    ["EventDungeonID"] = RxProps.EventDungeonRow.Id,
                     ["EventDungeonStageID"] = eventDungeonStageId,
                 };
                 Analyzer.Instance.Track("Unity/Click Guided Quest Enter Event Dungeon", props);
+            }
+            else
+            {
+                Find<Menu>().QuestClick();
             }
         }
 
@@ -698,8 +608,13 @@ namespace Nekoyume.UI
             playerButton.onClick.AddListener(() => callback?.Invoke());
         }
 
-        public void TutorialActionHackAndSlash() => HackAndSlash(GuidedQuest.WorldQuest?.Goal ?? 1);
+        // Invoke from TutorialController.PlayAction()
+        public void TutorialActionHackAndSlash()
+        {
+            HackAndSlash(GuidedQuest.WorldQuest?.Goal ?? 1);
+        }
 
+        // Invoke from TutorialController.PlayAction()
         public void TutorialActionGoToFirstRecipeCellView()
         {
             var firstRecipeRow = Game.Game.instance.TableSheets.EquipmentItemRecipeSheet.OrderedList
@@ -714,6 +629,7 @@ namespace Nekoyume.UI
             GoToCombinationEquipmentRecipe(firstRecipeRow.Id);
         }
 
+        // Invoke from TutorialController.PlayAction()
         public void TutorialActionClickGuidedQuestWorldStage2()
         {
             var player = Game.Game.instance.Stage.GetPlayer();


### PR DESCRIPTION
### Description

1. Now, guide quest doesn't pass to stage.
2. It works the same as Acquisition place button(Shortcut).

~~- **There may be variations in the log.**~~
~~`Unity/Click Guided Quest Enter Dungeon`~~
~~`Unity/Click Guided Quest Enter Event Dungeon`~~
~~Previously, there was Analyzer invoking at the same time as action tx.~~
~~Now, After analyzer invoking, player may not send a tx. We need check it.~~

### How to test

1. Click any stage guide quest or event dungeon quest.

### Related Links

[가이드 퀘스트 및 숏컷 동작 개선 및 리팩토링](https://app.asana.com/0/958521740385861/1202847454522981/f)

### Required Reviewers

@planetarium/9c-dev @jaeho0103 

### Screenshot
![Honeycam 2022-08-25 17-37-51](https://user-images.githubusercontent.com/48484989/186622605-ebce19fe-0f31-4f90-8dab-b810d86676bc.gif)

