### PR TITLE
Bugfix

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Module/Item/RuneSlotView.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/Item/RuneSlotView.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using Nekoyume.Game.Controller;
 using Nekoyume.Model.EnumType;
 using Nekoyume.Model.Rune;
+using Nekoyume.Model.State;
 using Nekoyume.State;
 using Nekoyume.TableData;
 
@@ -101,6 +102,27 @@ namespace Nekoyume.UI.Module
             }
         }
 
+        public void Set(
+            RuneSlot runeSlot,
+            RuneState runeState,
+            Action<RuneSlotView> onClick)
+        {
+            RuneSlot = runeSlot;
+            _onClick = onClick;
+            _onDoubleClick = null;
+            UpdateLoading(runeSlot);
+            UpdateLockState(runeSlot);
+            optionTagBg.gameObject.SetActive(false);
+            if (runeSlot.RuneId.HasValue)
+            {
+                Equip(runeState);
+            }
+            else
+            {
+                Unequip();
+            }
+        }
+
         private void UpdateLoading(RuneSlot runeSlot)
         {
             var value = LoadingHelper.UnlockRuneSlot.Any(x => x == runeSlot.Index);
@@ -160,6 +182,44 @@ namespace Nekoyume.UI.Module
             }
 
             enhancementText.text = $"+{state.Level}";
+            itemImage.enabled = true;
+            itemImage.overrideSprite = icon;
+            itemImage.SetNativeSize();
+
+            UpdateGrade(row);
+            UpdateOptionTag(option, row.Grade);
+        }
+
+        private void Equip(RuneState runeState)
+        {
+            if (runeState is null)
+            {
+                return;
+            }
+
+            if(!RuneFrontHelper.TryGetRuneIcon(runeState.RuneId, out var icon))
+            {
+                return;
+            }
+
+            var runeListSheet = Game.Game.instance.TableSheets.RuneListSheet;
+            if (!runeListSheet.TryGetValue(runeState.RuneId, out var row))
+            {
+                return;
+            }
+
+            var runeOptionSheet = Game.Game.instance.TableSheets.RuneOptionSheet;
+            if (!runeOptionSheet.TryGetValue(row.Id, out var optionRow))
+            {
+                return;
+            }
+
+            if (!optionRow.LevelOptionMap.TryGetValue(runeState.Level, out var option))
+            {
+                return;
+            }
+
+            enhancementText.text = $"+{runeState.Level}";
             itemImage.enabled = true;
             itemImage.overrideSprite = icon;
             itemImage.SetNativeSize();

--- a/nekoyume/Assets/_Scripts/UI/Module/Item/RuneSlots.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/Item/RuneSlots.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using Nekoyume.Model.Rune;
+using Nekoyume.Model.State;
 using UnityEngine;
 
 namespace Nekoyume.UI.Module
@@ -17,6 +19,23 @@ namespace Nekoyume.UI.Module
             foreach (var state in runeSlotStates)
             {
                 slots[state.Index].Set(state, onClick, onDoubleClick);
+            }
+        }
+
+        public void Set(
+            List<RuneSlot> runeSlotStates,
+            List<RuneState> runeStates,
+            System.Action<RuneSlotView> onClick)
+        {
+            foreach (var state in runeSlotStates)
+            {
+                RuneState runeState = null;
+                if (state.RuneId.HasValue)
+                {
+                    runeState = runeStates.FirstOrDefault(x => x.RuneId == state.RuneId.Value);
+                }
+
+                slots[state.Index].Set(state, runeState, onClick);
             }
         }
     }

--- a/nekoyume/Assets/_Scripts/UI/Widget/Popup/FriendInfoPopup.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Popup/FriendInfoPopup.cs
@@ -228,7 +228,7 @@ namespace Nekoyume.UI
             var runeSlot = _runes[battleType].GetRuneSlot();
             costumeSlots.SetPlayerCostumes(level, costumes, ShowTooltip, null);
             equipmentSlots.SetPlayerEquipments(level, equipments, ShowTooltip, null);
-            runeSlots.Set(runeSlot, ShowRuneTooltip, null);
+            runeSlots.Set(runeSlot, _runeStates,ShowRuneTooltip);
         }
 
         private void UpdateStatViews(AvatarState avatarState, BattleType battleType)


### PR DESCRIPTION
### Description

Fixed a bug where user rune information was incorrectly marked on the Arena board.

### Related Links

[[아레나] 다른 유저의 룬이 다르게 출력되는 현상](https://app.asana.com/0/1133453747809944/1203552523448195/f)

### Required Reviewers

@planetarium/9c-dev 

### Screenshot
![image](https://user-images.githubusercontent.com/40553495/207554414-dfc68891-507a-49e0-8b83-8df57bf1199c.png)
![image](https://user-images.githubusercontent.com/40553495/207554427-522ab1e5-2858-4684-9a0f-6e1faeaa86cf.png)
