### PR TITLE
Add condition to `EventReleaseNotePopup.Show()` about tutorial

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Widget/Popup/EventReleaseNotePopup.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Popup/EventReleaseNotePopup.cs
@@ -125,6 +125,11 @@ namespace Nekoyume.UI
 
         public override void Show(bool ignoreShowAnimation = false)
         {
+            if (!Game.Game.instance.Stage.TutorialController.IsCompleted)
+            {
+                return;
+            }
+
             var hasUnreadContents = NoticeManager.instance.HasUnreadEvent ||
                                     NoticeManager.instance.HasUnreadNotice;
             var notReadAtToday = true;


### PR DESCRIPTION
### Description

1. SSIA
2. Prevents event popup showing when the tutorial is not finished.

### Related Links

[튜토리얼 해야하는데 이벤트 배너 팝업 나옴](https://app.asana.com/0/1141562434100787/1203670290382034/f)

### Required Reviewers

@planetarium/9c-dev 

### Screenshot

![image](https://user-images.githubusercontent.com/48484989/212055318-2259b3d4-2d06-4b14-8f5a-55f481f6509d.png)
