### PR TITLE
Fix rune display

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Model/RuneItem.cs
+++ b/nekoyume/Assets/_Scripts/UI/Model/RuneItem.cs
@@ -37,6 +37,14 @@ namespace Nekoyume.UI.Model
 
             IsMaxLevel = level == optionRow.LevelOptionMap.Count;
 
+            var runeRow = Game.Game.instance.TableSheets.RuneSheet[row.Id];
+            if (!States.Instance.AvatarBalance.ContainsKey(runeRow.Ticker))
+            {
+                return;
+            }
+
+            RuneStone = States.Instance.AvatarBalance[runeRow.Ticker];
+
             var costSheet = Game.Game.instance.TableSheets.RuneCostSheet;
             if (!costSheet.TryGetValue(row.Id, out var costRow))
             {
@@ -55,13 +63,6 @@ namespace Nekoyume.UI.Model
                 return;
             }
 
-            var runeRow = Game.Game.instance.TableSheets.RuneSheet[row.Id];
-            if (!States.Instance.AvatarBalance.ContainsKey(runeRow.Ticker))
-            {
-                return;
-            }
-
-            RuneStone = States.Instance.AvatarBalance[runeRow.Ticker];
             EnoughRuneStone = RuneStone.MajorUnit >= Cost.RuneStoneQuantity;
             EnoughCrystal = States.Instance.CrystalBalance.MajorUnit >= Cost.CrystalQuantity;
             EnoughNcg = States.Instance.GoldBalanceState.Gold.MajorUnit >= Cost.NcgQuantity;


### PR DESCRIPTION
### Description

I changed the maximum level of Adventure Runes to 2 and tested it.


### Screenshot
![max level](https://user-images.githubusercontent.com/40553495/226632045-3b2e70f4-655c-4f74-9193-813fc7ea5834.png)


### Related Links

[[공방] 최대 레벨의 룬 선택 시 보유 룬조각이 0개로 출력되는 현상](https://app.asana.com/0/1133453747809944/1204061585905560/f)