### PR TITLE
Fix combo text not reset

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/ComboText.cs
+++ b/nekoyume/Assets/_Scripts/UI/ComboText.cs
@@ -1,10 +1,8 @@
 ﻿using System.Collections;
-using System.Collections.Generic;
 using TMPro;
 using UnityEngine;
 using UniRx;
 using DG.Tweening;
-using UnityEngine.UI;
 
 namespace Nekoyume.UI
 {
@@ -98,6 +96,7 @@ namespace Nekoyume.UI
 
         public void Close()
         {
+            _combo = 0;
             gameObject.SetActive(false);
         }
     }


### PR DESCRIPTION
### Description

Fix ComboText to initialize at the start of the battle

### Related Links

[전투에서 콤보 숫자가 다음 세션에서도 지속되는 문제 (최초 공격이 2콤보나 3콤보부터 시작하는 등의 현상)](https://app.asana.com/0/1141562434100787/1198998806481877/f)

### Screenshot

Fixed...
![combotext](https://user-images.githubusercontent.com/63496908/210501939-90f4f5be-c5d8-4d1a-a8e2-c6f1385291a2.gif)
