### PR TITLE
[Bugfix] Persistenting vfx follow target position

### DIFF
--- a/nekoyume/Assets/_Scripts/Game/Character/ArenaCharacter.cs
+++ b/nekoyume/Assets/_Scripts/Game/Character/ArenaCharacter.cs
@@ -317,7 +317,7 @@ namespace Nekoyume.Game.Character
             if (effect.IsPersisting)
             {
                 target.AttachPersistingVFX(buff.BuffInfo.GroupId, effect);
-                StartCoroutine(BuffController.CoChaseTarget(effect, transform));
+                StartCoroutine(BuffController.CoChaseTarget(effect, target.transform));
             }
 
             target._characterModel = info.Target;

--- a/nekoyume/Assets/_Scripts/Game/Character/ArenaCharacter.cs
+++ b/nekoyume/Assets/_Scripts/Game/Character/ArenaCharacter.cs
@@ -317,6 +317,7 @@ namespace Nekoyume.Game.Character
             if (effect.IsPersisting)
             {
                 target.AttachPersistingVFX(buff.BuffInfo.GroupId, effect);
+                StartCoroutine(BuffController.CoChaseTarget(effect, transform));
             }
 
             target._characterModel = info.Target;

--- a/nekoyume/Assets/_Scripts/Game/Character/CharacterBase.cs
+++ b/nekoyume/Assets/_Scripts/Game/Character/CharacterBase.cs
@@ -558,6 +558,7 @@ namespace Nekoyume.Game.Character
                 if (effect.IsPersisting)
                 {
                     target.AttachPersistingVFX(buff.BuffInfo.GroupId, effect);
+                    StartCoroutine(BuffController.CoChaseTarget(effect, transform));
                 }
 
                 target.UpdateHpBar();

--- a/nekoyume/Assets/_Scripts/Game/Character/CharacterBase.cs
+++ b/nekoyume/Assets/_Scripts/Game/Character/CharacterBase.cs
@@ -558,7 +558,7 @@ namespace Nekoyume.Game.Character
                 if (effect.IsPersisting)
                 {
                     target.AttachPersistingVFX(buff.BuffInfo.GroupId, effect);
-                    StartCoroutine(BuffController.CoChaseTarget(effect, transform));
+                    StartCoroutine(BuffController.CoChaseTarget(effect, target.transform));
                 }
 
                 target.UpdateHpBar();

--- a/nekoyume/Assets/_Scripts/Game/Character/RaidCharacter.cs
+++ b/nekoyume/Assets/_Scripts/Game/Character/RaidCharacter.cs
@@ -581,7 +581,7 @@ namespace Nekoyume.Game.Character
             if (effect.IsPersisting)
             {
                 target.AttachPersistingVFX(buff.BuffInfo.GroupId, effect);
-                StartCoroutine(BuffController.CoChaseTarget(effect, transform));
+                StartCoroutine(BuffController.CoChaseTarget(effect, target.transform));
             }
 
             target.AddNextBuff(buff);

--- a/nekoyume/Assets/_Scripts/Game/Character/RaidCharacter.cs
+++ b/nekoyume/Assets/_Scripts/Game/Character/RaidCharacter.cs
@@ -581,6 +581,7 @@ namespace Nekoyume.Game.Character
             if (effect.IsPersisting)
             {
                 target.AttachPersistingVFX(buff.BuffInfo.GroupId, effect);
+                StartCoroutine(BuffController.CoChaseTarget(effect, transform));
             }
 
             target.AddNextBuff(buff);

--- a/nekoyume/Assets/_Scripts/Game/VFX/Skill/BuffController.cs
+++ b/nekoyume/Assets/_Scripts/Game/VFX/Skill/BuffController.cs
@@ -1,6 +1,7 @@
 using Nekoyume.Game.Character;
 using Nekoyume.Game.Util;
 using Nekoyume.Model.Buff;
+using System.Collections;
 using UnityEngine;
 
 namespace Nekoyume.Game.VFX.Skill
@@ -112,6 +113,18 @@ namespace Nekoyume.Game.VFX.Skill
                      _pool.Get(resourceName, true, position);
 
             return GetEffect<T>(go);
+        }
+
+        public static IEnumerator CoChaseTarget(Component vfx, Transform target)
+        {
+            var g = vfx.gameObject;
+            var t = vfx.transform;
+            while (g.activeSelf &&
+                   target)
+            {
+                t.position = target.position + new Vector3(0f, 0.55f, 0f);
+                yield return null;
+            }
         }
     }
 }


### PR DESCRIPTION
### How to test

1. Enter raid battle with damage reduction rune (optional) and enough gears to pass wave 1.
2. When wave 1 defeated, check if damage reduction buff vfx or bleed vfx follows character properly.

### Related Links

### Required Reviewers
@planetarium/devops 
