### PR TITLE
fix: `Game.CachedBalance` bug.

### DIFF
--- a/nekoyume/Assets/_Scripts/BlockChain/ActionHandler.cs
+++ b/nekoyume/Assets/_Scripts/BlockChain/ActionHandler.cs
@@ -4,6 +4,7 @@ using Cysharp.Threading.Tasks;
 using Lib9c.Renderers;
 using Libplanet;
 using Libplanet.Assets;
+using LruCacheNet;
 using Nekoyume.Action;
 using Nekoyume.Extensions;
 using Nekoyume.Game;
@@ -258,10 +259,19 @@ namespace Nekoyume.BlockChain
 
         private static void UpdateGoldBalanceState(GoldBalanceState goldBalanceState)
         {
+            var game = Game.Game.instance;
             if (goldBalanceState is { } &&
-                Game.Game.instance.Agent.Address.Equals(goldBalanceState.address))
+                game.Agent.Address.Equals(goldBalanceState.address))
             {
-                Game.Game.instance.CachedBalance[goldBalanceState.address] = goldBalanceState.Gold;
+                var currency = goldBalanceState.Gold.Currency;
+                if (!game.CachedBalance.ContainsKey(currency))
+                {
+                    game.CachedBalance[currency] =
+                        new LruCache<Address, FungibleAssetValue>(2);
+                }
+
+                game.CachedBalance[currency][goldBalanceState.address] =
+                    goldBalanceState.Gold;
             }
 
             States.Instance.SetGoldBalanceState(goldBalanceState);

--- a/nekoyume/Assets/_Scripts/Game/Game.cs
+++ b/nekoyume/Assets/_Scripts/Game/Game.cs
@@ -89,12 +89,11 @@ namespace Nekoyume.Game
         public NineChroniclesAPIClient ApiClient => _apiClient;
         public NineChroniclesAPIClient RpcClient => _rpcClient;
 
-        public readonly LruCache<Address, IValue> CachedStates = new LruCache<Address, IValue>();
+        public readonly LruCache<Address, IValue> CachedStates = new();
+        public readonly Dictionary<Address, bool> CachedStateAddresses = new();
 
-        public readonly LruCache<Address, FungibleAssetValue> CachedBalance =
-            new LruCache<Address, FungibleAssetValue>(2);
-
-        public readonly Dictionary<Address, bool> CachedAddresses = new Dictionary<Address, bool>();
+        public readonly Dictionary<Currency, LruCache<Address, FungibleAssetValue>>
+            CachedBalance = new();
 
         private CommandLineOptions _options;
 


### PR DESCRIPTION
When we save a balance(i.e., FungibleAssetValue), it may have the same `Address` but a different `Currency`.
Make the `Game.CachedBalance` consider this.
