### PR TITLE
Fix craft recipe scroll

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Scroller/RecipeRow.cs
+++ b/nekoyume/Assets/_Scripts/UI/Scroller/RecipeRow.cs
@@ -102,14 +102,19 @@ namespace Nekoyume.UI.Scroller
             canvasGroup.alpha = 0f;
         }
 
-        public void ShowAnimation()
+        public void ShowWithAlpha(bool ignoreShowAnimation = false)
         {
-            if (!gameObject.activeSelf)
+            if (!gameObject.activeSelf && !ignoreShowAnimation)
             {
                 return;
             }
 
             canvasGroup.alpha = 1f;
+            if (ignoreShowAnimation)
+            {
+                return;
+            }
+
             animator.SetTrigger(_triggerHash);
         }
     }

--- a/nekoyume/Assets/_Scripts/UI/Scroller/RecipeScroll.cs
+++ b/nekoyume/Assets/_Scripts/UI/Scroller/RecipeScroll.cs
@@ -449,6 +449,11 @@ namespace Nekoyume.UI.Scroller
             if (_animationCoroutine != null)
             {
                 StopCoroutine(_animationCoroutine);
+                var rows = GetComponentsInChildren<RecipeRow>(true);
+                foreach (var row in rows)
+                {
+                    row.ShowWithAlpha(true);
+                }
             }
 
             _animationCoroutine = StartCoroutine(CoAnimateScroller());
@@ -470,7 +475,7 @@ namespace Nekoyume.UI.Scroller
 
             foreach (var row in rows)
             {
-                row.ShowAnimation();
+                row.ShowWithAlpha();
                 yield return wait;
             }
 


### PR DESCRIPTION
### Description

Fix craft recipe scroll error when show by QuestGuide

### How to test

1. Enter Craft ui twice by QuestGuide

### Related Links

[[가이드퀘스트] 이벤트 탭 클릭 후 가이트 퀘스트 진입 시 하단의 레시피가 출력되지 않는 현상](https://app.asana.com/0/1133453747809944/1204036280897303/f)