### PR TITLE
Fix MaskedRectTransformXRoller for uninitialized value

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Tween/MaskedRectTransformXRoller.cs
+++ b/nekoyume/Assets/_Scripts/UI/Tween/MaskedRectTransformXRoller.cs
@@ -92,7 +92,7 @@ namespace Nekoyume.UI.Tween
 
             if (scrollOnlyWhenNeed)
             {
-                if (_rectTransform.rect.x < content.rectTransform.rect.x)
+                if (_rectTransform.rect.x <= content.rectTransform.rect.x)
                 {
                     _coroutine = StartCoroutine(CoScrollContent());
                 }


### PR DESCRIPTION
### Description

- Fix MaskedRectTransformXRoller for uninitialized value(first enabled RectTransform's X position)

### Related Links

[[메일] 다인슬레이프의 스킬 효과가 증가할 경우 스킬효과와 증가한 스킬 효과 수치가 겹치는 현상](https://app.asana.com/0/1133453747809944/1204664465756572/f)