### PR TITLE
Fix rune ProductSellerMail l10n

### DIFF
--- a/nekoyume/Assets/_Scripts/Extensions/LocalizationExtensions.cs
+++ b/nekoyume/Assets/_Scripts/Extensions/LocalizationExtensions.cs
@@ -5,7 +5,6 @@ using System.Numerics;
 using System.Threading.Tasks;
 using Libplanet.Assets;
 using Nekoyume.Action;
-using Nekoyume.EnumType;
 using Nekoyume.Extensions;
 using Nekoyume.Game;
 using Nekoyume.Game.Controller;
@@ -18,6 +17,7 @@ using Nekoyume.Model.Item;
 using Nekoyume.Model.Mail;
 using Nekoyume.Model.Quest;
 using Nekoyume.Model.Stat;
+using Nekoyume.State;
 using Nekoyume.TableData;
 using Nekoyume.TableData.Crystal;
 using Nekoyume.UI.Model;
@@ -207,10 +207,14 @@ namespace Nekoyume
                 case ProductSellerMail productSellerMail:
                     var (sellProductName, item, fav) =
                         await Game.Game.instance.MarketServiceClient.GetProductInfo(productSellerMail.ProductId);
-                    var price = item?.Price ?? fav.Price;
+                    var price = item?.Price ?? fav?.Price ?? 0;
                     var tax = decimal.Divide(price, 100) * Buy.TaxRate;
                     var tp = price - tax;
-                    return L10nManager.Localize("UI_SELLER_MAIL_FORMAT", tp , sellProductName);
+                    var currency = States.Instance.GoldBalanceState.Gold.Currency;
+                    var majorUnit = (int)tp;
+                    var minorUnit = (int)((tp - majorUnit) * 100);
+                    var fungibleAsset = new FungibleAssetValue(currency, majorUnit, minorUnit);
+                    return L10nManager.Localize("UI_SELLER_MAIL_FORMAT", fungibleAsset , sellProductName);
 
                 default:
                     throw new NotSupportedException(


### PR DESCRIPTION
### Description

- Fix ProductSellerMail Localization - rune price(decimal) to fungible asset value
  - to bugfix NCG units in rune stone ProductSellerMail not displayed

### Related Links

[[우편] Stone류 아이템 판매 완료 시, 우편함에서 수수료를 제외하지 않은 금액을 수령했다고 뜸+재접해야 금액 업데이트 되는 오류](https://app.asana.com/0/1133453747809944/1204269663523021/f)

### Screenshot

Before
<img width="714" alt="image" src="https://user-images.githubusercontent.com/63496908/233281011-181fee22-7d60-4c5b-bdb8-e0720581b0f4.png">

After
<img width="414" alt="image" src="https://user-images.githubusercontent.com/63496908/233279750-5169ae17-6a28-4071-a9e5-294a7a01b947.png">
