### PR TITLE
Remove other ui closing in quest shortcut

### DIFF
--- a/nekoyume/Assets/_Scripts/Helper/ShortcutHelper.cs
+++ b/nekoyume/Assets/_Scripts/Helper/ShortcutHelper.cs
@@ -188,8 +188,9 @@ namespace Nekoyume.Helper
                     guideText = L10nManager.Localize("UI_MAIN_MENU_RANKING");
                     break;
                 case PlaceType.Quest:
-                    shortcutAction += () =>
+                    shortcutAction = () =>
                     {
+                        caller.Close();
                         Widget.Find<AvatarInfoPopup>().Close();
                         Widget.Find<QuestPopup>().Show();
                     };


### PR DESCRIPTION
### Description

1. Previously, there was a problem that all UIs turned off when using quest shortcuts.
2. Fixed that.

### How to test

1. Open any material tooltip.
2. Click 'Quest' shortcut.

### Required Reviewers

@planetarium/9c-dev 

### Screenshot

![Honeycam 2022-09-14 18-32-36](https://user-images.githubusercontent.com/48484989/190118079-3b81d2cc-ab06-4243-8757-d039757115b5.gif)
