### PR TITLE
Bump `Libplanet.Stun` DLL too

### DIFF
--- a/tools/bump_libplanet.sh
+++ b/tools/bump_libplanet.sh
@@ -13,7 +13,7 @@ SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
 cd "$SCRIPT_DIR"
 SCRIPT_DIR=$(pwd)
 
-PROJECTS=("Libplanet" "Libplanet.RocksDBStore")
+PROJECTS=("Libplanet" "Libplanet.RocksDBStore" "Libplanet.Stun")
 
 
 for project in "${PROJECTS[@]}"; do


### PR DESCRIPTION
### Description

The `tools/bump_libplanet.sh` script bumps Libplanet DLLs by the given version. But the script was staled and doesn't bump `Libplanet.Stun.dll`. This pull request makes the script do that.

### How to test

1. Run `./tools/bump_libplanet.sh <LIBPLANET_VERSION: 1.2.0-dev.20235107419 or 1.1.0>`
2. Check the `Libplanet.dll`, `Libplanet.RocksDBStore.dll`, and `Libplanet.Stun.dll` was updated well.

### Related Links

### Required Reviewers

### Screenshot
