### PR TITLE
Fix Inventory ItemView

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Module/Item/InventoryItemView.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/Item/InventoryItemView.cs
@@ -88,6 +88,7 @@ namespace Nekoyume.UI.Module
                 baseItemView.EnhancementImage.gameObject.SetActive(false);
             }
 
+            baseItemView.OptionTag.gameObject.SetActive(true);
             baseItemView.OptionTag.Set(model.ItemBase);
 
             baseItemView.CountText.gameObject.SetActive(


### PR DESCRIPTION
### Description

SSIA

### How to test

1. Check ItemView OptionTag in Invetory Equipment Tab
2. Click Rune Tab
3. Click Invetory Equipment Tab, Check ItemView OptionTag again

### Related Links

[[상점] Sell 탭에서 3번째 줄까지 장비의 별이 출력되지 않는 현상](https://app.asana.com/0/1133453747809944/1204279738898089/f)