### PR TITLE
Add auto scroll for last unlocked equipment recipe

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Scroller/RecipeScroll.cs
+++ b/nekoyume/Assets/_Scripts/UI/Scroller/RecipeScroll.cs
@@ -227,7 +227,9 @@ namespace Nekoyume.UI.Scroller
                     max = Mathf.Max(max, items.IndexOf(item));
                 }
             }
-            cellInterval = 0.2588997f;
+            // `Scroller.ViewportSize`(viewport.rect.size.x,y) was not initialized.
+            const float viewportSizeVertical = 458f;  // in `UI_Craft` prefab
+            AdjustCellIntervalAndScrollOffset(viewportSizeVertical);
             JumpTo(max-1);
 
             AnimateScroller();

--- a/nekoyume/Assets/_Scripts/UI/Scroller/RectScroll.cs
+++ b/nekoyume/Assets/_Scripts/UI/Scroller/RectScroll.cs
@@ -229,6 +229,13 @@ namespace Nekoyume.UI.Scroller
             Scroller.ScrollSensitivity = forcedScrollSensitivity;
         }
 
+        protected void AdjustCellIntervalAndScrollOffset(float viewportSize)
+        {
+            var totalSize = viewportSize + (CellSize + spacing) * (1f + reuseCellMarginCount * 2f);
+            cellInterval = (CellSize + spacing) / totalSize;
+            scrollOffset = cellInterval * (1f + reuseCellMarginCount);
+        }
+
         #endregion
 
         private float GetAlignmentToIncludeWithinViewport(TItemData itemData)

--- a/nekoyume/Assets/_Scripts/UI/Scroller/RectScroll.cs
+++ b/nekoyume/Assets/_Scripts/UI/Scroller/RectScroll.cs
@@ -229,6 +229,7 @@ namespace Nekoyume.UI.Scroller
             Scroller.ScrollSensitivity = forcedScrollSensitivity;
         }
 
+        // Polymorphic impletmentation of the base.AdjustCellIntervalAndScrollOffset() method.
         protected void AdjustCellIntervalAndScrollOffset(float viewportSize)
         {
             var totalSize = viewportSize + (CellSize + spacing) * (1f + reuseCellMarginCount * 2f);

--- a/nekoyume/ProjectSettings/EditorSettings.asset
+++ b/nekoyume/ProjectSettings/EditorSettings.asset
@@ -8,9 +8,11 @@ EditorSettings:
   m_LineEndingsForNewScripts: 2
   m_DefaultBehaviorMode: 1
   m_PrefabRegularEnvironment: {fileID: 0}
-  m_PrefabUIEnvironment: {fileID: 0}
+  m_PrefabUIEnvironment: {fileID: 102900000, guid: 366160239bdae4deb88708ecf51dced8,
+    type: 3}
   m_SpritePackerMode: 3
   m_SpritePackerPaddingPower: 1
+  m_Bc7TextureCompressor: 0
   m_EtcTextureCompressorBehavior: 1
   m_EtcTextureFastCompressor: 1
   m_EtcTextureNormalCompressor: 2
@@ -31,6 +33,7 @@ EditorSettings:
   m_SerializeInlineMappingsOnOneLine: 0
   m_DisableCookiesInLightmapper: 1
   m_AssetPipelineMode: 1
+  m_RefreshImportMode: 0
   m_CacheServerMode: 0
   m_CacheServerEndpoint: 
   m_CacheServerNamespacePrefix: default
@@ -38,3 +41,4 @@ EditorSettings:
   m_CacheServerEnableUpload: 1
   m_CacheServerEnableAuth: 0
   m_CacheServerEnableTls: 0
+  m_CacheServerValidationMode: 2


### PR DESCRIPTION
### Description

- Scroll Down so that the last unlocked Equipment Recipe is at the bottom of the Scoll View in Equipment Tap of Craft.
- Edit Prefab UI Environment settings for Game scene

### Related Links

[크래프트 자동 스크롤 추가](https://app.asana.com/0/958521740385861/1202984408005437/f)

### Screenshot

![set-recipe-scroll](https://user-images.githubusercontent.com/63496908/191187982-fe0008c3-05d0-462d-8946-b6563ca15043.gif)
