### PR TITLE
get sentry sample rate from command options

### DIFF
--- a/nekoyume/Assets/Resources/Sentry/SentryOptions.asset
+++ b/nekoyume/Assets/Resources/Sentry/SentryOptions.asset
@@ -16,7 +16,7 @@ MonoBehaviour:
   <Dsn>k__BackingField: https://58eacaea567c41cba9104c0e85ad1ffb@o195672.ingest.sentry.io/4503979492245504
   <CaptureInEditor>k__BackingField: 1
   <EnableLogDebouncing>k__BackingField: 0
-  <TracesSampleRate>k__BackingField: 1
+  <TracesSampleRate>k__BackingField: 0
   <AutoSessionTracking>k__BackingField: 1
   <AutoSessionTrackingInterval>k__BackingField: 30000
   <ReleaseOverride>k__BackingField: 
@@ -41,7 +41,8 @@ MonoBehaviour:
   <MacosNativeSupportEnabled>k__BackingField: 1
   <LinuxNativeSupportEnabled>k__BackingField: 1
   <Il2CppLineNumberSupportEnabled>k__BackingField: 1
-  <OptionsConfiguration>k__BackingField: {fileID: 0}
+  <OptionsConfiguration>k__BackingField: {fileID: 11400000, guid: e1f981f00f5b547bdb2a3e516d38e71f,
+    type: 2}
   <Debug>k__BackingField: 1
   <DebugOnlyInEditor>k__BackingField: 1
   <DiagnosticLevel>k__BackingField: 2

--- a/nekoyume/Assets/Resources/Sentry/SentryOptionsConfiguration.asset
+++ b/nekoyume/Assets/Resources/Sentry/SentryOptionsConfiguration.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 97a6de99f927e4551af5898ace7bf06f, type: 3}
+  m_Name: SentryOptionsConfiguration
+  m_EditorClassIdentifier: 

--- a/nekoyume/Assets/Resources/Sentry/SentryOptionsConfiguration.asset.meta
+++ b/nekoyume/Assets/Resources/Sentry/SentryOptionsConfiguration.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e1f981f00f5b547bdb2a3e516d38e71f
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/nekoyume/Assets/_Scripts/Helper/CommandLineParser.cs
+++ b/nekoyume/Assets/_Scripts/Helper/CommandLineParser.cs
@@ -61,6 +61,8 @@ namespace Nekoyume.Helper
 
         private string onBoardingHost;
 
+        private double sentrySampleRate = 0;
+
         public bool Empty { get; private set; } = true;
 
         public string genesisBlockPath;
@@ -342,6 +344,17 @@ namespace Nekoyume.Helper
             set
             {
                 onBoardingHost = value;
+                Empty = false;
+            }
+        }
+
+        [Option("sentry-sample-rate", Required = false, HelpText = "sample rate for sentry trace")]
+        public double SentrySampleRate
+        {
+            get => sentrySampleRate;
+            set
+            {
+                sentrySampleRate = value;
                 Empty = false;
             }
         }

--- a/nekoyume/Assets/_Scripts/SentryOptionsConfiguration.cs
+++ b/nekoyume/Assets/_Scripts/SentryOptionsConfiguration.cs
@@ -17,7 +17,7 @@ public class SentryOptionsConfiguration : ScriptableOptionsConfiguration
         var _options = CommandLineOptions.Load(
             CommandLineOptionsJsonPath
         );
-        options.SampleRate = (float) _options.SentrySampleRate;
+        options.SampleRate = _options.SentrySampleRate > 0 ? (float) _options.SentrySampleRate : 0.01f;
         options.TracesSampleRate = _options.SentrySampleRate;
     }
 }

--- a/nekoyume/Assets/_Scripts/SentryOptionsConfiguration.cs
+++ b/nekoyume/Assets/_Scripts/SentryOptionsConfiguration.cs
@@ -1,0 +1,23 @@
+using System.IO;
+using Nekoyume.Helper;
+using Sentry.Unity;
+using UnityEngine;
+
+[CreateAssetMenu(fileName = "Assets/Resources/Sentry/SentryOptionsConfiguration.cs", menuName = "Sentry/SentryOptionsConfiguration", order = 999)]
+public class SentryOptionsConfiguration : ScriptableOptionsConfiguration
+{
+    private static readonly string CommandLineOptionsJsonPath =
+        Path.Combine(Application.streamingAssetsPath, "clo.json");
+    // This method gets called when you instantiated the scriptable object and added it to the configuration window
+    public override void Configure(SentryUnityOptions options)
+    {
+        // NOTE: Native support is already initialized by the time this method runs, so Unity bugs are captured.
+        // That means changes done to the 'options' here will only affect events from C# scripts.
+
+        var _options = CommandLineOptions.Load(
+            CommandLineOptionsJsonPath
+        );
+        options.SampleRate = (float) _options.SentrySampleRate;
+        options.TracesSampleRate = _options.SentrySampleRate;
+    }
+}

--- a/nekoyume/Assets/_Scripts/SentryOptionsConfiguration.cs.meta
+++ b/nekoyume/Assets/_Scripts/SentryOptionsConfiguration.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 97a6de99f927e4551af5898ace7bf06f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Description
1. Add `SentrySampleRate` CommandLineOptions to control sample rate dynamically
2. but in the sentry `Configure` function, it needs to load all unnecessary options to use `SentrySampleRate` option only.
    because it isn't related to the game object where the commandlineoptions loaded on.
    if there is better way to get only one option, please let me know

### Ref
config sentry from code
https://docs.sentry.io/platforms/unity/configuration/options/#programmatic-configuration

9c-launcher will inject the option like below
https://github.com/planetarium/9c-launcher/pull/1970/files
