### PR TITLE
Use `ninechronicles-launcher` protocol when move to staking

### DIFF
--- a/nekoyume/Assets/Resources/UI/Prefabs/UI_StakingPopup.prefab
+++ b/nekoyume/Assets/Resources/UI/Prefabs/UI_StakingPopup.prefab
@@ -5181,7 +5181,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 15.6
+  m_fontSize: 16
   m_fontSizeBase: 16
   m_fontWeight: 400
   m_enableAutoSizing: 1
@@ -6651,7 +6651,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &2419188683430789436
 RectTransform:
   m_ObjectHideFlags: 0
@@ -7666,7 +7666,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 15.6
+  m_fontSize: 16
   m_fontSizeBase: 16
   m_fontWeight: 400
   m_enableAutoSizing: 1
@@ -16195,7 +16195,7 @@ PrefabInstance:
     - target: {fileID: 8393857624628101227, guid: 543ea58faa96c47bea69a87c29ba0ce7,
         type: 3}
       propertyPath: m_IsActive
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 543ea58faa96c47bea69a87c29ba0ce7, type: 3}

--- a/nekoyume/Assets/_Scripts/Helper/ShortcutHelper.cs
+++ b/nekoyume/Assets/_Scripts/Helper/ShortcutHelper.cs
@@ -10,6 +10,7 @@ using Nekoyume.State;
 using Nekoyume.TableData;
 using Nekoyume.UI;
 using Nekoyume.UI.Module;
+using UnityEngine;
 using static Nekoyume.Helper.ShortcutHelper;
 
 namespace Nekoyume.Helper
@@ -197,7 +198,11 @@ namespace Nekoyume.Helper
                     guideText = L10nManager.Localize("UI_QUEST");
                     break;
                 case PlaceType.Staking:
-                    shortcutAction += () => Widget.Find<StakingPopup>().Show();
+                    shortcutAction = () =>
+                    {
+                        caller.Close();
+                        Application.OpenURL(StakingPopup.StakingUrl);
+                    };
                     guideText = L10nManager.Localize("UI_PLACE_STAKING");
                     break;
                 default:

--- a/nekoyume/Assets/_Scripts/UI/Widget/Popup/StakingPopup.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Popup/StakingPopup.cs
@@ -68,11 +68,11 @@ namespace Nekoyume.UI
         private readonly StakingBenefitsListView.Model[] _cachedModel =
             new StakingBenefitsListView.Model[6];
 
+        public const string StakingUrl =
+            "ninechronicles-launcher://open/monster-collection";
         private const string ActionPointBuffFormat = "{0} <color=#1FFF00>{1}% DC</color>";
         private const string BuffBenefitRateFormat = "{0} <color=#1FFF00>+{1}%</color>";
         private const string RemainingBlockFormat = "<Style=G5>{0}({1})";
-        private const string StakingUrl =
-            "https://ninechronicles.medium.com/monster-collection-v2-update-6cde770c9f31";
         private const int RewardBlockInterval = 50400;
 
         protected override void Awake()
@@ -114,8 +114,8 @@ namespace Nekoyume.UI
             });
             archiveButton.OnClickSubject.Subscribe(_ =>
             {
-                // TODO: Invoke ActionManager.Instance.ClaimStakeReward()
                 AudioController.PlayClick();
+                Application.OpenURL(StakingUrl);
             }).AddTo(gameObject);
 
             SetBenefitsListViews();


### PR DESCRIPTION
### Description

Now, some button will transfer to launcher with Staking UI.
**It will work at upper version of launcher than v100290.**
1. (+) button of StakingPopup
2. `Started` button of StakingPopup
3. `Get` button of StakingPopup
4. Shortcut about monster collection

### How To Test
Try to open url `"ninechronicles-launcher://open/monster-collection"`.

### Related Links

[몬스터 콜렉션 게임에서 런처로 연결 DEV](https://app.asana.com/0/958521740385861/1202890739639223/f)
https://github.com/planetarium/9c-launcher/pull/1887

### Required Reviewers

@planetarium/9c-dev @BasixKOR 

### Screenshot

![Honeycam 2022-09-23 14-58-50](https://user-images.githubusercontent.com/48484989/191901230-3bff5664-23ec-4b2d-b9af-d3277ad99f74.gif)
![Honeycam 2022-09-23 14-59-41](https://user-images.githubusercontent.com/48484989/191901248-b0d676b7-e014-4d2b-bac3-298ff6b3f195.gif)
![Honeycam 2022-09-23 15-03-32](https://user-images.githubusercontent.com/48484989/191901264-894bf41f-d685-4585-a7b6-325aed2bb8ca.gif)
![Honeycam 2022-09-23 15-09-22](https://user-images.githubusercontent.com/48484989/191901269-fb00b6dd-c15b-4080-90a3-053665a75035.gif)
