### PR TITLE
Fix if statement about skipSynopsys

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Widget/Screen/PreloadingScreen.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Screen/PreloadingScreen.cs
@@ -49,23 +49,21 @@ namespace Nekoyume.UI
             if (!GameConfig.IsEditor)
             {
                 if (States.Instance.AgentState.avatarAddresses.Any() &&
-                    States.Instance.AvatarStates.Any(x => x.Value.level > 49))
+                    States.Instance.AvatarStates.Any(x => x.Value.level > 49) &&
+                    Util.TryGetStoredAvatarSlotIndex(out var si))
                 {
-                    if (Util.TryGetStoredAvatarSlotIndex(out var si))
-                    {
-                        var loadingScreen = Find<DataLoadingScreen>();
-                        loadingScreen.Message = L10nManager.Localize("UI_LOADING_BOOTSTRAP_START");
-                        loadingScreen.Show();
-                        await RxProps.SelectAvatarAsync(si);
-                        await WorldBossStates.Set(States.Instance.CurrentAvatarState.address);
-                        await States.Instance.InitRuneStoneBalance();
-                        await States.Instance.InitRuneStates();
-                        await States.Instance.InitRuneSlotStates();
-                        await States.Instance.InitItemSlotStates();
-                        loadingScreen.Close();
-                        Game.Event.OnRoomEnter.Invoke(false);
-                        Game.Event.OnUpdateAddresses.Invoke();
-                    }
+                    var loadingScreen = Find<DataLoadingScreen>();
+                    loadingScreen.Message = L10nManager.Localize("UI_LOADING_BOOTSTRAP_START");
+                    loadingScreen.Show();
+                    await RxProps.SelectAvatarAsync(si);
+                    await WorldBossStates.Set(States.Instance.CurrentAvatarState.address);
+                    await States.Instance.InitRuneStoneBalance();
+                    await States.Instance.InitRuneStates();
+                    await States.Instance.InitRuneSlotStates();
+                    await States.Instance.InitItemSlotStates();
+                    loadingScreen.Close();
+                    Game.Event.OnRoomEnter.Invoke(false);
+                    Game.Event.OnUpdateAddresses.Invoke();
                 }
                 else
                 {


### PR DESCRIPTION
### Description

1. SSIA, Invoke `Find<Synopsis>().Show()` when get false from `Util.TryGetStoredAvatarSlotIndex()`.

### How to test

1. Remove registry.
2. Execute game with active agent.

### Related Links

https://github.com/planetarium/NineChronicles/issues/2336

### Required Reviewers

@planetarium/9c-dev 