### PR TITLE
feat(IAgent): implement async methods for get balance

### DIFF
--- a/nekoyume/Assets/Plugins/StateViewer/Runtime/StateProxy.cs
+++ b/nekoyume/Assets/Plugins/StateViewer/Runtime/StateProxy.cs
@@ -87,6 +87,24 @@ namespace StateViewer.Runtime
             return (addr, Agent.GetBalance(addr, currency));
         }
 
+        public async UniTask<(Address addr, FungibleAssetValue fav)> GetBalanceAsync(
+            Address addr,
+            Currency currency,
+            long? blockIndex)
+        {
+            var balance = await Agent.GetBalanceAsync(addr, currency, blockIndex);
+            return (addr, balance);
+        }
+
+        public async UniTask<(Address addr, FungibleAssetValue? fav)> GetBalanceAsync(
+            Address addr,
+            Currency currency,
+            BlockHash blockHash)
+        {
+            var balance = await Agent.GetBalanceAsync(addr, currency, blockHash);
+            return (addr, balance);
+        }
+
         public void RegisterAlias(string alias, Address address)
         {
             if (!Aliases.ContainsKey(alias))

--- a/nekoyume/Assets/_Scripts/Blockchain/ActionHandler.cs
+++ b/nekoyume/Assets/_Scripts/Blockchain/ActionHandler.cs
@@ -247,7 +247,7 @@ namespace Nekoyume.Blockchain
         {
             var avatarAddress = States.Instance.CurrentAvatarState.address;
             var avatars =
-                await Game.Game.instance.Agent.GetAvatarStates(new[] { avatarAddress });
+                await Game.Game.instance.Agent.GetAvatarStatesAsync(new[] { avatarAddress });
             if (avatars.TryGetValue(avatarAddress, out var avatarState))
             {
                 await UpdateCurrentAvatarStateAsync(avatarState);

--- a/nekoyume/Assets/_Scripts/Blockchain/Agent.cs
+++ b/nekoyume/Assets/_Scripts/Blockchain/Agent.cs
@@ -264,7 +264,7 @@ namespace Nekoyume.Blockchain
             return await Task.Run(() => blocks.GetState(address, blockHash));
         }
 
-        public async Task<Dictionary<Address, AvatarState>> GetAvatarStates(
+        public async Task<Dictionary<Address, AvatarState>> GetAvatarStatesAsync(
             IEnumerable<Address> addressList,
             long? blockIndex = null)
         {
@@ -289,7 +289,7 @@ namespace Nekoyume.Blockchain
             });
         }
 
-        public async Task<Dictionary<Address, IValue>> GetStateBulk(IEnumerable<Address> addressList)
+        public async Task<Dictionary<Address, IValue>> GetStateBulkAsync(IEnumerable<Address> addressList)
         {
             return await Task.Run(async () =>
             {

--- a/nekoyume/Assets/_Scripts/Blockchain/Agent.cs
+++ b/nekoyume/Assets/_Scripts/Blockchain/Agent.cs
@@ -313,8 +313,26 @@ namespace Nekoyume.Blockchain
         public FungibleAssetValue GetBalance(Address address, Currency currency) =>
             blocks.GetBalance(address, currency);
 
-        public Task<FungibleAssetValue> GetBalanceAsync(Address address, Currency currency) =>
-            Task.Run(() => blocks.GetBalance(address, currency));
+        public Task<FungibleAssetValue> GetBalanceAsync(
+            Address address,
+            Currency currency,
+            long? blockIndex = null)
+        {
+            if (blockIndex.HasValue)
+            {
+                throw new NotImplementedException($"{nameof(blockIndex)} is not supported yet.");
+            }
+
+            return Task.Run(() => blocks.GetBalance(address, currency));
+        }
+
+        public Task<FungibleAssetValue> GetBalanceAsync(
+            Address address,
+            Currency currency,
+            BlockHash blockHash)
+        {
+            return Task.Run(() => blocks.GetBalance(address, currency, blockHash));
+        }
 
         #region Mono
 

--- a/nekoyume/Assets/_Scripts/Blockchain/IAgent.cs
+++ b/nekoyume/Assets/_Scripts/Blockchain/IAgent.cs
@@ -72,10 +72,10 @@ namespace Nekoyume.Blockchain
             Currency currency,
             BlockHash blockHash);
 
-        Task<Dictionary<Address, AvatarState>> GetAvatarStates(
+        Task<Dictionary<Address, AvatarState>> GetAvatarStatesAsync(
             IEnumerable<Address> addressList,
             long? blockIndex = null);
 
-        Task<Dictionary<Address, IValue>> GetStateBulk(IEnumerable<Address> addressList);
+        Task<Dictionary<Address, IValue>> GetStateBulkAsync(IEnumerable<Address> addressList);
     }
 }

--- a/nekoyume/Assets/_Scripts/Blockchain/IAgent.cs
+++ b/nekoyume/Assets/_Scripts/Blockchain/IAgent.cs
@@ -62,7 +62,15 @@ namespace Nekoyume.Blockchain
 
         FungibleAssetValue GetBalance(Address address, Currency currency);
 
-        Task<FungibleAssetValue> GetBalanceAsync(Address address, Currency currency);
+        Task<FungibleAssetValue> GetBalanceAsync(
+            Address address,
+            Currency currency,
+            long? blockIndex = null);
+
+        Task<FungibleAssetValue> GetBalanceAsync(
+            Address address,
+            Currency currency,
+            BlockHash blockHash);
 
         Task<Dictionary<Address, AvatarState>> GetAvatarStates(
             IEnumerable<Address> addressList,

--- a/nekoyume/Assets/_Scripts/Blockchain/RPCAgent.cs
+++ b/nekoyume/Assets/_Scripts/Blockchain/RPCAgent.cs
@@ -266,7 +266,7 @@ namespace Nekoyume.Blockchain
                 serialized.ElementAt(1).ToBigInteger());
         }
 
-        public async Task<Dictionary<Address, AvatarState>> GetAvatarStates(
+        public async Task<Dictionary<Address, AvatarState>> GetAvatarStatesAsync(
             IEnumerable<Address> addressList,
             long? blockIndex = null)
         {
@@ -288,7 +288,7 @@ namespace Nekoyume.Blockchain
             return result;
         }
 
-        public async Task<Dictionary<Address, IValue>> GetStateBulk(IEnumerable<Address> addressList)
+        public async Task<Dictionary<Address, IValue>> GetStateBulkAsync(IEnumerable<Address> addressList)
         {
             Dictionary<byte[], byte[]> raw =
                 await _service.GetStateBulk(addressList.Select(a => a.ToByteArray()),

--- a/nekoyume/Assets/_Scripts/Extensions/AvatarStateExtensions.cs
+++ b/nekoyume/Assets/_Scripts/Extensions/AvatarStateExtensions.cs
@@ -88,7 +88,7 @@ namespace Nekoyume
                 ItemSlotState.DeriveAddress(avatarAddress, BattleType.Arena),
                 ItemSlotState.DeriveAddress(avatarAddress, BattleType.Raid)
             };
-            var itemBulk = await Game.Game.instance.Agent.GetStateBulk(itemAddresses);
+            var itemBulk = await Game.Game.instance.Agent.GetStateBulkAsync(itemAddresses);
             var itemSlotStates = new List<ItemSlotState>();
             foreach (var value in itemBulk.Values)
             {
@@ -104,7 +104,7 @@ namespace Nekoyume
                 RuneSlotState.DeriveAddress(avatarAddress, BattleType.Arena),
                 RuneSlotState.DeriveAddress(avatarAddress, BattleType.Raid)
             };
-            var runeBulk = await Game.Game.instance.Agent.GetStateBulk(runeAddresses);
+            var runeBulk = await Game.Game.instance.Agent.GetStateBulkAsync(runeAddresses);
             var runeSlotStates = new List<RuneSlotState>();
             foreach (var value in runeBulk.Values)
             {
@@ -122,7 +122,7 @@ namespace Nekoyume
             var runeListSheet = Game.Game.instance.TableSheets.RuneListSheet;
             var runeIds = runeListSheet.Values.Select(x => x.Id).ToList();
             var addresses = runeIds.Select(id => RuneState.DeriveAddress(avatarState.address, id)).ToList();
-            var bulk = await Game.Game.instance.Agent.GetStateBulk(addresses);
+            var bulk = await Game.Game.instance.Agent.GetStateBulkAsync(addresses);
             var runeStates = new List<RuneState>();
             foreach (var value in bulk.Values)
             {

--- a/nekoyume/Assets/_Scripts/Game/Game.cs
+++ b/nekoyume/Assets/_Scripts/Game/Game.cs
@@ -764,7 +764,7 @@ namespace Nekoyume.Game
             var map = csvAssets.ToDictionary(
                 asset => Addresses.TableSheet.Derive(asset.name),
                 asset => asset.name);
-            var dict = await Agent.GetStateBulk(map.Keys);
+            var dict = await Agent.GetStateBulkAsync(map.Keys);
             var csv = dict.ToDictionary(
                 pair => map[pair.Key],
                 // NOTE: `pair.Value` is `null` when the chain not contains the `pair.Key`.

--- a/nekoyume/Assets/_Scripts/State/GrandFinaleStates.cs
+++ b/nekoyume/Assets/_Scripts/State/GrandFinaleStates.cs
@@ -150,7 +150,7 @@ namespace Nekoyume.State
                     avatarAddr.Derive(scoreDeriveString))
                 ).ToArray();
             // NOTE: If addresses is too large, and split and get separately.
-            var scores = await agent.GetStateBulk(
+            var scores = await agent.GetStateBulkAsync(
                 avatarAndScoreAddrList.Select(tuple => tuple.Item2));
             var avatarAddrAndScores = avatarAndScoreAddrList
                 .Select(tuple =>
@@ -219,8 +219,8 @@ namespace Nekoyume.State
             }
 
             // NOTE: If the [`addrBulk`] is too large, and split and get separately.
-            var runeStateBulk = await agent.GetStateBulk(runeAddrBulk);
-            var stateBulk = await agent.GetStateBulk(addrBulk);
+            var runeStateBulk = await agent.GetStateBulkAsync(runeAddrBulk);
+            var stateBulk = await agent.GetStateBulkAsync(addrBulk);
             var runeStates = new List<RuneState>();
             var result = avatarAddrAndScoresWithRank.Select(tuple =>
             {

--- a/nekoyume/Assets/_Scripts/State/RxProps.Arena.cs
+++ b/nekoyume/Assets/_Scripts/State/RxProps.Arena.cs
@@ -257,7 +257,7 @@ namespace Nekoyume.State
                     nextRoundData.ChampionshipId,
                     nextRoundData.Round)
                 : default;
-            var dict = await _agent.GetStateBulk(
+            var dict = await _agent.GetStateBulkAsync(
                 new[]
                 {
                     currentArenaInfoAddress,
@@ -339,7 +339,7 @@ namespace Nekoyume.State
                         currentRoundData.Round)))
                 .ToArray();
             // NOTE: If addresses is too large, and split and get separately.
-            var scores = await _agent.GetStateBulk(
+            var scores = await _agent.GetStateBulkAsync(
                 avatarAndScoreAddrList.Select(tuple => tuple.Item2));
             var avatarAddrAndScores = avatarAndScoreAddrList
                 .Select(tuple =>
@@ -419,7 +419,7 @@ namespace Nekoyume.State
             addrBulk.Add(arenaAvatarAddress);
 
             // NOTE: If the [`addrBulk`] is too large, and split and get separately.
-            var stateBulk = await _agent.GetStateBulk(addrBulk);
+            var stateBulk = await _agent.GetStateBulkAsync(addrBulk);
             var runeStates = new List<RuneState>();
             var result = avatarAddrAndScoresWithRank.Select(tuple =>
             {

--- a/nekoyume/Assets/_Scripts/State/States.cs
+++ b/nekoyume/Assets/_Scripts/State/States.cs
@@ -182,7 +182,7 @@ namespace Nekoyume.State
             var runeIds = runeListSheet.Values.Select(x => x.Id).ToList();
             var runeAddresses = runeIds.Select(id => RuneState.DeriveAddress(avatarAddress, id))
                 .ToList();
-            var stateBulk = await Game.Game.instance.Agent.GetStateBulk(runeAddresses);
+            var stateBulk = await Game.Game.instance.Agent.GetStateBulkAsync(runeAddresses);
             RuneStates.Clear();
             foreach (var value in stateBulk.Values)
             {
@@ -217,7 +217,7 @@ namespace Nekoyume.State
                     RuneSlotState.DeriveAddress(avatarState.address, BattleType.Arena),
                     RuneSlotState.DeriveAddress(avatarState.address, BattleType.Raid)
                 };
-                var stateBulk = await Game.Game.instance.Agent.GetStateBulk(addresses);
+                var stateBulk = await Game.Game.instance.Agent.GetStateBulkAsync(addresses);
                 foreach (var value in stateBulk.Values)
                 {
                     if (value is List list)
@@ -294,7 +294,7 @@ namespace Nekoyume.State
                     ItemSlotState.DeriveAddress(avatarState.address, BattleType.Arena),
                     ItemSlotState.DeriveAddress(avatarState.address, BattleType.Raid)
                 };
-                var stateBulk = await agent.GetStateBulk(addresses);
+                var stateBulk = await agent.GetStateBulkAsync(addresses);
                 foreach (var value in stateBulk.Values)
                 {
                     if (value is List list)
@@ -346,7 +346,7 @@ namespace Nekoyume.State
                 ItemSlotState.DeriveAddress(avatarState.address, BattleType.Raid)
             };
 
-            var stateBulk = await Game.Game.instance.Agent.GetStateBulk(addresses);
+            var stateBulk = await Game.Game.instance.Agent.GetStateBulkAsync(addresses);
             foreach (var value in stateBulk.Values)
             {
                 if (value is List list)
@@ -527,7 +527,7 @@ namespace Nekoyume.State
             }.Select(key => (Key: key, KeyAddress: address.Derive(key))).ToArray();
 
             var states =
-                await agent.GetStateBulk(addressPairList.Select(value => value.KeyAddress));
+                await agent.GetStateBulkAsync(addressPairList.Select(value => value.KeyAddress));
             // Make Tuple list by state value and state address key.
             var stateAndKeys = states.Join(
                 addressPairList,
@@ -798,7 +798,7 @@ namespace Nekoyume.State
                                 recipeId), recipeId))
                         .ToList();
                 var states =
-                    await Game.Game.instance.Agent.GetStateBulk(
+                    await Game.Game.instance.Agent.GetStateBulkAsync(
                         hammerPointStateAddresses.Select(tuple => tuple.Item1));
                 var joinedStates = states.Join(
                     hammerPointStateAddresses,
@@ -864,7 +864,7 @@ namespace Nekoyume.State
         private async UniTask SetPetStates(Address avatarAddress)
         {
             var petIds = TableSheets.Instance.PetSheet.Values.Select(row => row.Id).ToList();
-            var petRawStates = await Game.Game.instance.Agent.GetStateBulk(
+            var petRawStates = await Game.Game.instance.Agent.GetStateBulkAsync(
                 petIds.Select(id => PetState.DeriveAddress(avatarAddress, id))
             );
             foreach (var petId in petIds)


### PR DESCRIPTION
This work has a little complex. Because the implementation of `IAgent.GetBalance` using `Game.CachedBalance` in the `RPCAgent`. This is why the behavior of the two `GetBalanceAsync` methods I added is different.

# Changes

## Major

- Introduce `IAgent.GetBalanceAsync` methods.
- Rename async methods  of `IAgent` to `XyzAsync`.

## Minor

- Apply above to `StateViewer`.
- Fix `TrackStakeFeature` of `StateViewer`.

# Implementation of `RPCAgent`

```cs
// Use GetBalanceAsync(address, currency, blockIndex) instead of self implementation.
FungibleAssetValue GetBalance(Address address, Currency currency);

// Implement with `Game.CachedBalance` that had contained in `GetBalance` method.
Task<FungibleAssetValue> GetBalanceAsync(
    Address address,
    Currency currency,
    long? blockIndex = null);

// Implement without `Game.CachedBalance`.
Task<FungibleAssetValue> GetBalanceAsync(
    Address address,
    Currency currency,
    BlockHash blockHash);
```
