### PR TITLE
Use Addressables asset in NoticePopup

### DIFF
--- a/nekoyume/Assets/AddressableAssets/NoticeInfo.meta
+++ b/nekoyume/Assets/AddressableAssets/NoticeInfo.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 11c1e551c03a98f40b672e2a072d4b59
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/nekoyume/Assets/AddressableAssets/NoticeInfo/NoticeData_v100300.asset
+++ b/nekoyume/Assets/AddressableAssets/NoticeInfo/NoticeData_v100300.asset
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bd72fa3478604c348aac35787be0fe4f, type: 3}
+  m_Name: NoticeData_v100300
+  m_EditorClassIdentifier: 
+  noticeInfo:
+    name: SummerEvent&Wolrd6
+    contentImage: {fileID: 21300000, guid: 2bc57019582df4cb18fa52ab8bf3c41e, type: 3}
+    beginTime: 2022/08/25 00:00:00
+    endTime: 2022/09/16 23:59:59
+    pageUrlFormat: https://ninechronicles-banner.com/01

--- a/nekoyume/Assets/AddressableAssets/NoticeInfo/NoticeData_v100300.asset.meta
+++ b/nekoyume/Assets/AddressableAssets/NoticeInfo/NoticeData_v100300.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a5fe9e23b027a8c4eaefe44424ef1aa1
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/nekoyume/Assets/AddressableAssetsData/AddressableAssetSettings.asset
+++ b/nekoyume/Assets/AddressableAssetsData/AddressableAssetSettings.asset
@@ -100,6 +100,7 @@ MonoBehaviour:
     m_LabelNames:
     - default
     - banner
+    - notice
   m_SchemaTemplates: []
   m_GroupTemplateObjects:
   - {fileID: 11400000, guid: 9f4f41e954ec39941904844ab832b4ea, type: 2}

--- a/nekoyume/Assets/AddressableAssetsData/AssetGroups/RemoteAssets.asset
+++ b/nekoyume/Assets/AddressableAssetsData/AssetGroups/RemoteAssets.asset
@@ -67,6 +67,11 @@ MonoBehaviour:
     m_ReadOnly: 0
     m_SerializedLabels:
     - banner
+  - m_GUID: a5fe9e23b027a8c4eaefe44424ef1aa1
+    m_Address: Assets/AddressableAssets/NoticeInfo/NoticeData_v100300.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - notice
   m_ReadOnly: 0
   m_Settings: {fileID: 11400000, guid: ac541e2ce40a4e441b1e4fe7bb752ac7, type: 2}
   m_SchemaSet:

--- a/nekoyume/Assets/_Scripts/Game/ScriptableObject/NoticeInfoScriptableObject.cs
+++ b/nekoyume/Assets/_Scripts/Game/ScriptableObject/NoticeInfoScriptableObject.cs
@@ -1,0 +1,12 @@
+﻿using Nekoyume.UI;
+using UnityEngine;
+
+namespace Nekoyume.Game.ScriptableObject
+{
+    [CreateAssetMenu(fileName = "Notice info ScriptableObject",
+        menuName = "Scriptable Object/Notice info ScriptableObject")]
+    public class NoticeInfoScriptableObject : UnityEngine.ScriptableObject
+    {
+        public NoticePopup.NoticeInfo noticeInfo;
+    }
+}

--- a/nekoyume/Assets/_Scripts/Game/ScriptableObject/NoticeInfoScriptableObject.cs.meta
+++ b/nekoyume/Assets/_Scripts/Game/ScriptableObject/NoticeInfoScriptableObject.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: bd72fa3478604c348aac35787be0fe4f
+timeCreated: 1662446704

--- a/nekoyume/Assets/_Scripts/UI/Widget/Popup/NoticePopup.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Popup/NoticePopup.cs
@@ -87,6 +87,7 @@ namespace Nekoyume.UI
                 Close();
                 AudioController.PlayClick();
             });
+            closeButton.interactable = false;
         }
 
         public override void Initialize()
@@ -125,6 +126,7 @@ namespace Nekoyume.UI
         {
             var www = UnityWebRequestTexture.GetTexture($"{BucketUrl}{_usingNoticeInfo.name}.png");
             yield return www.SendWebRequest();
+            closeButton.interactable = true;
             if (www.result != UnityWebRequest.Result.Success)
             {
                 Debug.Log(www.error);

--- a/nekoyume/Assets/_Scripts/UI/Widget/Popup/NoticePopup.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Popup/NoticePopup.cs
@@ -84,7 +84,7 @@ namespace Nekoyume.UI
             });
         }
 
-        public override void Show(bool ignoreStartAnimation = false)
+        public override void Initialize()
         {
             Addressables.LoadAssetAsync<NoticeInfoScriptableObject>("notice").Completed +=
                 operationHandle =>
@@ -92,16 +92,21 @@ namespace Nekoyume.UI
                     if (operationHandle.IsValid())
                     {
                         _usingNoticeInfo = operationHandle.Result.noticeInfo;
-                        if (!CanShowNoticePopup(_usingNoticeInfo))
-                        {
-                            return;
-                        }
-
-                        contentImage.sprite = _usingNoticeInfo.contentImage
-                            ? _usingNoticeInfo.contentImage
-                            : contentImage.sprite;
                     }
+                    base.Initialize();
                 };
+        }
+
+        public override void Show(bool ignoreStartAnimation = false)
+        {
+            if (!CanShowNoticePopup(_usingNoticeInfo))
+            {
+                return;
+            }
+
+            contentImage.sprite = _usingNoticeInfo.contentImage
+                ? _usingNoticeInfo.contentImage
+                : contentImage.sprite;
 
             base.Show(ignoreStartAnimation);
         }

--- a/nekoyume/Assets/_Scripts/UI/Widget/Popup/NoticePopup.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Popup/NoticePopup.cs
@@ -1,9 +1,10 @@
 ﻿using System;
-using System.Linq;
 using UnityEngine.UI;
 using UnityEngine;
 using Nekoyume.Game.Controller;
+using Nekoyume.Game.ScriptableObject;
 using Nekoyume.Helper;
+using UnityEngine.AddressableAssets;
 
 namespace Nekoyume.UI
 {
@@ -28,10 +29,9 @@ namespace Nekoyume.UI
         [SerializeField]
         private Button closeButton;
 
-        [SerializeField]
-        private NoticeInfo[] noticeList;
-
         private const string LastNoticeDayKeyFormat = "LAST_NOTICE_DAY_{0}";
+
+        private NoticeInfo _usingNoticeInfo;
 
         private static bool CanShowNoticePopup(NoticeInfo notice)
         {
@@ -86,21 +86,29 @@ namespace Nekoyume.UI
 
         public override void Show(bool ignoreStartAnimation = false)
         {
-            var firstNotice = noticeList.FirstOrDefault();
-            if (!CanShowNoticePopup(firstNotice))
-            {
-                return;
-            }
+            Addressables.LoadAssetAsync<NoticeInfoScriptableObject>("notice").Completed +=
+                operationHandle =>
+                {
+                    if (operationHandle.IsValid())
+                    {
+                        _usingNoticeInfo = operationHandle.Result.noticeInfo;
+                        if (!CanShowNoticePopup(_usingNoticeInfo))
+                        {
+                            return;
+                        }
 
-            contentImage.sprite = firstNotice?.contentImage
-                ? firstNotice.contentImage
-                : contentImage.sprite;
+                        contentImage.sprite = _usingNoticeInfo.contentImage
+                            ? _usingNoticeInfo.contentImage
+                            : contentImage.sprite;
+                    }
+                };
+
             base.Show(ignoreStartAnimation);
         }
 
         private void GoToNoticePage()
         {
-            Application.OpenURL(noticeList.FirstOrDefault()?.pageUrlFormat);
+            Application.OpenURL(_usingNoticeInfo.pageUrlFormat);
         }
     }
 }


### PR DESCRIPTION
### Description

1. Add: Using addressable asset to `NoticePopup`.
2. Add: Addressable Asset Label `"notice"`.

### Related Links

[NoticePopup AddressableAsset화](https://app.asana.com/0/958521740385861/1202927199415140/f)

### Required Reviewers

@planetarium/nine-chronicles-engineers 

### Screenshot
![image](https://user-images.githubusercontent.com/48484989/188583613-042527dc-b789-4207-8126-7b94fe66c4ab.png)
