### PR TITLE
Clean up grinding slots when delete item

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Module/GrindModule.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/GrindModule.cs
@@ -284,15 +284,25 @@ namespace Nekoyume.UI.Module
 
         private void OnUpdateInventory(Inventory inventory, Nekoyume.Model.Item.Inventory inventoryModel)
         {
-            var selectedItemCount = _selectedItemsForGrind.Count;
-            for (int i = 0; i < selectedItemCount; i++)
+            var selectedItemList = _selectedItemsForGrind.OrderBy(i => i.GrindingCount.Value).ToList();
+            _selectedItemsForGrind.Clear();
+            var notExistItemCount = 0;
+            var slotIndex = 0;
+            foreach (var inventoryItem in selectedItemList)
             {
-                if (inventory.TryGetModel(_selectedItemsForGrind[i].ItemBase, out var inventoryItem))
+                if (inventory.TryGetModel(inventoryItem.ItemBase, out var newItem))
                 {
-                    inventoryItem.GrindingCount.SetValueAndForceNotify(_selectedItemsForGrind[i].GrindingCount.Value);
-                    _selectedItemsForGrind[i] = inventoryItem;
-                    itemSlots[i].UpdateSlot(_selectedItemsForGrind[i]);
+                    newItem.GrindingCount.SetValueAndForceNotify(
+                        inventoryItem.GrindingCount.Value - notExistItemCount);
+                    itemSlots[slotIndex - notExistItemCount].UpdateSlot(inventoryItem);
+                    _selectedItemsForGrind.Add(newItem);
                 }
+                else
+                {
+                    notExistItemCount++;
+                }
+
+                slotIndex++;
             }
 
             grindButton.Interactable = CanGrind;


### PR DESCRIPTION
### Description

change: Items deleted from the inventory were also deleted from the grinding slot.

### How to test

1. Enter to Grind menu.
2. Add any items to grinding slots.
3. Open your inventory, and turn on grind mode.
4. Try to grind items there added at Grind menu.
5. Check item slots at Grind menu.

### Related Links

[[Previewnet] 공방에서 그라인딩 장비 선택 후 인벤토리 그라인딩으로 그라인딩 후 공방에서 그라인딩이 가능한 현상](https://app.asana.com/0/1141562434100787/1202402217651509/f)

### Required Reviewers

@planetarium/9c-dev 

### Screenshot

![Honeycam 2022-09-28 18-40-44](https://user-images.githubusercontent.com/48484989/192746156-c3066646-c829-402c-8fe8-592691923349.gif)
