### PR TITLE
add agent address to mixpanel tracking

### DIFF
--- a/nekoyume/Assets/_Scripts/BlockChain/ActionManager.cs
+++ b/nekoyume/Assets/_Scripts/BlockChain/ActionManager.cs
@@ -239,6 +239,7 @@ namespace Nekoyume.BlockChain
                 ["StageId"] = stageId,
                 ["PlayCount"] = playCount,
                 ["AvatarAddress"] = States.Instance.CurrentAvatarState.address.ToString(),
+                ["AgentAddress"] = States.Instance.AgentState.address.ToString(),
             });
 
             var avatarAddress = States.Instance.CurrentAvatarState.address;
@@ -407,6 +408,7 @@ namespace Nekoyume.BlockChain
             {
                 ["RecipeId"] = recipeInfo.RecipeId,
                 ["AvatarAddress"] = States.Instance.CurrentAvatarState.address.ToString(),
+                ["AgentAddress"] = States.Instance.AgentState.address.ToString(),
             });
 
             var action = new CombinationConsumable
@@ -692,6 +694,7 @@ namespace Nekoyume.BlockChain
             Analyzer.Instance.Track("Unity/Item Enhancement", new Value
             {
                 ["AvatarAddress"] = States.Instance.CurrentAvatarState.address.ToString(),
+                ["AgentAddress"] = States.Instance.AgentState.address.ToString(),
             });
 
             var action = new ItemEnhancement
@@ -730,6 +733,7 @@ namespace Nekoyume.BlockChain
             Analyzer.Instance.Track("Unity/Ranking Battle", new Value
             {
                 ["AvatarAddress"] = States.Instance.CurrentAvatarState.address.ToString(),
+                ["AgentAddress"] = States.Instance.AgentState.address.ToString(),
             });
             var action = new RankingBattle
             {
@@ -858,6 +862,7 @@ namespace Nekoyume.BlockChain
             {
                 ["RecipeId"] = recipeInfo.RecipeId,
                 ["AvatarAddress"] = States.Instance.CurrentAvatarState.address.ToString(),
+                ["AgentAddress"] = States.Instance.AgentState.address.ToString(),
             });
 
             var agentAddress = States.Instance.AgentState.address;
@@ -931,6 +936,7 @@ namespace Nekoyume.BlockChain
             {
                 ["HourglassCount"] = cost,
                 ["AvatarAddress"] = States.Instance.CurrentAvatarState.address.ToString(),
+                ["AgentAddress"] = States.Instance.AgentState.address.ToString(),
             });
 
             var action = new RapidCombination

--- a/nekoyume/Assets/_Scripts/BlockChain/ActionRenderHandler.cs
+++ b/nekoyume/Assets/_Scripts/BlockChain/ActionRenderHandler.cs
@@ -98,6 +98,7 @@ namespace Nekoyume.BlockChain
                             ["ActionType"] = actionType.TypeIdentifier,
                             ["Elapsed"] = elapsed,
                             ["AvatarAddress"] = States.Instance.CurrentAvatarState.address.ToString(),
+                            ["AgentAddress"] = States.Instance.AgentState.address.ToString(),
                         });
                     }
                 }
@@ -548,6 +549,7 @@ namespace Nekoyume.BlockChain
                                     ["GainedCrystal"] = (long)enhancementResultModel.CRYSTAL.MajorUnit,
                                     ["BurntNCG"] = (long)enhancementResultModel.gold,
                                     ["AvatarAddress"] = States.Instance.CurrentAvatarState.address.ToString(),
+                                    ["AgentAddress"] = States.Instance.AgentState.address.ToString(),
                                 });
                                 formatKey = "NOTIFICATION_ITEM_ENHANCEMENT_COMPLETE_FAIL";
                                 break;
@@ -831,6 +833,7 @@ namespace Nekoyume.BlockChain
                             ["GainedCrystal"] = (long)result.CRYSTAL.MajorUnit,
                             ["BurntNCG"] = (long)result.gold,
                             ["AvatarAddress"] = States.Instance.CurrentAvatarState.address.ToString(),
+                            ["AgentAddress"] = States.Instance.AgentState.address.ToString(),
                         });
                         formatKey = "NOTIFICATION_ITEM_ENHANCEMENT_COMPLETE_FAIL";
                         break;
@@ -1157,6 +1160,7 @@ namespace Nekoyume.BlockChain
                         ["RandomSkillId"] = eval.Action.StageBuffId,
                         ["IsCleared"] = simulator.Log.IsClear,
                         ["AvatarAddress"] = States.Instance.CurrentAvatarState.address.ToString(),
+                        ["AgentAddress"] = States.Instance.AgentState.address.ToString(),
                     });
                 }
 

--- a/nekoyume/Assets/_Scripts/BlockChain/RPCAgent.cs
+++ b/nekoyume/Assets/_Scripts/BlockChain/RPCAgent.cs
@@ -258,6 +258,7 @@ namespace Nekoyume.BlockChain
                 .Subscribe(_ => Analyzer.Instance.Track("Unity/RPC Disconnected", new Value
                 {
                     ["AvatarAddress"] = States.Instance.CurrentAvatarState.address.ToString(),
+                    ["AgentAddress"] = States.Instance.AgentState.address.ToString(),
                 }))
                 .AddTo(_disposables);
             OnRetryStarted
@@ -265,6 +266,7 @@ namespace Nekoyume.BlockChain
                 .Subscribe(_ => Analyzer.Instance.Track("Unity/RPC Retry Connect Started", new Value
                 {
                     ["AvatarAddress"] = States.Instance.CurrentAvatarState.address.ToString(),
+                    ["AgentAddress"] = States.Instance.AgentState.address.ToString(),
                 }))
                 .AddTo(_disposables);
             OnRetryEnded
@@ -272,6 +274,7 @@ namespace Nekoyume.BlockChain
                 .Subscribe(_ => Analyzer.Instance.Track("Unity/RPC Retry Connect Ended", new Value
                 {
                     ["AvatarAddress"] = States.Instance.CurrentAvatarState.address.ToString(),
+                    ["AgentAddress"] = States.Instance.AgentState.address.ToString(),
                 }))
                 .AddTo(_disposables);
             OnPreloadStarted
@@ -279,6 +282,7 @@ namespace Nekoyume.BlockChain
                 .Subscribe(_ => Analyzer.Instance.Track("Unity/RPC Preload Started", new Value
                 {
                     ["AvatarAddress"] = States.Instance.CurrentAvatarState.address.ToString(),
+                    ["AgentAddress"] = States.Instance.AgentState.address.ToString(),
                 }))
                 .AddTo(_disposables);
             OnPreloadEnded
@@ -286,6 +290,7 @@ namespace Nekoyume.BlockChain
                 .Subscribe(_ => Analyzer.Instance.Track("Unity/RPC Preload Ended", new Value
                 {
                     ["AvatarAddress"] = States.Instance.CurrentAvatarState.address.ToString(),
+                    ["AgentAddress"] = States.Instance.AgentState.address.ToString(),
                 }))
                 .AddTo(_disposables);
             OnRetryAttempt

--- a/nekoyume/Assets/_Scripts/Game/Character/Player.cs
+++ b/nekoyume/Assets/_Scripts/Game/Character/Player.cs
@@ -634,6 +634,7 @@ namespace Nekoyume.Game.Character
                 {
                     ["code"] = level,
                     ["AvatarAddress"] = Game.instance.States.CurrentAvatarState.address.ToString(),
+                    ["AgentAddress"] = Game.instance.States.AgentState.address.ToString(),
                 });
 
                 Widget.Find<LevelUpCelebratePopup>()?.Show(level, Level);

--- a/nekoyume/Assets/_Scripts/Game/Prologue.cs
+++ b/nekoyume/Assets/_Scripts/Game/Prologue.cs
@@ -35,6 +35,7 @@ namespace Nekoyume.Game
         {
             Analyzer.Instance.Track("Unity/Prologuebattle Start", new Value
             {
+                ["AvatarAddress"] = Game.instance.States.CurrentAvatarState.address.ToString(),
                 ["AgentAddress"] = Game.instance.States.AgentState.address.ToString(),
             });
             StartCoroutine(Widget.Find<Blind>().FadeOut(2f));

--- a/nekoyume/Assets/_Scripts/Game/Stage.cs
+++ b/nekoyume/Assets/_Scripts/Game/Stage.cs
@@ -609,6 +609,7 @@ namespace Nekoyume.Game
                 ["CP"] = cp,
                 ["FoodCount"] = foodCount,
                 ["AvatarAddress"] = States.Instance.CurrentAvatarState.address.ToString(),
+                ["AgentAddress"] = States.Instance.AgentState.address.ToString(),
             };
             Analyzer.Instance.Track("Unity/Stage End", props);
         }

--- a/nekoyume/Assets/_Scripts/UI/Module/GrindModule.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/GrindModule.cs
@@ -463,6 +463,7 @@ namespace Nekoyume.UI.Module
                 ["EquipmentCount"] = equipments.Count,
                 ["GainedCrystal"] = (long) _cachedGrindingRewardCrystal.MajorUnit,
                 ["AvatarAddress"] = States.Instance.CurrentAvatarState.address.ToString(),
+                ["AgentAddress"] = States.Instance.AgentState.address.ToString(),
             });
             ActionManager.Instance
                 .Grinding(equipments, chargeAp)

--- a/nekoyume/Assets/_Scripts/UI/Scroller/RecipeScroll.cs
+++ b/nekoyume/Assets/_Scripts/UI/Scroller/RecipeScroll.cs
@@ -181,6 +181,7 @@ namespace Nekoyume.UI.Scroller
             {
                 ["BurntCrystal"] = (long)_openCost,
                 ["AvatarAddress"] = States.Instance.CurrentAvatarState.address.ToString(),
+                ["AgentAddress"] = States.Instance.AgentState.address.ToString(),
             });
             Game.Game.instance.ActionManager
                 .UnlockEquipmentRecipe(_unlockableRecipeIds, _openCost)

--- a/nekoyume/Assets/_Scripts/UI/Widget/BattlePreparation.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/BattlePreparation.cs
@@ -235,6 +235,7 @@ namespace Nekoyume.UI
             Analyzer.Instance.Track("Unity/Click Stage", new Value
             {
                 ["AvatarAddress"] = States.Instance.CurrentAvatarState.address.ToString(),
+                ["AgentAddress"] = States.Instance.AgentState.address.ToString(),
             });
 
             var stage = Game.Game.instance.Stage;

--- a/nekoyume/Assets/_Scripts/UI/Widget/Craft.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Craft.cs
@@ -502,6 +502,7 @@ namespace Nekoyume.UI
                                     .Sum(x => x.Value),
                                 ["BurntCrystal"] = (long)recipeInfo.CostCrystal,
                                 ["AvatarAddress"] = States.Instance.CurrentAvatarState.address.ToString(),
+                                ["AgentAddress"] = States.Instance.AgentState.address.ToString(),
                             });
 
                         ActionManager.Instance

--- a/nekoyume/Assets/_Scripts/UI/Widget/Menu.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Menu.cs
@@ -201,6 +201,7 @@ namespace Nekoyume.UI
             Analyzer.Instance.Track("Unity/Click Guided Quest Combination Equipment", new Value
             {
                 ["AvatarAddress"] = States.Instance.CurrentAvatarState.address.ToString(),
+                ["AgentAddress"] = States.Instance.AgentState.address.ToString(),
             });
             CombinationClickInternal(() =>
                 Find<Craft>().ShowWithEquipmentRecipeId(recipeId));
@@ -364,6 +365,7 @@ namespace Nekoyume.UI
             Analyzer.Instance.Track("Unity/Enter arena page", new Value
             {
                 ["AvatarAddress"] = States.Instance.CurrentAvatarState.address.ToString(),
+                ["AgentAddress"] = States.Instance.AgentState.address.ToString(),
             });
             AudioController.PlayClick();
         }

--- a/nekoyume/Assets/_Scripts/UI/Widget/Popup/BuffBonusPopup.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Popup/BuffBonusPopup.cs
@@ -167,6 +167,7 @@ namespace Nekoyume.UI
                 ["BurntCrystal"] = (long) (advanced ? _advancedCost : _normalCost),
                 ["isAdvanced"] = advanced,
                 ["AvatarAddress"] = States.Instance.CurrentAvatarState.address.ToString(),
+                ["AgentAddress"] = States.Instance.AgentState.address.ToString(),
             });
 
             ActionManager.Instance.HackAndSlashRandomBuff(advanced).Subscribe();

--- a/nekoyume/Assets/_Scripts/UI/Widget/Popup/SweepPopup.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Popup/SweepPopup.cs
@@ -440,6 +440,7 @@ namespace Nekoyume.UI
                 ["apStoneCount"] = apStoneCount,
                 ["playCount"] = totalPlayCount,
                 ["AvatarAddress"] = States.Instance.CurrentAvatarState.address.ToString(),
+                ["AgentAddress"] = States.Instance.AgentState.address.ToString(),
             });
 
             Close();

--- a/nekoyume/Assets/_Scripts/UI/Widget/ShopBuy.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/ShopBuy.cs
@@ -220,6 +220,7 @@ namespace Nekoyume.UI
                 {
                     ["Count"] = models.Count,
                     ["AvatarAddress"] = States.Instance.CurrentAvatarState.address.ToString(),
+                    ["AgentAddress"] = States.Instance.AgentState.address.ToString(),
                 };
                 Analyzer.Instance.Track("Unity/Number of Purchased Items", props);
             }
@@ -230,6 +231,7 @@ namespace Nekoyume.UI
                 {
                     ["Price"] = model.OrderDigest.Price.GetQuantityString(),
                     ["AvatarAddress"] = States.Instance.CurrentAvatarState.address.ToString(),
+                    ["AgentAddress"] = States.Instance.AgentState.address.ToString(),
                 };
                 Analyzer.Instance.Track("Unity/Buy", props);
 

--- a/nekoyume/Assets/_Scripts/UI/Widget/ShopSell.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/ShopSell.cs
@@ -293,6 +293,7 @@ namespace Nekoyume.UI
             {
                 ["Quantity"] = updateSellInfos.Count,
                 ["AvatarAddress"] = States.Instance.CurrentAvatarState.address.ToString(),
+                ["AgentAddress"] = States.Instance.AgentState.address.ToString(),
             });
 
             string message;
@@ -378,6 +379,7 @@ namespace Nekoyume.UI
             Analyzer.Instance.Track("Unity/Sell", new Value
             {
                 ["AvatarAddress"] = States.Instance.CurrentAvatarState.address.ToString(),
+                ["AgentAddress"] = States.Instance.AgentState.address.ToString(),
             });
             ResponseSell();
         }
@@ -429,6 +431,7 @@ namespace Nekoyume.UI
             Analyzer.Instance.Track("Unity/UpdateSell", new Value
             {
                 ["AvatarAddress"] = States.Instance.CurrentAvatarState.address.ToString(),
+                ["AgentAddress"] = States.Instance.AgentState.address.ToString(),
             });
             ResponseSell();
         }
@@ -530,6 +533,7 @@ namespace Nekoyume.UI
                 Analyzer.Instance.Track("Unity/Sell Cancellation", new Value
                 {
                     ["AvatarAddress"] = States.Instance.CurrentAvatarState.address.ToString(),
+                    ["AgentAddress"] = States.Instance.AgentState.address.ToString(),
                 });
                 Game.Game.instance.ActionManager.SellCancellation(
                     avatarAddress,

--- a/nekoyume/Assets/_Scripts/UI/Widget/WorldMap.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/WorldMap.cs
@@ -283,6 +283,7 @@ namespace Nekoyume.UI
                 Analyzer.Instance.Track("Unity/Click Yggdrasil", new Value
                 {
                     ["AvatarAddress"] = States.Instance.CurrentAvatarState.address.ToString(),
+                    ["AgentAddress"] = States.Instance.AgentState.address.ToString(),
                 });
             }
 
@@ -400,6 +401,7 @@ namespace Nekoyume.UI
                     {
                         ["BurntCrystal"] = (long)cost,
                         ["AvatarAddress"] = States.Instance.CurrentAvatarState.address.ToString(),
+                        ["AgentAddress"] = States.Instance.AgentState.address.ToString(),
                     });
                     ActionManager.Instance.UnlockWorld(new List<int> { worldId }).Subscribe();
                 },
@@ -436,6 +438,7 @@ namespace Nekoyume.UI
                             {
                                 ["BurntCrystal"] = (long)cost,
                                 ["AvatarAddress"] = States.Instance.CurrentAvatarState.address.ToString(),
+                                ["AgentAddress"] = States.Instance.AgentState.address.ToString(),
                             });
                             ActionManager.Instance.UnlockWorld(worldIdListForUnlock).Subscribe();
                         },


### PR DESCRIPTION
This PR adds an `AgentAddress` property to all mixpanel events that we are currently tracking.

A similar PR: https://github.com/planetarium/NineChronicles/pull/1860