### PR TITLE
Fix cost text in TicketPurchasePopup

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Widget/Popup/ArenaTicketPurchasePopup.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Popup/ArenaTicketPurchasePopup.cs
@@ -110,9 +110,7 @@ namespace Nekoyume.UI
 
             remainingContainer.SetActive(false);
             costContainer.SetActive(true);
-            costText.text = cost.MinorUnit > 0
-                ? $"{cost.MajorUnit:#,0}.{cost.MinorUnit}"
-                : $"{cost.MajorUnit:#,0}";
+            costText.text = cost.GetQuantityString();
             costText.color = enoughBalance
                 ? Color.white
                 : Palette.GetColor(EnumType.ColorType.ButtonDisabled);

--- a/nekoyume/Assets/_Scripts/UI/Widget/Popup/TicketPurchasePopup.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Popup/TicketPurchasePopup.cs
@@ -88,9 +88,7 @@ namespace Nekoyume.UI
             var enoughBalance = balance >= cost;
 
             costContainer.SetActive(true);
-            costText.text = cost.MinorUnit > 0
-                ? $"{cost.MajorUnit:#,0}.{cost.MinorUnit}"
-                : $"{cost.MajorUnit:#,0}";
+            costText.text = cost.GetQuantityString();
             costText.color = enoughBalance
                 ? Color.white
                 : Palette.GetColor(EnumType.ColorType.ButtonDisabled);


### PR DESCRIPTION
### Description

SSIA

### Related Links

[티켓 구매 팝업에서 Cost인 0.05NCG가 0.5NCG로 표시됨](https://app.asana.com/0/1141562434100787/1203616987717568/f)

### Screenshot

**Before**
In practice, normal cost(0.05) are used..
![image](https://user-images.githubusercontent.com/63496908/209925401-c00aec67-c709-481c-9d56-915bcf4e9d3d.png)
![image](https://user-images.githubusercontent.com/63496908/209924894-25dacbf2-61c8-478a-8704-6ec5380f306e.png)

**After**
![image](https://user-images.githubusercontent.com/63496908/209924949-7f3bbde2-49a4-4b36-a362-cf25c292f299.png)

