### PR TITLE
Fix gold to be updated after purchasing event dungeon tickets

### DIFF
--- a/nekoyume/Assets/_Scripts/BlockChain/ActionRenderHandler.cs
+++ b/nekoyume/Assets/_Scripts/BlockChain/ActionRenderHandler.cs
@@ -1458,6 +1458,8 @@ namespace Nekoyume.BlockChain
             await Task.WhenAll(
                 States.Instance.UpdateItemSlotStates(BattleType.Adventure),
                 States.Instance.UpdateRuneSlotStates(BattleType.Adventure));
+            UpdateAgentStateAsync(eval).Forget();
+
             _disposableForBattleEnd?.Dispose();
             _disposableForBattleEnd =
                 Game.Game.instance.Stage.onEnterToStageEnd


### PR DESCRIPTION
### Description

Fix gold to be updated after purchasing event dungeon tickets

### Related Links

[이벤트 던전 추가 티켓 구매시 NCG 갱신 안되는 현상](https://app.asana.com/0/1133453747809944/1203605612434782/f)
