### PR TITLE
Minimize Sentry SampleRate only for errors

### DIFF
--- a/nekoyume/Assets/_Scripts/SentryOptionsConfiguration.cs
+++ b/nekoyume/Assets/_Scripts/SentryOptionsConfiguration.cs
@@ -19,7 +19,7 @@ public class SentryOptionsConfiguration : ScriptableOptionsConfiguration
         var _options = CommandLineOptions.Load(
             CommandLineOptionsJsonPath
         );
-        options.SampleRate = _options.SentrySampleRate > 0 ? (float) _options.SentrySampleRate : 0.01f;
+        options.SampleRate = 0.01f;
         options.TracesSampleRate = _options.SentrySampleRate;
         options.AddExceptionFilterForType<NullReferenceException>();
     }


### PR DESCRIPTION
### Description
Minimize Sentry SampleRate only for errors because it sends too many errors so that we cannot raise sample rates for more traces
