### PR TITLE
add application version in android platform

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Widget/System/VersionSystem.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/System/VersionSystem.cs
@@ -53,7 +53,7 @@ namespace Nekoyume.UI
 #if UNITY_ANDROID || UNITY_IOS
             informationText.text = $"APV: {_version} / #{_blockIndex} / Hash: {hash} / ver: {UnityEngine.Application.version}({_clientCommitHash})";
 #else
-            informationText.text = $"APV: {_version} / #{_blockIndex} / Hash: {hash} / ver: {clientCommitHash}";
+            informationText.text = $"APV: {_version} / #{_blockIndex} / Hash: {hash} / ver: {_clientCommitHash}";
 #endif
         }
     }

--- a/nekoyume/Assets/_Scripts/UI/Widget/System/VersionSystem.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/System/VersionSystem.cs
@@ -17,6 +17,9 @@ namespace Nekoyume.UI
             base.Awake();
             Game.Game.instance.Agent.BlockIndexSubject.Subscribe(SubscribeBlockIndex).AddTo(gameObject);
             Game.Game.instance.Agent.BlockTipHashSubject.Subscribe(SubscribeBlockHash).AddTo(gameObject);
+#if UNITY_ANDROID || UNITY_IOS
+            UpdateText();
+#endif
         }
 
         public void SetVersion(int version)
@@ -39,14 +42,13 @@ namespace Nekoyume.UI
 
         private void UpdateText()
         {
-            const string format = "APV: {0} / #{1} / Hash: {2}";
             var hash = _hash.ToString();
-            var text = string.Format(
-                format,
-                _version,
-                _blockIndex,
-                hash.Length >= 4 ? hash.Substring(0, 4) : "...");
-            informationText.text = text;
+            hash = hash.Length >= 4 ? hash.Substring(0, 4) : "...";
+#if UNITY_ANDROID || UNITY_IOS
+            informationText.text = $"APV: {_version} / #{_blockIndex} / Hash: {hash} / ver: {UnityEngine.Application.version}";
+#else
+            informationText.text = $"APV: {_version} / #{_blockIndex} / Hash: {hash}";
+#endif
         }
     }
 }

--- a/nekoyume/Assets/_Scripts/UI/Widget/System/VersionSystem.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/System/VersionSystem.cs
@@ -2,6 +2,7 @@ using Libplanet;
 using Libplanet.Blocks;
 using TMPro;
 using UniRx;
+using UnityEngine;
 
 namespace Nekoyume.UI
 {
@@ -11,12 +12,16 @@ namespace Nekoyume.UI
         private int _version;
         private long _blockIndex;
         private BlockHash _hash;
+        private string _clientCommitHash;
 
         protected override void Awake()
         {
             base.Awake();
             Game.Game.instance.Agent.BlockIndexSubject.Subscribe(SubscribeBlockIndex).AddTo(gameObject);
             Game.Game.instance.Agent.BlockTipHashSubject.Subscribe(SubscribeBlockHash).AddTo(gameObject);
+
+            _clientCommitHash = Resources.Load<TextAsset>("ClientHash")?.text[..8] ?? string.Empty;
+
 #if UNITY_ANDROID || UNITY_IOS
             UpdateText();
 #endif
@@ -44,10 +49,11 @@ namespace Nekoyume.UI
         {
             var hash = _hash.ToString();
             hash = hash.Length >= 4 ? hash.Substring(0, 4) : "...";
+
 #if UNITY_ANDROID || UNITY_IOS
-            informationText.text = $"APV: {_version} / #{_blockIndex} / Hash: {hash} / ver: {UnityEngine.Application.version}";
+            informationText.text = $"APV: {_version} / #{_blockIndex} / Hash: {hash} / ver: {UnityEngine.Application.version}({_clientCommitHash})";
 #else
-            informationText.text = $"APV: {_version} / #{_blockIndex} / Hash: {hash}";
+            informationText.text = $"APV: {_version} / #{_blockIndex} / Hash: {hash} / ver: {clientCommitHash}";
 #endif
         }
     }


### PR DESCRIPTION
add application version
Only the application version added.
Since Unity does not provide the function to access the corresponding value at run time for the bundled version code, it is necessary to modify the code before compiling or to store the value somewhere, which can affect CI, so further work.
Related forum posts
https://forum.unity.com/threads/how-can-i-get-bundle-version-and-bundle-version-code-through-script.68331/