### PR TITLE
feat: render `ClaimItems`, `TransferAssets`

### DIFF
--- a/nekoyume/Assets/_Scripts/Blockchain/ActionHandler.cs
+++ b/nekoyume/Assets/_Scripts/Blockchain/ActionHandler.cs
@@ -16,6 +16,7 @@ using Nekoyume.State;
 using Nekoyume.TableData;
 using Nekoyume.UI.Scroller;
 using UnityEngine;
+using static Lib9c.SerializeKeys;
 
 namespace Nekoyume.Blockchain
 {
@@ -209,7 +210,7 @@ namespace Nekoyume.Blockchain
 
             var avatarAddr = states.CurrentAvatarState.address;
             var inventoryAddr = avatarAddr.Derive(LegacyInventoryKey);
-            var inventory = eval.OutputState.GetInventory(inventoryAddr);
+            var inventory = StateGetter.GetInventory(inventoryAddr, eval.OutputState);
             var avatarState = states.CurrentAvatarState;
             avatarState.inventory = inventory;
             avatarState = LocalLayer.Instance.ModifyInventoryOnly(avatarState);

--- a/nekoyume/Assets/_Scripts/Blockchain/ActionHandler.cs
+++ b/nekoyume/Assets/_Scripts/Blockchain/ActionHandler.cs
@@ -198,6 +198,24 @@ namespace Nekoyume.Blockchain
             }
         }
 
+        protected static void UpdateCurrentAvatarInventory<T>(ActionEvaluation<T> eval)
+            where T : ActionBase
+        {
+            var states = States.Instance;
+            if (states.CurrentAvatarState is null)
+            {
+                return;
+            }
+
+            var avatarAddr = states.CurrentAvatarState.address;
+            var inventoryAddr = avatarAddr.Derive(LegacyInventoryKey);
+            var inventory = eval.OutputState.GetInventory(inventoryAddr);
+            var avatarState = states.CurrentAvatarState;
+            avatarState.inventory = inventory;
+            avatarState = LocalLayer.Instance.ModifyInventoryOnly(avatarState);
+            ReactiveAvatarState.UpdateInventory(avatarState.inventory);
+        }
+
         protected static void UpdateGameConfigState<T>(ActionEvaluation<T> evaluation) where T : ActionBase
         {
             if (evaluation.Action is not PatchTableSheet

--- a/nekoyume/Assets/_Scripts/Blockchain/ActionManager.cs
+++ b/nekoyume/Assets/_Scripts/Blockchain/ActionManager.cs
@@ -56,12 +56,14 @@ namespace Nekoyume.Blockchain
 
         public static bool IsLastBattleActionId(Guid actionId) => actionId == Instance._lastBattleActionId;
 
-        public Exception HandleException(Guid actionId, Exception e)
+        public Exception HandleException(Guid? actionId, Exception e)
         {
             if (e is TimeoutException)
             {
-                var txId = _actionIdToTxIdBridge.ContainsKey(actionId)
-                    ? (TxId?)_actionIdToTxIdBridge[actionId].txId
+                var txId = actionId.HasValue
+                    ? _actionIdToTxIdBridge.TryGetValue(actionId.Value, out var value)
+                        ? (TxId?)value.txId
+                        : null
                     : null;
                 e = new ActionTimeoutException(e.Message, txId, actionId);
             }
@@ -836,7 +838,7 @@ namespace Nekoyume.Blockchain
                 ["AvatarAddress"] = States.Instance.CurrentAvatarState.address.ToString(),
                 ["AgentAddress"] = States.Instance.AgentState.address.ToString(),
             }, true);
-            
+
             var action = new ItemEnhancement
             {
                 itemId = baseEquipment.NonFungibleId,
@@ -1556,7 +1558,51 @@ namespace Nekoyume.Blockchain
                 });
         }
 
-#if LIB9C_DEV_EXTENSIONS || UNITY_EDITOR
+        public IObservable<ActionEvaluation<ClaimItems>> ClaimItems(
+            params (Address, IReadOnlyList<FungibleAssetValue>)[] claimData)
+        {
+            var action = new ClaimItems(claimData);
+            ProcessAction(action);
+            return _agent.ActionRenderer.EveryRender<ClaimItems>()
+                .Timeout(ActionTimeout)
+                .Where(eval => eval.Action.Id.Equals(action.Id))
+                .First()
+                .ObserveOnMainThread()
+                .DoOnError(e => HandleException(action.Id, e));
+        }
+
+        public IObservable<ActionEvaluation<TransferAsset>> TransferAsset(
+            Address sender,
+            Address recipient,
+            FungibleAssetValue amount)
+        {
+            var action = new TransferAsset(sender, recipient, amount);
+            ProcessAction(action);
+            return _agent.ActionRenderer.EveryRender<TransferAsset>()
+                .Timeout(ActionTimeout)
+                .Where(eval => eval.Action.PlainValue.Equals(action.PlainValue))
+                .First()
+                .ObserveOnMainThread()
+                // .DoOnError(e => HandleException(action.Id, e));
+                .DoOnError(e => { });
+        }
+
+        public IObservable<ActionEvaluation<TransferAssets>> TransferAssets(
+            Address sender,
+            params (Address, FungibleAssetValue)[] recipients)
+        {
+            var action = new TransferAssets(sender, recipients.ToList());
+            ProcessAction(action);
+            return _agent.ActionRenderer.EveryRender<TransferAssets>()
+                .Timeout(ActionTimeout)
+                .Where(eval => eval.Action.PlainValue.Equals(action.PlainValue))
+                .First()
+                .ObserveOnMainThread()
+                // .DoOnError(e => HandleException(action.Id, e));
+                .DoOnError(e => { });
+        }
+
+#if UNITY_EDITOR || LIB9C_DEV_EXTENSIONS
         public IObservable<ActionEvaluation<CreateTestbed>> CreateTestbed()
         {
             var action = new CreateTestbed

--- a/nekoyume/Assets/_Scripts/Blockchain/ActionRenderHandler.cs
+++ b/nekoyume/Assets/_Scripts/Blockchain/ActionRenderHandler.cs
@@ -37,7 +37,6 @@ using Nekoyume.Model.Arena;
 using Nekoyume.Model.BattleStatus.Arena;
 using Nekoyume.Model.EnumType;
 using Nekoyume.Model.Market;
-using Nekoyume.TableData;
 using Nekoyume.UI.Module.WorldBoss;
 using Skill = Nekoyume.Model.Skill.Skill;
 

--- a/nekoyume/Assets/_Scripts/Blockchain/ActionRenderHandler.cs
+++ b/nekoyume/Assets/_Scripts/Blockchain/ActionRenderHandler.cs
@@ -178,6 +178,9 @@ namespace Nekoyume.Blockchain
             // GARAGE
             UnloadFromMyGarages();
 
+            // Claim Items
+            ClaimItems();
+
 #if LIB9C_DEV_EXTENSIONS || UNITY_EDITOR
             Testbed();
             ManipulateState();
@@ -608,6 +611,28 @@ namespace Nekoyume.Blockchain
                 .Where(ValidateEvaluationForCurrentAgent)
                 .ObserveOnMainThread()
                 .Subscribe(ResponseAuraSummon)
+                .AddTo(_disposables);
+        }
+
+        /// <summary>
+        /// Process the action rendering of <see cref="ClaimItems"/>.
+        /// At now, rendering is only for updating the inventory of the current avatar.
+        /// </summary>
+        private void ClaimItems()
+        {
+            _actionRenderer.EveryRender<ClaimItems>()
+                .Where(ValidateEvaluationForCurrentAvatarState)
+                .ObserveOnMainThread()
+                .Subscribe(eval =>
+                {
+                    if (eval.Exception is not null)
+                    {
+                        Debug.Log(eval.Exception.Message);
+                        return;
+                    }
+
+                    UpdateCurrentAvatarInventory(eval);
+                })
                 .AddTo(_disposables);
         }
 

--- a/nekoyume/Assets/_Scripts/Blockchain/ActionTimeoutException.cs
+++ b/nekoyume/Assets/_Scripts/Blockchain/ActionTimeoutException.cs
@@ -7,9 +7,9 @@ namespace Nekoyume.Blockchain
     public class ActionTimeoutException : TimeoutException
     {
         public readonly TxId? TxId;
-        public readonly Guid ActionId;
+        public readonly Guid? ActionId;
 
-        public ActionTimeoutException(string message, TxId? txId, Guid actionId) : base(message)
+        public ActionTimeoutException(string message, TxId? txId, Guid? actionId) : base(message)
         {
             TxId = txId;
             ActionId = actionId;
@@ -18,13 +18,15 @@ namespace Nekoyume.Blockchain
         protected ActionTimeoutException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
-            ActionId = (Guid) info.GetValue(nameof(ActionId), typeof(Guid));
+            TxId = (TxId?) info.GetValue(nameof(TxId), typeof(TxId));
+            ActionId = (Guid?) info.GetValue(nameof(ActionId), typeof(Guid));
         }
 
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             base.GetObjectData(info, context);
 
+            info.AddValue(nameof(TxId), TxId);
             info.AddValue(nameof(ActionId), ActionId);
         }
     }

--- a/nekoyume/Assets/_Scripts/Blockchain/ErrorCode.cs
+++ b/nekoyume/Assets/_Scripts/Blockchain/ErrorCode.cs
@@ -138,9 +138,9 @@ namespace Nekoyume.Blockchain
                             code = "27";
                         }
                     }
-                    else
+                    else if (ate.ActionId.HasValue)
                     {
-                        if (Game.Game.instance.Agent.TryGetTxId(ate.ActionId, out txId))
+                        if (Game.Game.instance.Agent.TryGetTxId(ate.ActionId.Value, out txId))
                         {
                             errorMsg += $" Transaction for action is still staged. (txId: {txId})";
                             code = "26";

--- a/nekoyume/Assets/_Scripts/State/LocalLayer.cs
+++ b/nekoyume/Assets/_Scripts/State/LocalLayer.cs
@@ -44,8 +44,7 @@ namespace Nekoyume.State
         private ModifierInfo<AvatarStateModifier> _avatarModifierInfo;
 
         private readonly Dictionary<Address, ModifierInfo<CombinationSlotStateModifier>>
-            _combinationSlotModifierInfos =
-                new Dictionary<Address, ModifierInfo<CombinationSlotStateModifier>>();
+            _combinationSlotModifierInfos = new();
 
         private ModifierInfo<WeeklyArenaStateModifier> _weeklyArenaModifierInfo;
 
@@ -523,6 +522,36 @@ namespace Nekoyume.State
             }
 
             return PostModify(state, _avatarModifierInfo);
+        }
+
+        public AvatarState ModifyInventoryOnly(AvatarState avatarState)
+        {
+            if (avatarState is null ||
+                _avatarModifierInfo is null)
+            {
+                return null;
+            }
+
+            var address = avatarState.address;
+            if (!_avatarModifierInfo.Address.Equals(address))
+            {
+                return null;
+            }
+
+            foreach (var m in _avatarModifierInfo.Modifiers)
+            {
+                if (m is not AvatarInventoryFungibleItemRemover &&
+                    m is not AvatarInventoryItemEquippedModifier &&
+                    m is not AvatarInventoryTradableItemRemover &&
+                    m is not AvatarInventoryNonFungibleItemRemover)
+                {
+                    continue;
+                }
+
+                avatarState = m.Modify(avatarState);
+            }
+
+            return avatarState;
         }
 
         public CombinationSlotState Modify(CombinationSlotState state)

--- a/nekoyume/Assets/_Scripts/UI/Widget/Menu.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Menu.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using System.Linq;
 using DG.Tweening;
 using Lib9c;
+using Libplanet.Crypto;
 using Libplanet.Types.Assets;
 using Nekoyume.Game;
 using Nekoyume.Game.Controller;
@@ -728,55 +729,100 @@ namespace Nekoyume.UI
         {
             base.Update();
 
-            if (Input.GetKey(KeyCode.LeftControl))
+            if (!Input.GetKey(KeyCode.LeftControl))
             {
-                if (Input.GetKeyDown(KeyCode.C) &&
-                    !Find<CombinationResultPopup>().gameObject.activeSelf)
-                {
-                    Find<CombinationResultPopup>().ShowWithEditorProperty();
-                }
-                else if (Input.GetKeyDown(KeyCode.E) &&
-                         !Find<EnhancementResultPopup>().gameObject.activeSelf)
-                {
-                    Find<EnhancementResultPopup>().ShowWithEditorProperty();
-                }
-                else if (Input.GetKeyDown(KeyCode.U) &&
-                         !Find<OneButtonSystem>().gameObject.activeSelf)
+                return;
+            }
+
+            if (Input.GetKeyDown(KeyCode.C))
+            {
+                var game = Game.Game.instance;
+                var states = game.States;
+                var avatarAddr = states.CurrentAvatarState.address;
+                ActionManager.Instance.ClaimItems(
+                    (
+                        avatarAddr,
+                        new[]
+                        {
+                            FungibleAssetValue.FromRawValue(
+                                Currency.Uncapped(
+                                    ticker: "Item_T_400000",
+                                    decimalPlaces: 0,
+                                    minters: null),
+                                100)
+                        }));
+            }
+
+            if (Input.GetKey(KeyCode.T))
+            {
+                if (Input.GetKeyDown(KeyCode.Alpha1))
                 {
                     var game = Game.Game.instance;
                     var states = game.States;
-                    var sheet = game.TableSheets.MaterialItemSheet;
-                    var mail = new UnloadFromMyGaragesRecipientMail(
-                        game.Agent.BlockIndex,
-                        Guid.NewGuid(),
-                        game.Agent.BlockIndex,
-                        fungibleAssetValue: new[]
-                        {
-                            (
-                                states.AgentState.address,
-                                new FungibleAssetValue(
-                                    states.GoldBalanceState.Gold.Currency,
-                                    9,
-                                    99)
-                            ),
-                            (states.CurrentAvatarState.address, 99 * Currencies.Crystal),
-                        },
-                        fungibleIdAndCount: sheet.OrderedList!.Take(3)
-                            .Select((row, index) => (
-                                row.ItemId,
-                                index + 1)),
-                        "memo")
-                    {
-                        New = true,
-                    };
-                    var mailBox = states.CurrentAvatarState.mailBox;
-                    mailBox.Add(mail);
-                    mailBox.CleanUp();
-                    states.CurrentAvatarState.mailBox = mailBox;
-                    LocalLayerModifier.AddNewMail(
-                        game.States.CurrentAvatarState.address,
-                        mail.id);
+                    var sender = states.AgentState.address;
+                    ActionManager.Instance.TransferAsset(
+                        sender,
+                        new Address("0x9723f230A20372564c50d63403223e83549a477f"),
+                        states.GoldBalanceState.Gold.Currency * 100);
                 }
+                else if (Input.GetKeyDown(KeyCode.Alpha2))
+                {
+                    var game = Game.Game.instance;
+                    var states = game.States;
+                    var sender = states.AgentState.address;
+                    var recipient = new Address("0x9723f230A20372564c50d63403223e83549a477f");
+                    ActionManager.Instance.TransferAssets(
+                        sender,
+                        (
+                            recipient,
+                            states.GoldBalanceState.Gold.Currency * 100
+                        ),
+                        (
+                            recipient,
+                            Currency.Uncapped(
+                                ticker: "Item_T_400000",
+                                decimalPlaces: 0,
+                                minters: null) * 100
+                        ));
+                }
+            }
+
+            if (Input.GetKeyDown(KeyCode.U) &&
+                !Find<OneButtonSystem>().gameObject.activeSelf)
+            {
+                var game = Game.Game.instance;
+                var states = game.States;
+                var sheet = game.TableSheets.MaterialItemSheet;
+                var mail = new UnloadFromMyGaragesRecipientMail(
+                    game.Agent.BlockIndex,
+                    Guid.NewGuid(),
+                    game.Agent.BlockIndex,
+                    fungibleAssetValue: new[]
+                    {
+                        (
+                            states.AgentState.address,
+                            new FungibleAssetValue(
+                                states.GoldBalanceState.Gold.Currency,
+                                9,
+                                99)
+                        ),
+                        (states.CurrentAvatarState.address, 99 * Currencies.Crystal),
+                    },
+                    fungibleIdAndCount: sheet.OrderedList!.Take(3)
+                        .Select((row, index) => (
+                            row.ItemId,
+                            index + 1)),
+                    "memo")
+                {
+                    New = true,
+                };
+                var mailBox = states.CurrentAvatarState.mailBox;
+                mailBox.Add(mail);
+                mailBox.CleanUp();
+                states.CurrentAvatarState.mailBox = mailBox;
+                LocalLayerModifier.AddNewMail(
+                    game.States.CurrentAvatarState.address,
+                    mail.id);
             }
         }
 #endif


### PR DESCRIPTION
- [x] I'll rebase this after https://github.com/planetarium/NineChronicles/pull/3138 will be merged.

# Main features

- introduce `LocalLayer.ModifyInventoryOnly(avatarState)` method.
- introduce `ActionHandler.UpdateCurrentAvatarInventory<T>(eval)` method.
- rendering the `ClaimItems` action.
- rendering the `TransferAssets` action.

# Other features

- improve `StateViewer`.
- change test shortcuts on lobby.