### PR TITLE
Disable the avatar info icon in the battle preparation

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Widget/ArenaBattlePreparation.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/ArenaBattlePreparation.cs
@@ -185,6 +185,7 @@ namespace Nekoyume.UI
             AgentStateSubject.Crystal
                 .Subscribe(_ => ReadyToBattle())
                 .AddTo(_disposables);
+            Find<HeaderMenuStatic>().SetActiveAvatarInfo(false);
             base.Show(ignoreShowAnimation);
         }
 
@@ -196,6 +197,7 @@ namespace Nekoyume.UI
             }
 
             _disposables.DisposeAllAndClear();
+            Find<HeaderMenuStatic>().SetActiveAvatarInfo(true);
             base.Close(ignoreCloseAnimation);
         }
 

--- a/nekoyume/Assets/_Scripts/UI/Widget/BattlePreparation.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/BattlePreparation.cs
@@ -308,6 +308,7 @@ namespace Nekoyume.UI
                 UpdateStartButton(States.Instance.CurrentAvatarState);
             }).AddTo(_disposables);
 
+            Find<HeaderMenuStatic>().SetActiveAvatarInfo(false);
             base.Show(ignoreShowAnimation);
         }
 
@@ -328,6 +329,7 @@ namespace Nekoyume.UI
             _shouldResetPlayer = true;
             consumableSlots.Clear();
             _disposables.DisposeAllAndClear();
+            Find<HeaderMenuStatic>().SetActiveAvatarInfo(true);
             base.Close(ignoreCloseAnimation);
         }
 

--- a/nekoyume/Assets/_Scripts/UI/Widget/RaidPreparation.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/RaidPreparation.cs
@@ -179,6 +179,7 @@ namespace Nekoyume.UI
 
             _bossId = bossId;
             _headerMenu = Find<HeaderMenuStatic>();
+            _headerMenu.SetActiveAvatarInfo(false);
 
             var currentAvatarState = Game.Game.instance.States.CurrentAvatarState;
             var currentBlockIndex = Game.Game.instance.Agent.BlockIndex;
@@ -269,6 +270,7 @@ namespace Nekoyume.UI
 
         public override void Close(bool ignoreCloseAnimation = false)
         {
+            Find<HeaderMenuStatic>().SetActiveAvatarInfo(true);
             consumableSlots.Clear();
             _disposables.DisposeAllAndClear();
 

--- a/nekoyume/Assets/_Scripts/UI/Widget/Static/HeaderMenuStatic.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Static/HeaderMenuStatic.cs
@@ -417,6 +417,12 @@ namespace Nekoyume.UI.Module
             _toggleNotifications[ToggleType.AvatarInfo].Value = hasNotification;
         }
 
+        public void SetActiveAvatarInfo(bool value)
+        {
+            var avatarInfo = toggles.FirstOrDefault(x => x.Type == ToggleType.AvatarInfo);
+            avatarInfo?.Toggle.gameObject.SetActive(value);
+        }
+
         public void TutorialActionClickBottomMenuWorkShopButton()
         {
             var info = toggles.FirstOrDefault(x => x.Type.Equals(ToggleType.CombinationSlots));


### PR DESCRIPTION
### Description

Disable the avatar info icon in the battle preparation

### Related Links

- [[월드 보스] 전투 준비 화면과 상단 UI에서의 장비 변경이 공유되는 현상](https://app.asana.com/0/1133453747809944/1202992445149638/f)

### Required Reviewers

@planetarium/9c-dev 