### PR TITLE
Fix/rpc-reconnection

### DIFF
--- a/nekoyume/Assets/_Scripts/BlockChain/RPCAgent.cs
+++ b/nekoyume/Assets/_Scripts/BlockChain/RPCAgent.cs
@@ -560,10 +560,18 @@ namespace Nekoyume.BlockChain
                     Debug.LogWarning($"TimeoutException occurred. Retrying... {retryCount}\n{toe}");
                     retryCount--;
                 }
-                catch (RpcException re)
+                catch (AggregateException ae)
                 {
-                    Debug.LogWarning($"RpcException occurred. Retrying... {retryCount}\n{re}");
-                    retryCount--;
+                    if (ae.InnerException is RpcException re)
+                    {
+                        Debug.LogWarning($"RpcException occurred. Retrying... {retryCount}\n{re}");
+                        retryCount--;
+                    }
+                    else
+                    {
+                        Debug.LogWarning($"Unexpected error occurred during rpc connection. {ae}");
+                        break;
+                    }
                 }
                 catch (ObjectDisposedException ode)
                 {

--- a/nekoyume/Assets/_Scripts/BlockChain/RPCAgent.cs
+++ b/nekoyume/Assets/_Scripts/BlockChain/RPCAgent.cs
@@ -43,7 +43,7 @@ namespace Nekoyume.BlockChain
 
     public class RPCAgent : MonoBehaviour, IAgent, IActionEvaluationHubReceiver
     {
-        private const int RpcConnectionRetryCount = 10;
+        private const int RpcConnectionRetryCount = 20;
         private const float TxProcessInterval = 1.0f;
         private readonly ConcurrentQueue<NCAction> _queuedActions = new ConcurrentQueue<NCAction>();
 


### PR DESCRIPTION
### Description

1. Problems to solve.
The client does not seem to catch `RpcExceptions` when trying to reconnect to an RPC node.

3. Cause
The `RpcException` was actually being thrown as an `innerException` value within the `AggregateException`. 

4. Fix
- The retry logic is updated to catch the `AggregateException` before handling the `RpcException`.
- The retry attempt is increased from 10 to 20 to better ensure a successful reconnection.

