### PR TITLE
Fix shader for recipe slot's legendary effect

### DIFF
--- a/nekoyume/Assets/Resources/UI/Materials/Distortion_Additive_Maskable.shader
+++ b/nekoyume/Assets/Resources/UI/Materials/Distortion_Additive_Maskable.shader
@@ -1,0 +1,76 @@
+﻿Shader "Custom/Distortion_Additive_Masked"
+{
+    Properties
+    {
+        _MainTex ("Texture", 2D) = "white" {}
+        _Color ("Color", Color) = (1, 1, 1, 1)
+        [NoScaleOffset] _NoiseTex ("Texture", 2D) = "black" {}
+        _Size("Noise Size", Range(0.001, 50)) = 1
+        _Speed("Noise Speed", Range(0.001, 5)) = 1
+        _Mag("Magnitude", Range(0.0001, 0.1)) = 1
+    }
+
+    SubShader
+    {
+        Tags
+        {
+            "Queue"="Transparent"
+        }
+        ZWrite Off
+        Blend SrcAlpha One
+        Stencil
+        {
+            Ref 1
+            Comp Equal
+        }
+
+        Pass
+        {
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            #include "UnityCG.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float2 uv : TEXCOORD0;
+            };
+
+            struct v2f
+            {
+                float2 uv : TEXCOORD0;
+                UNITY_FOG_COORDS(1)
+                float4 vertex : SV_POSITION;
+            };
+
+            sampler2D _MainTex;
+            sampler2D _NoiseTex;
+            float4 _MainTex_ST;
+            fixed4 _Color;
+            float _Size;
+            float _Speed;
+            float _Mag;
+
+            v2f vert(appdata v)
+            {
+                v2f o;
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                o.uv = TRANSFORM_TEX(v.uv, _MainTex);
+
+                return o;
+            }
+
+            fixed4 frag(v2f i) : SV_Target
+            {
+                // sample the texture
+
+                fixed2 uv = tex2D(_NoiseTex, i.uv * _Size + (_Time.y * _Speed)).rg * 2 - 1;
+                fixed4 col = tex2D(_MainTex, i.uv + uv * _Mag);
+
+                return col * _Color;
+            }
+            ENDCG
+        }
+    }
+}

--- a/nekoyume/Assets/Resources/UI/Materials/Distortion_Additive_Maskable.shader.meta
+++ b/nekoyume/Assets/Resources/UI/Materials/Distortion_Additive_Maskable.shader.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: e9515ace3bbe42cabcdf7990be3f2273
+timeCreated: 1684832767

--- a/nekoyume/Assets/UIResources/Content/Effect/Grade/Distortion_RecipeSlotOpen_eff.mat
+++ b/nekoyume/Assets/UIResources/Content/Effect/Grade/Distortion_RecipeSlotOpen_eff.mat
@@ -8,7 +8,7 @@ Material:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: Distortion_RecipeSlotOpen_eff
-  m_Shader: {fileID: 4800000, guid: c3da13bfce1354c11af0ce57aec987db, type: 3}
+  m_Shader: {fileID: 4800000, guid: e9515ace3bbe42cabcdf7990be3f2273, type: 3}
   m_ValidKeywords: []
   m_InvalidKeywords:
   - ETC1_EXTERNAL_ALPHA


### PR DESCRIPTION
### Description

Add new shader("Custom/Distortion_Additive_Masked") with **stencil** added to "Custom/Distortion_Additive" shader
to fix recipe slot's legendary effect in Craft ui

### Related Links

[[공방] 레전드리 장비 레시피의 이펙트가 장비 종류 탭 하단에 출력되는 현상](https://app.asana.com/0/1133453747809944/1204627454773842/f)

### Screenshot

Before
![image](https://github.com/planetarium/NineChronicles/assets/63496908/d8ef2653-f448-468c-aaed-82e1a0424baf)

After
![image](https://github.com/planetarium/NineChronicles/assets/63496908/f0b15639-fef1-472d-9d2a-53aa089bd40c)

