### PR TITLE
Fix inventory notification

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Widget/Static/HeaderMenuStatic.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Static/HeaderMenuStatic.cs
@@ -377,7 +377,12 @@ namespace Nekoyume.UI.Module
         {
             var blockIndex = Game.Game.instance.Agent.BlockIndex;
             var avatarLevel = States.Instance.CurrentAvatarState?.level ?? 0;
-            var hasNotification = inventory?.HasNotification(avatarLevel, blockIndex) ?? false;
+            var sheets = Game.Game.instance.TableSheets;
+            var hasNotification = inventory?.HasNotification(avatarLevel, blockIndex,
+                sheets.ItemRequirementSheet,
+                sheets.EquipmentItemRecipeSheet,
+                sheets.EquipmentItemSubRecipeSheetV2,
+                sheets.EquipmentItemOptionSheet) ?? false;
             UpdateInventoryNotification(hasNotification);
         }
 


### PR DESCRIPTION
### Description

- Fix inventory notification
  The inventory notification(red dot) appears when the player doesn't equip the best equipments.
  but, item requirement level check was not included in the best equipment.
- lib9c PR : https://github.com/planetarium/lib9c/pull/1383

### How to test

1. Equip all best equipments.
2. Check the inventory icon of header menu has not red dot.

### Related Links

[CP가 높더라도 장착불가 템이면 인디케이터 안보여줘야 하는데, 인벤토리 아이콘에서 인디케이터를 보여주는 문제](https://app.asana.com/0/1141562434100787/1202619716401117/f)

### Screenshot

![image](https://user-images.githubusercontent.com/63496908/191429401-8f6abf8b-1f84-432e-9ef7-58932d5c1efa.png)
