### PR TITLE
[Fix] L10nManager filename split error

### DIFF
--- a/nekoyume/Assets/_Scripts/L10n/L10nManager.cs
+++ b/nekoyume/Assets/_Scripts/L10n/L10nManager.cs
@@ -244,7 +244,7 @@ namespace Nekoyume.L10n
                     // wait for load
                 }
 
-                String[] fileNames = directory.text.Split("\r\n");
+                String[] fileNames = directory.text.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
 
                 Dictionary<string, string> dictionary = new Dictionary<string, string>();
                 foreach (String fileName in fileNames)


### PR DESCRIPTION
### Description

Handle crlf,lf split delimiter

### How to test

1. First step.

### Related Links

### Required Reviewers

### Screenshot
