### PR TITLE
change logic of `EventReleaseNotePopup.Show()`

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Tutorial/TutorialController.cs
+++ b/nekoyume/Assets/_Scripts/UI/Tutorial/TutorialController.cs
@@ -28,19 +28,6 @@ namespace Nekoyume.UI
 
         public bool IsPlaying => _tutorial.IsActive();
 
-        public bool IsCompleted
-        {
-            get
-            {
-                var worldInfo = Game.Game.instance.States.CurrentAvatarState.worldInformation;
-                if (worldInfo is null) return false;
-                var clearedStageId = worldInfo.TryGetLastClearedStageId(out var id) ? id : 1;
-                if (GetCheckPoint(clearedStageId) != 0) return false;
-
-                return !IsPlaying;
-            }
-        }
-
         public TutorialController(IEnumerable<Widget> widgets)
         {
             foreach (var widget in widgets)

--- a/nekoyume/Assets/_Scripts/UI/Widget/Popup/EventReleaseNotePopup.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Popup/EventReleaseNotePopup.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using Nekoyume.Game.LiveAsset;
+using Nekoyume.State;
 using Nekoyume.UI.Model;
 using Nekoyume.UI.Module;
 using UnityEngine;
@@ -125,7 +126,14 @@ namespace Nekoyume.UI
 
         public override void Show(bool ignoreShowAnimation = false)
         {
-            if (!Game.Game.instance.Stage.TutorialController.IsCompleted)
+            var worldInfo = States.Instance.CurrentAvatarState?.worldInformation;
+            if (worldInfo is null)
+            {
+                return;
+            }
+
+            var clearedStageId = worldInfo.TryGetLastClearedStageId(out var id) ? id : 1;
+            if (clearedStageId <= GameConfig.RequireClearedStageLevel.CombinationEquipmentAction)
             {
                 return;
             }


### PR DESCRIPTION
### Description

1. remove `TutorialController.IsCompleted`. This is a meaningless code.
2. change logic of `EventReleaseNotePopup.Show()`. Check world information, not PlayerPrefs.

### Related Links

[튜토리얼 도중에 공지사항/이벤트 팝업이 나오는 현상](https://app.asana.com/0/1141562434100787/1204387310593487/f)

