### PR TITLE
Re-develop `LocalMailHelper`

### DIFF
--- a/nekoyume/Assets/_Scripts/BlockChain/ActionRenderHandler.cs
+++ b/nekoyume/Assets/_Scripts/BlockChain/ActionRenderHandler.cs
@@ -1386,14 +1386,6 @@ namespace Nekoyume.BlockChain
                 }
 
                 var tempPlayer = new AvatarState((Dictionary)States.Instance.CurrentAvatarState.Serialize());
-                if (LocalMailHelper.Instance.TryGetAllLocalMail(tempPlayer.address, out var mails))
-                {
-                    foreach (var mail in mails)
-                    {
-                        tempPlayer.mailBox.Remove(mail);
-                    }
-                }
-
                 var resultModel = eval.GetHackAndSlashReward(tempPlayer,
                     States.Instance.GetEquippedRuneStates(BattleType.Adventure),
                     skillsOnWaveStart,

--- a/nekoyume/Assets/_Scripts/Helper/LocalMailHelper.cs
+++ b/nekoyume/Assets/_Scripts/Helper/LocalMailHelper.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using Libplanet;
+using Nekoyume.Game;
 using Nekoyume.Model.Mail;
 using Nekoyume.State;
 
@@ -15,36 +15,30 @@ namespace Nekoyume.Helper
         {
             _localMailDictionary = new Dictionary<Address, List<Mail>>();
             _disposables = new List<IDisposable>();
+            _localMailBox = new ReactiveProperty<MailBox>();
         }
 
         private readonly Dictionary<Address, List<Mail>> _localMailDictionary;
         private readonly List<IDisposable> _disposables;
+        private readonly ReactiveProperty<MailBox> _localMailBox;
         private static LocalMailHelper _instance;
 
         public static LocalMailHelper Instance => _instance ??= new LocalMailHelper();
+        public IObservable<MailBox> ObservableMailBox => _localMailBox.ObserveOnMainThread();
+        public MailBox MailBox => _localMailBox.Value ?? States.Instance.CurrentAvatarState?.mailBox;
 
-        public void Initialize()
+        public void Initialize(Address address)
         {
-            if (_disposables.Any())
+            if (_localMailDictionary.ContainsKey(address))
             {
                 return;
             }
 
-            ReactiveAvatarState.MailBox.Subscribe(mailBox =>
-            {
-                if (_localMailDictionary.TryGetValue(States.Instance.CurrentAvatarState.address,
-                        out var mails))
-                {
-                    foreach (var mail in mails.Where(mail => !mailBox.Contains(mail)))
-                    {
-                        // It works like `States.Instance.CurrentAvatarState.mailBox.Add(...)`
-                        mailBox.Add(mail);
-                    }
-                }
-            }).AddTo(_disposables);
+            ReactiveAvatarState.MailBox.Subscribe(UpdateLocalMailBox).AddTo(_disposables);
+            Event.OnUpdateAddresses.AsObservable().First().Subscribe(_ => CleanupAndDispose());
         }
 
-        public void Add(Address address, Mail mail, bool notifyUpdate = false)
+        public void Add(Address address, Mail mail)
         {
             if (!_localMailDictionary.ContainsKey(address))
             {
@@ -52,19 +46,33 @@ namespace Nekoyume.Helper
             }
 
             _localMailDictionary[address].Add(mail);
-            if (notifyUpdate)
-            {
-                ReactiveAvatarState.UpdateMailBox(States.Instance.CurrentAvatarState.mailBox);
-            }
+            UpdateLocalMailBox(States.Instance.CurrentAvatarState.mailBox);
         }
 
-        public void CleanupAndDispose(Address address)
+        private void CleanupAndDispose()
         {
-            _localMailDictionary[address].Clear();
+            _localMailDictionary.Clear();
             _disposables.DisposeAllAndClear();
         }
 
-        public bool TryGetAllLocalMail(Address address, out List<Mail> localMails) =>
-            _localMailDictionary.TryGetValue(address, out localMails);
+        private void UpdateLocalMailBox(MailBox mailBox)
+        {
+            var newMailBox = new MailBox();
+            foreach (var mail in mailBox)
+            {
+                newMailBox.Add(mail);
+            }
+
+            if (_localMailDictionary.TryGetValue(States.Instance.CurrentAvatarState.address,
+                    out var localMailList))
+            {
+                foreach (var mail in localMailList)
+                {
+                    newMailBox.Add(mail);
+                }
+            }
+
+            _localMailBox.SetValueAndForceNotify(newMailBox);
+        }
     }
 }

--- a/nekoyume/Assets/_Scripts/UI/Module/Lobby/WorldBossMenu.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/Lobby/WorldBossMenu.cs
@@ -68,7 +68,7 @@ namespace Nekoyume.UI.Module.Lobby
 
         private void CheckSeasonRewards()
         {
-            if (States.Instance.CurrentAvatarState == null || Game.Game.instance.Agent == null)
+            if (States.Instance.CurrentAvatarState == null)
             {
                 return;
             }
@@ -109,7 +109,7 @@ namespace Nekoyume.UI.Module.Lobby
 
         private void MakeSeasonRewardMail(int id, Address address, IEnumerable<SeasonRewards> rewards, bool isNew)
         {
-            LocalMailHelper.Instance.Initialize();
+            LocalMailHelper.Instance.Initialize(address);
             var now = Game.Game.instance.Agent.BlockIndex;
             foreach (var reward in rewards.OrderBy(reward => reward.ticker))
             {
@@ -122,17 +122,9 @@ namespace Nekoyume.UI.Module.Lobby
                         now,
                         currencyName,
                         reward.amount,
-                        id) {New = isNew},
-                    true
+                        id) {New = isNew}
                 );
             }
-
-            ReactiveAvatarState.Address.First(addr => addr != address)
-                .Subscribe(_ =>
-                {
-                    _madeRaidMail = false;
-                    LocalMailHelper.Instance.CleanupAndDispose(address);
-                });
         }
 
         private void AddSeasonRewardMail(int raidId)

--- a/nekoyume/Assets/_Scripts/UI/Widget/Popup/MailPopup.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Popup/MailPopup.cs
@@ -4,11 +4,8 @@ using System.Linq;
 using System.Threading.Tasks;
 using Cysharp.Threading.Tasks;
 using Lib9c.Model.Order;
-using Libplanet.Action;
 using Libplanet.Assets;
 using Nekoyume.Action;
-using Nekoyume.BlockChain;
-using Nekoyume.Game;
 using Nekoyume.Game.Controller;
 using Nekoyume.Helper;
 using Nekoyume.L10n;
@@ -21,9 +18,7 @@ using Nekoyume.UI.Module;
 using Nekoyume.UI.Scroller;
 using TMPro;
 using UnityEngine;
-using UnityEngine.PlayerLoop;
 using UnityEngine.UI;
-using Random = System.Random;
 
 namespace Nekoyume.UI
 {
@@ -263,7 +258,7 @@ namespace Nekoyume.UI
         {
             base.Initialize();
 
-            ReactiveAvatarState.MailBox?.Subscribe(SetList).AddTo(gameObject);
+            LocalMailHelper.Instance.ObservableMailBox?.Subscribe(SetList).AddTo(gameObject);
             Game.Game.instance.Agent.BlockIndexSubject
                 .ObserveOnMainThread()
                 .Subscribe(UpdateNotification)
@@ -274,7 +269,7 @@ namespace Nekoyume.UI
 
         public override void Show(bool ignoreShowAnimation = false)
         {
-            MailBox = States.Instance.CurrentAvatarState.mailBox;
+            MailBox = LocalMailHelper.Instance.MailBox;
             _toggleGroup.SetToggledOffAll();
             allButton.SetToggledOn();
             loading.SetActive(false);
@@ -372,13 +367,12 @@ namespace Nekoyume.UI
 
         private void UpdateNotification(long blockIndex)
         {
-            var avatarState = States.Instance.CurrentAvatarState;
-            if (avatarState is null)
+            MailBox = LocalMailHelper.Instance.MailBox;
+            if (MailBox is null)
             {
                 return;
             }
 
-            MailBox = avatarState.mailBox;
             UpdateTabs(blockIndex);
         }
 
@@ -677,7 +671,6 @@ namespace Nekoyume.UI
         public void Read(RaidRewardMail raidRewardMail)
         {
             raidRewardMail.New = false;
-            ReactiveAvatarState.UpdateMailBox(MailBox);
         }
 
         public void TutorialActionClickFirstCombinationMailSubmitButton()

--- a/nekoyume/Assets/_Scripts/UI/Widget/Static/HeaderMenuStatic.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Static/HeaderMenuStatic.cs
@@ -242,7 +242,7 @@ namespace Nekoyume.UI.Module
             _disposablesAtOnEnable.DisposeAllAndClear();
             ReactiveAvatarState.QuestList?.Subscribe(SubscribeAvatarQuestList)
                 .AddTo(_disposablesAtOnEnable);
-            ReactiveAvatarState.MailBox?.Subscribe(SubscribeAvatarMailBox)
+            LocalMailHelper.Instance.ObservableMailBox?.Subscribe(SubscribeAvatarMailBox)
                 .AddTo(_disposablesAtOnEnable);
             ReactiveAvatarState.Inventory?.Subscribe(SubscribeInventory)
                 .AddTo(_disposablesAtOnEnable);


### PR DESCRIPTION
### Description

1. It will not modify `States.Instance.CurrentAvatarState.MailBox`.
2. not notify `ReactiveAvatarState.MailBox`.
3. Wrapped `States.Instance.CurrentAvatarState.MailBox` to `LocalMailHelper.MailBox` and `LocalMailHelper.ObservableMailBox`.
4. It will fix many bug about `MailBox.Serialize()`.

### Related Links

https://app.asana.com/0/1133453747809944/1204361983054631/f
