### PR TITLE
Modify raid related buttons

### DIFF
--- a/nekoyume/Assets/AddressableAssets/UI/Module/Lobby/RaidBtn.prefab
+++ b/nekoyume/Assets/AddressableAssets/UI/Module/Lobby/RaidBtn.prefab
@@ -44849,7 +44849,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &24083207468950827
 RectTransform:
   m_ObjectHideFlags: 0

--- a/nekoyume/Assets/_Scripts/UI/Widget/RaidPreparation.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/RaidPreparation.cs
@@ -254,7 +254,6 @@ namespace Nekoyume.UI
             crystalText.color = States.Instance.CrystalBalance.MajorUnit >= crystalCost ?
                 Palette.GetColor(ColorType.ButtonEnabled) :
                 Palette.GetColor(ColorType.TextDenial);
-            startButton.enabled = States.Instance.CrystalBalance.MajorUnit >= crystalCost;
         }
 
         private static int GetEntranceFee(AvatarState currentAvatarState)
@@ -579,11 +578,28 @@ namespace Nekoyume.UI
                     if (raiderState is null)
                     {
                         var cost = GetEntranceFee(currentAvatarState);
-                        Find<PaymentPopup>()
-                            .ShowWithAddCost("UI_TOTAL_COST", "UI_BOSS_JOIN_THE_SEASON",
-                                CostType.Crystal, cost,
-                                CostType.WorldBossTicket, 1,
-                                () => StartCoroutine(CoRaid()));
+                        if (States.Instance.CrystalBalance.MajorUnit < cost)
+                        {
+                            Find<PaymentPopup>().ShowAttract(
+                                CostType.Crystal,
+                                cost,
+                                L10nManager.Localize("UI_NOT_ENOUGH_CRYSTAL"),
+                                L10nManager.Localize("UI_GO_GRINDING"),
+                                () =>
+                                {
+                                    Find<Grind>().Show();
+                                    Find<WorldBoss>().Close();
+                                    Close();
+                                });
+                        }
+                        else
+                        {
+                            Find<PaymentPopup>()
+                                .ShowWithAddCost("UI_TOTAL_COST", "UI_BOSS_JOIN_THE_SEASON",
+                                    CostType.Crystal, cost,
+                                    CostType.WorldBossTicket, 1,
+                                    () => StartCoroutine(CoRaid()));
+                        }
                     }
                     else
                     {


### PR DESCRIPTION
### Description

- Grind pop-up display when there are not enough crystals to enter the world boss
- Bugfix world boss enter button

### Related Links

[[월드 보스] 크리스탈이 부족한 상태로 시작 버튼을 클릭할 경우 크리스탈 부족 팝업이 출력되지 않는 현상](https://app.asana.com/0/1133453747809944/1203018991450425/f)

### Required Reviewers

@planetarium/9c-dev 

### Screenshot

![ezgif com-gif-maker (10)](https://user-images.githubusercontent.com/40553495/191425566-5181890d-80b4-4989-8a33-56f4ad14f3a0.gif)
