### PR TITLE
Add crystal per gold sorting to Shop UI

### DIFF
--- a/nekoyume/Assets/StreamingAssets/Localization/common.csv
+++ b/nekoyume/Assets/StreamingAssets/Localization/common.csv
@@ -762,7 +762,6 @@ Environ {0}({1}/{2})","""Оставшееся время {0}({1}/{2})""",,,剩�
 UI_WIN,Win,승,Ganha,,勝利,Sieg,,ชนะ,Wygrana,,,Menang,Victoire,Победа,,,赢,
 UI_LOSE,Lose,패,Perde,,敗北,Niederlage,,แพ้,Przegrana,,,Kalah,Défaite,Поражение,,,输,
 UI_CLASS,Class,등급,Classe,,クラス,Klasse,,อาชีพ,Klasa,,,Kelas,Classe,Класс,,,类,
-UI_CRYSTALPERNCG,Crystal/NCG,NCG당 크리스탈,,,,,,,,,,,,,,,,
 UI_CP,CP,CP,CP,,CP,CP,,CP,CP,,,CP,CP,CP,,,CP,
 UI_PRICE,Price,가격,Preço,,価格,Preis,,ราคา,Cena,,,Harga,Prix,Цена,,,价格,
 UI_CHALLENGE,Challenge,도전,Challenge,,,,,,,,,,Défier,,,,,

--- a/nekoyume/Assets/StreamingAssets/Localization/common.csv
+++ b/nekoyume/Assets/StreamingAssets/Localization/common.csv
@@ -762,6 +762,7 @@ Environ {0}({1}/{2})","""Оставшееся время {0}({1}/{2})""",,,剩�
 UI_WIN,Win,승,Ganha,,勝利,Sieg,,ชนะ,Wygrana,,,Menang,Victoire,Победа,,,赢,
 UI_LOSE,Lose,패,Perde,,敗北,Niederlage,,แพ้,Przegrana,,,Kalah,Défaite,Поражение,,,输,
 UI_CLASS,Class,등급,Classe,,クラス,Klasse,,อาชีพ,Klasa,,,Kelas,Classe,Класс,,,类,
+UI_CRYSTALPERNCG,Crystal/NCG,NCG당 크리스탈,,,,,,,,,,,,,,,,
 UI_CP,CP,CP,CP,,CP,CP,,CP,CP,,,CP,CP,CP,,,CP,
 UI_PRICE,Price,가격,Preço,,価格,Preis,,ราคา,Cena,,,Harga,Prix,Цена,,,价格,
 UI_CHALLENGE,Challenge,도전,Challenge,,,,,,,,,,Défier,,,,,

--- a/nekoyume/Assets/_Scripts/EnumType/ShopSortFilter.cs
+++ b/nekoyume/Assets/_Scripts/EnumType/ShopSortFilter.cs
@@ -7,6 +7,7 @@ namespace Nekoyume.EnumType
         CP = 0,
         Price = 1,
         Class = 2,
+        CrystalPerNcg = 3,
     }
 
     public static class ShopSortFilterExtension
@@ -20,6 +21,7 @@ namespace Nekoyume.EnumType
                     ShopSortFilter.CP,
                     ShopSortFilter.Price,
                     ShopSortFilter.Class,
+                    ShopSortFilter.CrystalPerNcg,
                 };
             }
         }

--- a/nekoyume/Assets/_Scripts/EnumType/ShopSortFilter.cs
+++ b/nekoyume/Assets/_Scripts/EnumType/ShopSortFilter.cs
@@ -7,7 +7,7 @@ namespace Nekoyume.EnumType
         CP = 0,
         Price = 1,
         Class = 2,
-        CrystalPerNcg = 3,
+        Crystal = 3,
     }
 
     public static class ShopSortFilterExtension
@@ -21,7 +21,7 @@ namespace Nekoyume.EnumType
                     ShopSortFilter.CP,
                     ShopSortFilter.Price,
                     ShopSortFilter.Class,
-                    ShopSortFilter.CrystalPerNcg,
+                    ShopSortFilter.Crystal,
                 };
             }
         }

--- a/nekoyume/Assets/_Scripts/UI/Shop/BuyView.cs
+++ b/nekoyume/Assets/_Scripts/UI/Shop/BuyView.cs
@@ -2,20 +2,25 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Numerics;
 using System.Text.RegularExpressions;
 using Nekoyume.EnumType;
+using Nekoyume.Game;
 using Nekoyume.Game.Controller;
 using Nekoyume.Helper;
 using Nekoyume.L10n;
+using Nekoyume.Model.Item;
 using Nekoyume.Model.Mail;
+using Nekoyume.State;
 using Nekoyume.UI;
-using Nekoyume.UI.Model;
 using Nekoyume.UI.Module;
 using Nekoyume.UI.Scroller;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
+using ShopItem = Nekoyume.UI.Model.ShopItem;
 using Toggle = UnityEngine.UI.Toggle;
+using Vector3 = UnityEngine.Vector3;
 
 namespace Nekoyume
 {
@@ -407,6 +412,20 @@ namespace Nekoyume
                 models = models.Where(x => Util.IsUsableItem(x.ItemBase)).ToList();
             }
 
+            BigInteger GetCrystalPerPrice(ShopItem item)
+            {
+                return item.ItemBase.ItemType == ItemType.Equipment
+                    ? CrystalCalculator.CalculateCrystal(
+                            new[] {(Equipment) item.ItemBase},
+                            false,
+                            TableSheets.Instance.CrystalEquipmentGrindingSheet,
+                            TableSheets.Instance.CrystalMonsterCollectionMultiplierSheet,
+                            States.Instance.StakingLevel).DivRem(item.OrderDigest.Price.MajorUnit)
+                        .Quotient
+                        .MajorUnit
+                    : 0;
+            }
+
             return _selectedSortFilter.Value switch
             {
                 ShopSortFilter.CP => _isAscending.Value
@@ -422,6 +441,9 @@ namespace Nekoyume
                     : models.OrderByDescending(x => x.Grade)
                         .ThenByDescending(x => x.ItemBase.ItemType)
                         .ToList(),
+                ShopSortFilter.CrystalPerNcg => _isAscending.Value
+                    ? models.OrderBy(GetCrystalPerPrice).ToList()
+                    : models.OrderByDescending(GetCrystalPerPrice).ToList(),
                 _ => throw new ArgumentOutOfRangeException()
             };
         }

--- a/nekoyume/Assets/_Scripts/UI/Shop/BuyView.cs
+++ b/nekoyume/Assets/_Scripts/UI/Shop/BuyView.cs
@@ -441,7 +441,7 @@ namespace Nekoyume
                     : models.OrderByDescending(x => x.Grade)
                         .ThenByDescending(x => x.ItemBase.ItemType)
                         .ToList(),
-                ShopSortFilter.CrystalPerNcg => _isAscending.Value
+                ShopSortFilter.Crystal => _isAscending.Value
                     ? models.OrderBy(GetCrystalPerPrice).ToList()
                     : models.OrderByDescending(GetCrystalPerPrice).ToList(),
                 _ => throw new ArgumentOutOfRangeException()

--- a/nekoyume/Assets/_Scripts/UI/Shop/SellView.cs
+++ b/nekoyume/Assets/_Scripts/UI/Shop/SellView.cs
@@ -127,7 +127,7 @@ namespace Nekoyume
                 ShopSortFilter.Price => models.OrderByDescending(x => x.OrderDigest.Price).ToList(),
                 ShopSortFilter.Class => models.OrderByDescending(x => x.Grade)
                     .ThenByDescending(x => x.ItemBase.ItemType).ToList(),
-                ShopSortFilter.CrystalPerNcg => models.OrderByDescending(x => x.ItemBase.ItemType == ItemType.Equipment
+                ShopSortFilter.Crystal => models.OrderByDescending(x => x.ItemBase.ItemType == ItemType.Equipment
                     ? CrystalCalculator.CalculateCrystal(
                             new[] {(Equipment) x.ItemBase},
                             false,

--- a/nekoyume/Assets/_Scripts/UI/Shop/SellView.cs
+++ b/nekoyume/Assets/_Scripts/UI/Shop/SellView.cs
@@ -2,11 +2,15 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Nekoyume.EnumType;
+using Nekoyume.Game;
+using Nekoyume.Helper;
 using Nekoyume.L10n;
-using Nekoyume.UI.Model;
+using Nekoyume.Model.Item;
+using Nekoyume.State;
 using Nekoyume.UI.Module;
 using TMPro;
 using UnityEngine;
+using ShopItem = Nekoyume.UI.Model.ShopItem;
 
 namespace Nekoyume
 {
@@ -123,6 +127,16 @@ namespace Nekoyume
                 ShopSortFilter.Price => models.OrderByDescending(x => x.OrderDigest.Price).ToList(),
                 ShopSortFilter.Class => models.OrderByDescending(x => x.Grade)
                     .ThenByDescending(x => x.ItemBase.ItemType).ToList(),
+                ShopSortFilter.CrystalPerNcg => models.OrderByDescending(x => x.ItemBase.ItemType == ItemType.Equipment
+                    ? CrystalCalculator.CalculateCrystal(
+                            new[] {(Equipment) x.ItemBase},
+                            false,
+                            TableSheets.Instance.CrystalEquipmentGrindingSheet,
+                            TableSheets.Instance.CrystalMonsterCollectionMultiplierSheet,
+                            States.Instance.StakingLevel).DivRem(x.OrderDigest.Price.MajorUnit)
+                        .Quotient
+                        .MajorUnit
+                    : 0),
                 _ => throw new ArgumentOutOfRangeException()
             };
         }


### PR DESCRIPTION
### Description

1. SSIA
2. `Crystal` sorting option: Sort shop items with Crystal per price

### Related Links

[샵 크리스탈 소팅 추가](https://www.notion.so/planetarium/7961a929ddfd4813ad97946f69333fc5#408310c593184f0aa8bdac679322271b)

### Required Reviewers

@planetarium/9c-dev 

### Screenshot

![image](https://user-images.githubusercontent.com/48484989/207238525-353f51a3-174e-4988-b648-fc83684edc42.png)
