### PR TITLE
Use Addresses in AddressToolWindow

### DIFF
--- a/nekoyume/Assets/Planetarium/Nekoyume/Editor/AddressToolWindow.cs
+++ b/nekoyume/Assets/Planetarium/Nekoyume/Editor/AddressToolWindow.cs
@@ -1,6 +1,8 @@
 using System.Globalization;
 using System.Linq;
+using System.Reflection;
 using Libplanet;
+using Nekoyume;
 using Nekoyume.Action;
 using Nekoyume.Game;
 using Nekoyume.Model.Arena;
@@ -13,7 +15,12 @@ namespace Planetarium.Nekoyume.Editor
 {
     public class AddressToolWindow : EditorWindow
     {
+        private static (string name, Address addr, string addrStr)[] _addresses;
+        private static GUIContent[] _addressesContents;
+
         //
+        private bool _useAddressesAsOriginal;
+        private int _selectedIndexOfAddresses;
         private string _originalAddr;
         private string _deriveKey;
         private string _derivedAddr;
@@ -43,6 +50,20 @@ namespace Planetarium.Nekoyume.Editor
                 .Show();
         }
 
+        private void OnEnable()
+        {
+            _addresses = typeof(Addresses).GetFields(BindingFlags.Public | BindingFlags.Static)
+                .Where(fi => fi.FieldType == typeof(Address))
+                .Select(fi =>
+                {
+                    var addr = (Address)fi.GetValue(null);
+                    return (fi.Name, addr, addr.ToString());
+                })
+                .ToArray();
+            _addressesContents = _addresses.Select(tuple =>
+                new GUIContent($"{tuple.name}:  {tuple.addrStr}")).ToArray();
+        }
+
         private void OnGUI()
         {
             DrawArea1();
@@ -52,9 +73,24 @@ namespace Planetarium.Nekoyume.Editor
         private void DrawArea1()
         {
             GUILayout.Label("Derive Address", EditorStyles.boldLabel);
-            _originalAddr = ToHex(EditorGUILayout.TextField(
-                "Original Address",
-                _originalAddr));
+            _useAddressesAsOriginal = EditorGUILayout.Toggle(
+                "Use Addresses as Original",
+                _useAddressesAsOriginal);
+            if (_useAddressesAsOriginal)
+            {
+                _selectedIndexOfAddresses = EditorGUILayout.Popup(
+                    new GUIContent("Original Address"),
+                    _selectedIndexOfAddresses,
+                    _addressesContents);
+                _originalAddr = _addresses[_selectedIndexOfAddresses].addrStr;
+            }
+            else
+            {
+                _originalAddr = EditorGUILayout.TextField(
+                    "Original Address",
+                    _originalAddr);
+            }
+
             _deriveKey = EditorGUILayout.TextField("Derive Key", _deriveKey);
 
             if (!string.IsNullOrEmpty(_originalAddr) &&
@@ -73,7 +109,7 @@ namespace Planetarium.Nekoyume.Editor
                 }
 
                 var derivedAddr = originalAddr.Derive(_deriveKey);
-                _derivedAddr = derivedAddr.ToHex();
+                _derivedAddr = derivedAddr.ToString();
             }
 
             CopyableLabelField("Derived Address", _derivedAddr);
@@ -90,15 +126,15 @@ namespace Planetarium.Nekoyume.Editor
                 Game.instance.IsInitialized &&
                 Game.instance.Agent is { })
             {
-                _agentAddr = Game.instance.Agent.Address.ToHex();
+                _agentAddr = Game.instance.Agent.Address.ToString();
                 DeriveAvatarAddresses();
             }
 
             EditorGUI.EndDisabledGroup();
             EditorGUILayout.BeginHorizontal();
-            _agentAddr = ToHex(EditorGUILayout.TextField(
+            _agentAddr = EditorGUILayout.TextField(
                 "Agent Address",
-                _agentAddr));
+                _agentAddr);
 
             if (GUILayout.Button("Derive", GUILayout.Width(50)) &&
                 !string.IsNullOrEmpty(_agentAddr))
@@ -159,18 +195,6 @@ namespace Planetarium.Nekoyume.Editor
             EditorGUILayout.EndHorizontal();
         }
 
-        private static string ToHex(string hexString)
-        {
-            if (string.IsNullOrEmpty(hexString))
-            {
-                return hexString;
-            }
-
-            return hexString.StartsWith("0x")
-                ? hexString[2..]
-                : hexString;
-        }
-
         private void DeriveAvatarAddresses()
         {
             try
@@ -190,27 +214,27 @@ namespace Planetarium.Nekoyume.Editor
                     i)))
                 .ToArray();
             _avatarAddrArr = _avatarAddresses
-                .Select(addr => addr.ToHex())
+                .Select(addr => addr.ToString())
                 .ToArray();
             _avatarAddrIndexes = _avatarAddrArr
                 .Select((_, index) => index.ToString())
                 .ToArray();
             _selectedAvatarIndex = 0;
             _inventoryAddrArr = _avatarAddresses
-                .Select(addr => addr.Derive(LegacyInventoryKey).ToHex())
+                .Select(addr => addr.Derive(LegacyInventoryKey).ToString())
                 .ToArray();
             _worldInformationAddrArr = _avatarAddresses
-                .Select(addr => addr.Derive(LegacyWorldInformationKey).ToHex())
+                .Select(addr => addr.Derive(LegacyWorldInformationKey).ToString())
                 .ToArray();
             _questListAddrArr = _avatarAddresses
-                .Select(addr => addr.Derive(LegacyQuestListKey).ToHex())
+                .Select(addr => addr.Derive(LegacyQuestListKey).ToString())
                 .ToArray();
             _workshopSlotAddrArr = _avatarAddresses
                 .Select(addr => Enumerable.Range(0, AvatarState.CombinationSlotCapacity)
                     .Select(i => addr.Derive(string.Format(
                         CultureInfo.InvariantCulture,
                         CombinationSlotState.DeriveFormat,
-                        i)).ToHex())
+                        i)).ToString())
                     .ToArray())
                 .ToArray();
 
@@ -225,13 +249,13 @@ namespace Planetarium.Nekoyume.Editor
                 .Select(addr => ArenaInformation.DeriveAddress(
                     addr,
                     _championshipId,
-                    _round).ToHex())
+                    _round).ToString())
                 .ToArray();
             _arenaScoreAddrArr = _avatarAddresses
                 .Select(addr => ArenaScore.DeriveAddress(
                     addr,
                     _championshipId,
-                    _round).ToHex())
+                    _round).ToString())
                 .ToArray();
         }
     }


### PR DESCRIPTION
- Add `Use Addresses as Original` toggle.

<img width="558" alt="image" src="https://user-images.githubusercontent.com/6128868/230880856-254df431-8eae-4c23-baae-74856914fe5d.png">

- The `Original Address` UI will be changed when you toggled on the toggle.

<img width="563" alt="image" src="https://user-images.githubusercontent.com/6128868/230880911-e62ff909-f61a-4081-beed-4585e893ffab.png">

- Let's select the Blacksmith address.

<img width="628" alt="image" src="https://user-images.githubusercontent.com/6128868/230880965-4beb32e8-708d-46d4-b984-8b5f77a6346b.png">

- And derive some item address.

<img width="558" alt="image" src="https://user-images.githubusercontent.com/6128868/230881011-44062313-f0a7-437d-97ab-329865f02822.png">
