### PR TITLE
Fix prologue

### DIFF
--- a/nekoyume/Assets/_Scripts/Game/Character/PrologueCharacter.cs
+++ b/nekoyume/Assets/_Scripts/Game/Character/PrologueCharacter.cs
@@ -242,10 +242,11 @@ namespace Nekoyume.Game.Character
             var effect = Game.instance.Stage.objectPool.Get<FenrirSkillVFX>(position);
             effect.Stop();
             AudioController.instance.PlaySfx(AudioController.SfxCode.FenrirGrowlSkill);
-            yield return new WaitForSeconds(1f);
+            yield return new WaitForSeconds(2f);
             Animator.Skill();
             ActionCamera.instance.Shake();
-            yield return new WaitUntil(() => AttackEndCalled);
+            var time = Time.time;
+            yield return new WaitUntil(() => AttackEndCalled || Time.time - time > 1f);
             for (var i = 0; i < 2; i++)
             {
                 var first = i == 0;


### PR DESCRIPTION
### Description

Fixed an issue where the Fenrir Finisher skill was not activating properly. Additionally, a forced activation logic has been implemented.

### Related Links

[시놉시스에서 캐릭터 스파인 나올때(시놉시스16, 17~) 전체 파츠 이어진 스파인 파일 없어서 진행 불가](https://app.asana.com/0/1133453747809944/1204009886813855/f)