### PR TITLE
Fix CurrencyNotation expression

### DIFF
--- a/nekoyume/Assets/_Scripts/Extensions/BigIntegerExtensions.cs
+++ b/nekoyume/Assets/_Scripts/Extensions/BigIntegerExtensions.cs
@@ -20,8 +20,8 @@ namespace Nekoyume
                         return num.ToString();
                     case 4:
                     case 5:
-                        return BigInteger.Divide(num, (BigInteger)1e3) + "K";
                     case 6:
+                        return BigInteger.Divide(num, (BigInteger)1e3) + "K";
                     case 7:
                     case 8:
                     case 9:


### PR DESCRIPTION
### Description

1. before: `1000001` => `1M`
2. now: `1000001` => `1000K`
### Screenshot

![image](https://user-images.githubusercontent.com/48484989/196133163-1d918d0f-dea3-4ca2-900b-8f7d6a991693.png)
