### PR TITLE
Fix pet animation at worldboss

### DIFF
--- a/nekoyume/Assets/_Scripts/Game/Character/Pet.cs
+++ b/nekoyume/Assets/_Scripts/Game/Character/Pet.cs
@@ -16,8 +16,8 @@ namespace Nekoyume.Game.Character
         public PetAnimator Animator { get; private set; }
 
         private BoneFollower _boneFollower;
-        private Coroutine _coroutine;
-
+        private Coroutine _playSpecialCoroutine;
+        private Coroutine _delayedPlayCoroutine;
 
         private void Awake()
         {
@@ -79,12 +79,13 @@ namespace Nekoyume.Game.Character
 
             Animator.ResetTarget(go);
 
-            if (_coroutine != null)
+            if (_playSpecialCoroutine != null)
             {
-                StopCoroutine(_coroutine);
+                StopCoroutine(_playSpecialCoroutine);
+                _playSpecialCoroutine = null;
             }
 
-            _coroutine = StartCoroutine(CoPlaySpecial());
+            _playSpecialCoroutine = StartCoroutine(CoPlaySpecial());
         }
 
         private IEnumerator CoPlaySpecial()
@@ -95,6 +96,29 @@ namespace Nekoyume.Game.Character
 
                 Animator.Play(PetAnimation.Type.Special);
             }
+        }
+
+        public void DelayedPlay(PetAnimation.Type type, float time = 0f)
+        {
+            if (time <= 0)
+            {
+                Animator.Play(type);
+                return;
+            }
+
+            if (_delayedPlayCoroutine != null)
+            {
+                StopCoroutine(_delayedPlayCoroutine);
+                _delayedPlayCoroutine = null;
+            }
+
+            _delayedPlayCoroutine = StartCoroutine(CoDelayedPlay(type, time));
+        }
+
+        private IEnumerator CoDelayedPlay(PetAnimation.Type type, float time)
+        {
+            yield return new WaitForSeconds(time);
+            Animator.Play(type);
         }
 
         [ContextMenu("Spawn Pet")]

--- a/nekoyume/Assets/_Scripts/Game/RaidStage.cs
+++ b/nekoyume/Assets/_Scripts/Game/RaidStage.cs
@@ -210,8 +210,8 @@ namespace Nekoyume.Game
             _wave = 0;
             _currentScore = 0;
 
+            _player.Pet.DelayedPlay(Character.PetAnimation.Type.BattleStart, 2.5f);
             yield return StartCoroutine(container.CoPlayAppearCutscene());
-            _player.Pet.Animator.Play(Character.PetAnimation.Type.BattleStart);
             _boss.Animator.Idle();
         }
 


### PR DESCRIPTION
### Description

- Fix pet animation in worldboss
  - to sync it with character animation of appear cutscene
  - it was written in hardcoding...

### Related Links

[[펫] 월드보스 전투 연출에서 Battle Start 모션이 출력되지 않는 현상](https://app.asana.com/0/1133453747809944/1204172051496798/f)
