### PR TITLE
introduce fillWithNullToEmptyCellGroup

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Scroller/GridScroll.cs
+++ b/nekoyume/Assets/_Scripts/UI/Scroller/GridScroll.cs
@@ -29,6 +29,9 @@ namespace Nekoyume.UI.Scroller
         [SerializeField]
         private bool fillWithNullToEmptyViewport = default;
 
+        [SerializeField]
+        private bool fillWithNullToEmptyCellGroup;
+
         protected abstract FancyCell<TItemData, TContext> CellTemplate { get; }
 
         protected override void SetupCellTemplate() => Setup<TCellGroup>(CellTemplate);
@@ -98,6 +101,16 @@ namespace Nekoyume.UI.Scroller
                 var cellCountInGroup = Context.GetGroupCount();
                 var cellCount = cellGroupCount * cellCountInGroup;
                 var addCount = math.max(0, cellCount - itemsSource.Count);
+                for (var i = 0; i < addCount; i++)
+                {
+                    itemsSource.Add(null);
+                }
+            }
+
+            if (fillWithNullToEmptyCellGroup)
+            {
+                var cellCountInGroup = Context.GetGroupCount();
+                var addCount = cellCountInGroup - itemsSource.Count % cellCountInGroup;
                 for (var i = 0; i < addCount; i++)
                 {
                     itemsSource.Add(null);


### PR DESCRIPTION
### Description

1. introduce `fillWithNullToEmptyCellGroup` to `GridScroll`
2. It fills null to empty cell group.

### Required Reviewers

@planetarium/9c-dev 

### Screenshot

not use(count 10):
![image](https://user-images.githubusercontent.com/48484989/228712743-ac5f4a8b-3937-4da9-9f6b-f217f0b38935.png)
use(count 10):
![image](https://user-images.githubusercontent.com/48484989/228712866-a3f03c80-1e4f-41fe-9f33-5d131634ffbc.png)

![image](https://user-images.githubusercontent.com/48484989/228713458-09283c44-4475-4660-ad03-45d191510525.png)
