### PR TITLE
Fix lifecycle of Bleed VFX

### DIFF
--- a/nekoyume/Assets/_Scripts/Game/Character/ArenaCharacter.cs
+++ b/nekoyume/Assets/_Scripts/Game/Character/ArenaCharacter.cs
@@ -127,7 +127,8 @@ namespace Nekoyume.Game.Character
             var removedVfx = new List<int>();
             foreach (var buff in _persistingVFXMap.Keys)
             {
-                if (!_characterModel.Buffs.Keys.Contains(buff))
+                if (_characterModel.IsDead ||
+                    !_characterModel.Buffs.Keys.Contains(buff))
                 {
                     _persistingVFXMap[buff].LazyStop();
                     removedVfx.Add(buff);
@@ -323,6 +324,12 @@ namespace Nekoyume.Game.Character
 
         private void AttachPersistingVFX(int groupId, BuffVFX vfx)
         {
+            if (_persistingVFXMap.TryGetValue(groupId, out var prevVFX))
+            {
+                prevVFX.LazyStop();
+                _persistingVFXMap.Remove(groupId);
+            }
+
             _persistingVFXMap[groupId] = vfx;
         }
 

--- a/nekoyume/Assets/_Scripts/Game/Character/CharacterBase.cs
+++ b/nekoyume/Assets/_Scripts/Game/Character/CharacterBase.cs
@@ -223,7 +223,8 @@ namespace Nekoyume.Game.Character
             var removedVfx = new List<int>();
             foreach (var buff in _persistingVFXMap.Keys)
             {
-                if (!CharacterModel.Buffs.Keys.Contains(buff))
+                if (CharacterModel.IsDead ||
+                    !CharacterModel.Buffs.Keys.Contains(buff))
                 {
                     _persistingVFXMap[buff].LazyStop();
                     removedVfx.Add(buff);
@@ -566,6 +567,12 @@ namespace Nekoyume.Game.Character
 
         private void AttachPersistingVFX(int groupId, BuffVFX vfx)
         {
+            if (_persistingVFXMap.TryGetValue(groupId, out var prevVFX))
+            {
+                prevVFX.LazyStop();
+                _persistingVFXMap.Remove(groupId);
+            }
+
             _persistingVFXMap[groupId] = vfx;
         }
 

--- a/nekoyume/Assets/_Scripts/Game/Character/RaidCharacter.cs
+++ b/nekoyume/Assets/_Scripts/Game/Character/RaidCharacter.cs
@@ -136,7 +136,8 @@ namespace Nekoyume.Game.Character
             var removedVfx = new List<int>();
             foreach (var buff in _persistingVFXMap.Keys)
             {
-                if (!Model.Buffs.Keys.Contains(buff))
+                if (Model.IsDead ||
+                    !Model.Buffs.Keys.Contains(buff))
                 {
                     _persistingVFXMap[buff].LazyStop();
                     removedVfx.Add(buff);
@@ -588,6 +589,12 @@ namespace Nekoyume.Game.Character
 
         private void AttachPersistingVFX(int groupId, BuffVFX vfx)
         {
+            if (_persistingVFXMap.TryGetValue(groupId, out var prevVFX))
+            {
+                prevVFX.LazyStop();
+                _persistingVFXMap.Remove(groupId);
+            }
+
             _persistingVFXMap[groupId] = vfx;
         }
 

--- a/nekoyume/Assets/_Scripts/Game/VFX/Skill/BuffVFX.cs
+++ b/nekoyume/Assets/_Scripts/Game/VFX/Skill/BuffVFX.cs
@@ -10,5 +10,15 @@ namespace Nekoyume.Game.VFX.Skill
 
         [field: SerializeField]
         public bool IsPersisting { get; set; } = false;
+
+        public override void Play()
+        {
+            base.Play();
+
+            if (IsPersisting)
+            {
+                _isPlaying = true;
+            }
+        }
     }
 }

--- a/nekoyume/Assets/_Scripts/Game/VFX/VFX.cs
+++ b/nekoyume/Assets/_Scripts/Game/VFX/VFX.cs
@@ -19,8 +19,8 @@ namespace Nekoyume.Game.VFX
         protected Renderer _rootRenderer = null;
         protected virtual float EmitDuration { get; set; } = 1.0f;
 
-        private bool _isPlaying = false;
-        private bool _isFinished = false;
+        protected bool _isPlaying = false;
+        protected bool _isFinished = false;
 
         [SerializeField]
         private bool _initializeSortingProbsOfChildren;


### PR DESCRIPTION
### Description

1. Fix lifecycle of Bleed VFX.

### How to test

1. Equip Fenrir bleed rune and enter a battle.
2. Cast bleed on same enemy twice and check if vfx is properly vanished.

### Related Links
[[룬] 펜리르 출혈의 룬이 적용된 몬스터가 사망할 경우 출혈 이펙트가 사라지지 않는 현상](https://app.asana.com/0/1133453747809944/1203506202018244)

### Required Reviewers
@planetarium/9c-dev 