### PR TITLE
Add price-per-unit marker on shop item price text

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Module/Item/ShopItemView.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/Item/ShopItemView.cs
@@ -75,7 +75,16 @@ namespace Nekoyume.UI.Module
 
             baseItemView.CountText.gameObject.SetActive(model.ItemBase.ItemType == ItemType.Material);
             baseItemView.CountText.text = model.OrderDigest.ItemCount.ToString();
-            baseItemView.PriceText.text = model.OrderDigest.Price.GetQuantityString();
+
+            if (model.OrderDigest.ItemCount > 1 && decimal.TryParse(model.OrderDigest.Price.GetQuantityString(), out var price))
+            {
+                var priceText = decimal.Ceiling(price / model.OrderDigest.ItemCount * 1000) / 1000;
+                baseItemView.PriceText.text = $"{model.OrderDigest.Price.GetQuantityString()}({priceText})";
+            }
+            else
+            {
+                baseItemView.PriceText.text = model.OrderDigest.Price.GetQuantityString();
+            }
 
             model.Selected.Subscribe(b => baseItemView.SelectObject.SetActive(b)).AddTo(_disposables);
             model.Expired.Subscribe(b => baseItemView.ExpiredObject.SetActive(b)).AddTo(_disposables);

--- a/nekoyume/Assets/_Scripts/UI/Module/Item/ShopItemView.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/Item/ShopItemView.cs
@@ -78,7 +78,7 @@ namespace Nekoyume.UI.Module
 
             if (model.OrderDigest.ItemCount > 1 && decimal.TryParse(model.OrderDigest.Price.GetQuantityString(), out var price))
             {
-                var priceText = decimal.Ceiling(price / model.OrderDigest.ItemCount * 1000) / 1000;
+                var priceText = decimal.Round(price / model.OrderDigest.ItemCount, 3);
                 baseItemView.PriceText.text = $"{model.OrderDigest.Price.GetQuantityString()}({priceText})";
             }
             else


### PR DESCRIPTION
### Description

Solved #2016. 

Implemented price-per-unit text in Shop item display UI.

### How to test

1. Connect to main RPC node.
2. Open shop menu.
3. Click Material tab button.
4. View price text.

### Related Links

None

### Required Reviewers

@Atralupus 

### Screenshot
<img width="365" alt="image" src="https://user-images.githubusercontent.com/23236291/192787202-51c7a6de-badb-40d7-b19f-a56933bc077f.png">
<img width="361" alt="image" src="https://user-images.githubusercontent.com/23236291/192787265-8be3e409-024a-4b73-9c05-4ade5c370a21.png">
<img width="364" alt="image" src="https://user-images.githubusercontent.com/23236291/192787318-428f04fb-4ce0-40b4-a516-61d893539e41.png">


