### PR TITLE
increase rpc reconnection attempt count from `20` to `50`

### DIFF
--- a/nekoyume/Assets/_Scripts/Blockchain/RPCAgent.cs
+++ b/nekoyume/Assets/_Scripts/Blockchain/RPCAgent.cs
@@ -43,7 +43,7 @@ namespace Nekoyume.Blockchain
 
     public class RPCAgent : MonoBehaviour, IAgent, IActionEvaluationHubReceiver
     {
-        private const int RpcConnectionRetryCount = 20;
+        private const int RpcConnectionRetryCount = 50;
         private const float TxProcessInterval = 1.0f;
         private readonly ConcurrentQueue<ActionBase> _queuedActions = new ConcurrentQueue<ActionBase>();
 


### PR DESCRIPTION
Increase the default `RpcConnectionRetryCount` from `20` to `50` because the mobile version's reconnection interval is twice faster than the PC version and therefore, fails to reconnect every time the RPC node restarts.