### PR TITLE
Fix craft button disable check

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Combination/SubRecipeView.cs
+++ b/nekoyume/Assets/_Scripts/UI/Combination/SubRecipeView.cs
@@ -569,9 +569,8 @@ namespace Nekoyume.UI
                     ? outFungibleItems.Sum(e => e.count)
                     : 0;
 
-                // when a material is unreplaceable.
-                if (material.Value > itemCount &&
-                    !TableSheets.Instance.CrystalMaterialCostSheet.ContainsKey(material.Key))
+                // consumable materials are basically unreplaceable so unreplaceable check isn't required
+                if (material.Value > itemCount)
                 {
                     submittable = false;
                 }

--- a/nekoyume/Assets/_Scripts/UI/Combination/SubRecipeView.cs
+++ b/nekoyume/Assets/_Scripts/UI/Combination/SubRecipeView.cs
@@ -272,7 +272,7 @@ namespace Nekoyume.UI
                     if (Craft.SharedModel.UnlockedRecipes.HasValue &&
                         gameObject.activeSelf)
                     {
-                        UpdateButton();
+                        UpdateButtonForEquipment();
                     }
                 });
             }
@@ -465,18 +465,11 @@ namespace Nekoyume.UI
 
             if (equipmentRow != null)
             {
-                UpdateButton();
+                UpdateButtonForEquipment();
             }
             else if (consumableRow != null)
             {
-                var submittable = CheckNCGAndSlotIsEnough();
-                var cost = new ConditionalCostButton.CostParam(
-                    CostType.NCG,
-                    (long)_selectedRecipeInfo.CostNCG);
-                button.SetCost(cost);
-                button.Interactable = submittable;
-                button.gameObject.SetActive(true);
-                lockedObject.SetActive(false);
+                UpdateButtonForConsumable();
             }
         }
 
@@ -507,7 +500,7 @@ namespace Nekoyume.UI
             return replacedMaterialMap;
         }
 
-        private void UpdateButton()
+        private void UpdateButtonForEquipment()
         {
             button.Interactable = false;
             if (_selectedRecipeInfo.Equals(default))
@@ -559,6 +552,39 @@ namespace Nekoyume.UI
                 lockedObject.SetActive(true);
                 lockedText.text = L10nManager.Localize("UI_INFORM_UNLOCK_RECIPE");
             }
+        }
+
+        private void UpdateButtonForConsumable()
+        {
+            var submittable = CheckNCGAndSlotIsEnough();
+            var inventory = States.Instance.CurrentAvatarState.inventory;
+            foreach (var material in _selectedRecipeInfo.Materials)
+            {
+                if (!TableSheets.Instance.MaterialItemSheet.TryGetValue(material.Key, out var row))
+                {
+                    continue;
+                }
+
+                var itemCount = inventory.TryGetFungibleItems(row.ItemId, out var outFungibleItems)
+                    ? outFungibleItems.Sum(e => e.count)
+                    : 0;
+
+                // when a material is unreplaceable.
+                if (material.Value > itemCount &&
+                    !TableSheets.Instance.CrystalMaterialCostSheet.ContainsKey(material.Key))
+                {
+                    submittable = false;
+                }
+            }
+
+            var cost = new ConditionalCostButton.CostParam(
+                CostType.NCG,
+                (long)_selectedRecipeInfo.CostNCG);
+
+            button.SetCost(cost);
+            button.Interactable = submittable;
+            button.gameObject.SetActive(true);
+            lockedObject.SetActive(false);
         }
 
         private void SetOptions(


### PR DESCRIPTION
### Description

- Fix craft button
  - to disable if it can't replaced with crystal

### Related Links

[레시피 제작 불가 처리 예외 현상](https://app.asana.com/0/1141562434100787/1202588760044684/f)

### Screenshot

Before

<img width="508" alt="image" src="https://user-images.githubusercontent.com/63496908/192687497-5a422ef2-403e-4584-bf49-3f3fb6c83d4f.png">

After
<img width="508" alt="image" src="https://user-images.githubusercontent.com/63496908/192485786-f2155a90-9f06-48d3-8fe0-4a048a6e7ee5.png">
