### PR TITLE
Edit arena participants order

### DIFF
--- a/nekoyume/Assets/_Scripts/State/RxProps.Arena.cs
+++ b/nekoyume/Assets/_Scripts/State/RxProps.Arena.cs
@@ -323,7 +323,7 @@ namespace Nekoyume.State
                 })
                 .ToArray();
             var avatarAddrAndScoresWithRank =
-                AddRank(avatarAddrAndScores);
+                AddRank(avatarAddrAndScores, currentAvatarAddr);
             PlayerArenaParticipant playersArenaParticipant = null;
             int playerScore;
             try
@@ -400,7 +400,7 @@ namespace Nekoyume.State
                     avatar,
                     (win, lose)
                 );
-            }).OrderByDescending(e => e.Score).ThenByDescending(e => e.AvatarAddr == currentAvatarAddr).ToArray();
+            }).ToArray();
 
             var playerArenaInfo = stateBulk[playerArenaInfoAddr] is List arenaInfoList
                 ? new ArenaInformation(arenaInfoList)
@@ -423,7 +423,7 @@ namespace Nekoyume.State
         }
 
         public static (Address avatarAddr, int score, int rank)[] AddRank(
-            (Address avatarAddr, int score)[] tuples)
+            (Address avatarAddr, int score)[] tuples, Address? currentAvatarAddr = null)
         {
             if (tuples.Length == 0)
             {
@@ -432,6 +432,7 @@ namespace Nekoyume.State
 
             var orderedTuples = tuples
                 .OrderByDescending(tuple => tuple.score)
+                .ThenByDescending(tuple => tuple.avatarAddr == currentAvatarAddr)
                 .ThenBy(tuple => tuple.avatarAddr)
                 .Select(tuple => (tuple.avatarAddr, tuple.score, 0))
                 .ToArray();

--- a/nekoyume/Assets/_Scripts/State/RxProps.Arena.cs
+++ b/nekoyume/Assets/_Scripts/State/RxProps.Arena.cs
@@ -400,7 +400,7 @@ namespace Nekoyume.State
                     avatar,
                     (win, lose)
                 );
-            }).ToArray();
+            }).OrderByDescending(e => e.Score).ThenByDescending(e => e.AvatarAddr == currentAvatarAddr).ToArray();
 
             var playerArenaInfo = stateBulk[playerArenaInfoAddr] is List arenaInfoList
                 ? new ArenaInformation(arenaInfoList)


### PR DESCRIPTION
### Description
Edit arena participants order so that the local player is at the top of the tie.

### Related Links
[아레나 참가자 정렬 수정](https://app.asana.com/0/958521740385861/1203264848476233/f)

### Screenshot
![image](https://user-images.githubusercontent.com/63496908/198919913-a502a00f-3e76-42a4-96b9-ff8b6a642256.png)