### PR TITLE
Add command line option - RpcServerHosts

### DIFF
--- a/nekoyume/Assets/Resources/ScriptableObject/LiveAssetEndpoint.asset
+++ b/nekoyume/Assets/Resources/ScriptableObject/LiveAssetEndpoint.asset
@@ -16,3 +16,4 @@ MonoBehaviour:
   <NoticeJsonUrl>k__BackingField: https://raw.githubusercontent.com/planetarium/NineChronicles.LiveAssets/main/Assets/Json/TextNotice.json
   <ImageRootUrl>k__BackingField: https://raw.githubusercontent.com/planetarium/NineChronicles.LiveAssets/main/Assets/Images
   <GameConfigJsonUrl>k__BackingField: https://raw.githubusercontent.com/planetarium/NineChronicles.LiveAssets/main/Assets/Json/GameConfig.json
+  <CommandLineOptionsJsonUrl>k__BackingField: https://raw.githubusercontent.com/planetarium/NineChronicles.LiveAssets/main/Assets/Json/clo-internal.json

--- a/nekoyume/Assets/_Scripts/Game/Game.cs
+++ b/nekoyume/Assets/_Scripts/Game/Game.cs
@@ -204,30 +204,18 @@ namespace Nekoyume.Game
             Screen.sleepTimeout = SleepTimeout.NeverSleep;
             base.Awake();
 
-#if UNITY_IOS
-            _commandLineOptions =
- CommandLineOptions.Load(Platform.GetStreamingAssetsPath("clo.json"));
+#if UNITY_ANDROID
+            // Load CommandLineOptions at Start() after init
+#elif UNITY_IOS
+            _commandLineOptions = CommandLineOptions.Load(Platform.GetStreamingAssetsPath("clo.json"));
+            OnLoadCommandlineOptions();
 #else
             _commandLineOptions = CommandLineOptions.Load(CommandLineOptionsJsonPath);
+            OnLoadCommandlineOptions();
 #endif
-
-            _commandLineOptions.RpcServerHost = _commandLineOptions.RpcClient
-                ? _commandLineOptions.RpcServerHosts.OrderBy(_ => Guid.NewGuid()).First()
-                : null;
-
-            InitializeAnalyzer(
-                agentAddr: _commandLineOptions.PrivateKey is null
-                    ? null
-                    : PrivateKey.FromString(_commandLineOptions.PrivateKey).ToAddress(),
-                rpcServerHost: _commandLineOptions.RpcServerHost);
-            Analyzer.Track("Unity/Started");
-
             URL = Url.Load(UrlJsonPath);
 
-            Debug.Log("[Game] Awake() CommandLineOptions loaded");
-            Debug.Log($"APV: {_commandLineOptions.AppProtocolVersion}");
-
-#if UNITY_EDITOR
+#if UNITY_EDITOR && !UNITY_ANDROID
             // Local Headless
             if (useLocalHeadless && HeadlessHelper.CheckHeadlessSettings())
             {
@@ -253,9 +241,6 @@ namespace Nekoyume.Game
             LocalLayer = new LocalLayer();
             LocalLayerActions = new LocalLayerActions();
             MainCanvas.instance.InitializeIntro();
-#if UNITY_ANDROID
-            _deepLinkHandler = new DeepLinkHandler(_commandLineOptions.MeadPledgePortalUrl);
-#endif
         }
 
         private IEnumerator Start()
@@ -264,6 +249,20 @@ namespace Nekoyume.Game
             Lib9c.DevExtensions.TestbedHelper.LoadTestbedCreateAvatarForQA();
 #endif
             Debug.Log("[Game] Start() invoked");
+
+            // Initialize RequestManager and LiveAssetManager
+            gameObject.AddComponent<RequestManager>();
+            var liveAssetManager = gameObject.AddComponent<LiveAssetManager>();
+            liveAssetManager.InitializeData();
+            yield return new WaitUntil(() => liveAssetManager.IsInitialized);
+            Debug.Log("[Game] Start() RequestManager & LiveAssetManager initialized");
+
+            _commandLineOptions = liveAssetManager.CommandLineOptions;
+
+#if UNITY_ANDROID
+            OnLoadCommandlineOptions();
+            _deepLinkHandler = new DeepLinkHandler(_commandLineOptions.MeadPledgePortalUrl);
+#endif
 
 #if ENABLE_IL2CPP
             // Because of strict AOT environments, use StaticCompositeResolver for IL2CPP.
@@ -367,12 +366,6 @@ namespace Nekoyume.Game
 
             yield return SyncTableSheetsAsync().ToCoroutine();
             Debug.Log("[Game] Start() TableSheets synchronized");
-            // Initialize RequestManager and LiveAssetManager
-            gameObject.AddComponent<RequestManager>();
-            var liveAssetManager = gameObject.AddComponent<LiveAssetManager>();
-            liveAssetManager.InitializeData();
-            yield return new WaitUntil(() => liveAssetManager.IsInitialized);
-            Debug.Log("[Game] Start() RequestManager & LiveAssetManager initialized");
             RxProps.Start(Agent, States, TableSheets);
 #if UNITY_ANDROID
             IAPServiceManager = new IAPServiceManager(_commandLineOptions.IAPServiceHost, Store.GoogleTest);
@@ -437,6 +430,23 @@ namespace Nekoyume.Game
 
             ActionManager?.Dispose();
             base.OnDestroy();
+        }
+
+        private void OnLoadCommandlineOptions()
+        {
+            _commandLineOptions.RpcServerHost = !string.IsNullOrEmpty(_commandLineOptions.RpcServerHost)
+                ? _commandLineOptions.RpcServerHost
+                : _commandLineOptions.RpcServerHosts.OrderBy(_ => Guid.NewGuid()).First();
+
+            InitializeAnalyzer(
+                agentAddr: _commandLineOptions.PrivateKey is null
+                    ? null
+                    : PrivateKey.FromString(_commandLineOptions.PrivateKey).ToAddress(),
+                rpcServerHost: _commandLineOptions.RpcServerHost);
+            Analyzer.Track("Unity/Started");
+
+            Debug.Log("[Game] CommandLineOptions loaded");
+            Debug.Log($"APV: {_commandLineOptions.AppProtocolVersion}");
         }
 
         private void SubscribeRPCAgent()

--- a/nekoyume/Assets/_Scripts/Game/Game.cs
+++ b/nekoyume/Assets/_Scripts/Game/Game.cs
@@ -211,13 +211,15 @@ namespace Nekoyume.Game
             _commandLineOptions = CommandLineOptions.Load(CommandLineOptionsJsonPath);
 #endif
 
+            _commandLineOptions.RpcServerHost = _commandLineOptions.RpcClient
+                ? _commandLineOptions.RpcServerHosts.OrderBy(_ => Guid.NewGuid()).First()
+                : null;
+
             InitializeAnalyzer(
                 agentAddr: _commandLineOptions.PrivateKey is null
                     ? null
                     : PrivateKey.FromString(_commandLineOptions.PrivateKey).ToAddress(),
-                rpcServerHost: _commandLineOptions.RpcClient
-                    ? _commandLineOptions.RpcServerHost
-                    : null);
+                rpcServerHost: _commandLineOptions.RpcServerHost);
             Analyzer.Track("Unity/Started");
 
             URL = Url.Load(UrlJsonPath);

--- a/nekoyume/Assets/_Scripts/Game/ScriptableObject/LiveAssetEndpointScriptableObject.cs
+++ b/nekoyume/Assets/_Scripts/Game/ScriptableObject/LiveAssetEndpointScriptableObject.cs
@@ -17,5 +17,8 @@ namespace Nekoyume.Game.ScriptableObject
 
         [field: SerializeField]
         public string GameConfigJsonUrl { get; private set; }
+
+        [field: SerializeField]
+        public string CommandLineOptionsJsonUrl { get; private set; }
     }
 }

--- a/nekoyume/Assets/_Scripts/Helper/CommandLineParser.cs
+++ b/nekoyume/Assets/_Scripts/Helper/CommandLineParser.cs
@@ -6,7 +6,6 @@ using System.IO;
 using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using Nekoyume.L10n;
 using UnityEngine;
 using System.Runtime.InteropServices;
 
@@ -68,7 +67,7 @@ namespace Nekoyume.Helper
 
         private string marketServiceHost;
 
-        private string _meadPledgePortalUrl;
+        private string meadPledgePortalUrl;
 
         private string iapServiceHost;
 
@@ -396,10 +395,10 @@ namespace Nekoyume.Helper
         [Option("mead-pledge-portal-url", Required = false, HelpText = "mead pledge portal url")]
         public string MeadPledgePortalUrl
         {
-            get => _meadPledgePortalUrl;
+            get => meadPledgePortalUrl;
             set
             {
-                _meadPledgePortalUrl = value;
+                meadPledgePortalUrl = value;
                 Empty = false;
             }
         }

--- a/nekoyume/Assets/_Scripts/Helper/CommandLineParser.cs
+++ b/nekoyume/Assets/_Scripts/Helper/CommandLineParser.cs
@@ -38,6 +38,8 @@ namespace Nekoyume.Helper
 
         private string rpcServerHost;
 
+        private string[] rpcServerHosts = { };
+
         private int rpcServerPort;
 
         private bool autoPlay;
@@ -198,6 +200,20 @@ namespace Nekoyume.Helper
             {
                 rpcServerHost = value;
                 Empty = false;
+            }
+        }
+
+        [Option("rpc-server-hosts", Required = false, HelpText = "The host names for client mode.")]
+        public IEnumerable<string> RpcServerHosts
+        {
+            get => rpcServerHosts;
+            set
+            {
+                rpcServerHosts = value.ToArray();
+                if (value.Any())
+                {
+                    Empty = false;
+                }
             }
         }
 


### PR DESCRIPTION
### Description

Add command line option - RpcServerHosts


### How to test

```
{
  "GenesisBlockPath": "https://download.nine-chronicles.com/genesis-block-9c-main",
  "NoMiner": true,
  "RpcClient": true,
  "RpcServerHosts": [
    "9c-main-rpc-1.nine-chronicles.com",
    "9c-main-rpc-2.nine-chronicles.com",
    "9c-main-rpc-3.nine-chronicles.com"
  ],
  "RpcServerPort": 31238,
  "ApiServerHost": "https://api.9c.gg/graphql",
  "DataProviderUrl": "https://api.9c.gg/graphql",
  "OnboardingPortalUrl": "https://world-boss.9c.gg",
  "MarketServiceHost": "https://market.9c.gg",
  "Development": true
}
```

### Related Links

https://app.asana.com/0/958521740385861/1204951963817787/f