### PR TITLE
Fix equip cp effect

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Module/AvatarCP.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/AvatarCP.cs
@@ -50,6 +50,10 @@ namespace Nekoyume.UI.Module
                 additionalCpText.text = (currentCp - prevCp).ToString();
                 _disableCpTween = StartCoroutine(CoDisableIncreasedCp());
             }
+            else
+            {
+                additionalCpArea.gameObject.SetActive(false);
+            }
         }
 
         private IEnumerator CoDisableIncreasedCp()

--- a/nekoyume/Assets/_Scripts/UI/Widget/Popup/AvatarInfoPopup.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Popup/AvatarInfoPopup.cs
@@ -288,15 +288,15 @@ namespace Nekoyume.UI
                 return;
             }
 
+            var currentAvatarState = Game.Game.instance.States.CurrentAvatarState;
+            var characterSheet = Game.Game.instance.TableSheets.CharacterSheet;
+            var costumeStatSheet = Game.Game.instance.TableSheets.CostumeStatSheet;
+            var prevCp = CPHelper.GetCPV2(currentAvatarState, characterSheet, costumeStatSheet);
             if (!slot.IsEmpty)
             {
                 Unequip(slot, true);
             }
 
-            var currentAvatarState = Game.Game.instance.States.CurrentAvatarState;
-            var characterSheet = Game.Game.instance.TableSheets.CharacterSheet;
-            var costumeStatSheet = Game.Game.instance.TableSheets.CostumeStatSheet;
-            var prevCp = CPHelper.GetCPV2(currentAvatarState, characterSheet, costumeStatSheet);
             slot.Set(itemBase, OnClickSlot, OnDoubleClickSlot);
             LocalLayerModifier.SetItemEquip(currentAvatarState.address, slot.Item, true);
 


### PR DESCRIPTION
### Description

- Fix AvatarInfo popup to show difference value with cp effect when equip another equipment.

### How to test

1. Equip in AvatarInfo popup and Check CP change effect.

### Related Links

[장비 교체시, 장착하던 장비와 교체하는 장비의 차이값 만큼 CP상승 효과 숫자로 보여야 하는데, 교체하는 장비의 총 CP가 통째로 CP상승 효과에서 보이고 있음](https://app.asana.com/0/1141562434100787/1202734295506681/f)

### Screenshot

![equip_cp_effect](https://user-images.githubusercontent.com/63496908/191168877-d824bb09-7141-4baf-9138-fcbe8dc386d8.gif)