### PR TITLE
Use local `Agent` in unity editor

### DIFF
--- a/nekoyume/Assets/Planetarium/Nekoyume/Editor/HeadlessTool.cs
+++ b/nekoyume/Assets/Planetarium/Nekoyume/Editor/HeadlessTool.cs
@@ -4,7 +4,7 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
-using Libplanet.Crypto;
+using Libplanet;
 using Nekoyume.BlockChain;
 using UnityEditor;
 using UnityEngine;
@@ -197,9 +197,9 @@ namespace Planetarium.Nekoyume.Editor
 
             if (PlayerPrefs.HasKey("initialValidator"))
             {
-                var pkHex = PlayerPrefs.GetString("initialValidator");
+                var pkHex = ByteUtil.Hex(Agent.ProposerKey.ByteArray);
                 startInfo.Arguments +=
-                    $" --miner-private-key {pkHex} --consensus-private-key {pkHex} --consensus-seed {new PrivateKey(pkHex).PublicKey},localhost,60000";
+                    $" --miner-private-key {pkHex} --consensus-private-key {pkHex} --consensus-seed {Agent.ProposerKey.PublicKey},localhost,60000";
             }
 
             Debug.Log(startInfo.Arguments);

--- a/nekoyume/Assets/Planetarium/Nekoyume/Editor/LibplanetEditor.cs
+++ b/nekoyume/Assets/Planetarium/Nekoyume/Editor/LibplanetEditor.cs
@@ -14,13 +14,7 @@ namespace Planetarium.Nekoyume.Editor
     {
         private static PublicKey GetOrCreateInitialValidator()
         {
-            var pk = new PrivateKey();
-            if (PlayerPrefs.HasKey("initialValidator"))
-            {
-                pk = new PrivateKey(PlayerPrefs.GetString("initialValidator"));
-            }
-
-            PlayerPrefs.SetString("initialValidator", ByteUtil.Hex(pk.ByteArray));
+            var pk = Agent.ProposerKey;
             Debug.Log($"Private Key of initialValidator: {ByteUtil.Hex(pk.ByteArray)}");
             Debug.Log($"Public Key of initialValidator: {pk.PublicKey}");
             return pk.PublicKey;

--- a/nekoyume/Assets/_Scripts/Game/Game.cs
+++ b/nekoyume/Assets/_Scripts/Game/Game.cs
@@ -201,9 +201,20 @@ namespace Nekoyume.Game
                 headlessThread = new Thread(() => HeadlessHelper.RunLocalHeadless(initialValidator));
                 headlessThread.Start();
             }
-#endif
+
+            if (useLocalHeadless)
+            {
+                Agent = GetComponent<RPCAgent>();
+                SubscribeRPCAgent();
+            }
+            else
+            {
+                Agent = GetComponent<Agent>();
+            }
+#else
             Agent = GetComponent<RPCAgent>();
             SubscribeRPCAgent();
+#endif
 
             States = new States();
             LocalLayer = new LocalLayer();


### PR DESCRIPTION
Makes Unity editor to play in `Agent`(not `RPCAgent`) when `Use Local Headless` is `false`.