### PR TITLE
feat: introduce `BlockchainCache`

### DIFF
--- a/nekoyume/Assets/Tests/EditMode/Blockchain.meta
+++ b/nekoyume/Assets/Tests/EditMode/Blockchain.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 6c49c4779c9c429f8cc595b56f925d7c
+timeCreated: 1697159683

--- a/nekoyume/Assets/Tests/EditMode/Blockchain/BlockHashCacheTest.cs
+++ b/nekoyume/Assets/Tests/EditMode/Blockchain/BlockHashCacheTest.cs
@@ -1,0 +1,98 @@
+using System.Security.Cryptography;
+using Libplanet.Common;
+using Libplanet.Types.Blocks;
+using Nekoyume.Blockchain;
+using NUnit.Framework;
+
+namespace Tests.EditMode.Blockchain
+{
+    public class BlockHashCacheTest
+    {
+        [Test]
+        public void Add()
+        {
+            var cache = new BlockHashCache(2);
+            var blockHash = BlockHash.FromString("0123456789012345678901234567890123456789012345678901234567890123");
+            var stateRootHash =
+                HashDigest<SHA256>.FromString("0123456789012345678901234567890123456789012345678901234567890123");
+            cache.Add(0, blockHash, stateRootHash);
+            cache.Add(1, blockHash, stateRootHash);
+            cache.Add(2, blockHash, stateRootHash);
+        }
+
+        [Test]
+        public void TryGetWithBlockIndex()
+        {
+            var cache = new BlockHashCache(1);
+            Assert.IsFalse(cache.TryGet(0, out _, out _));
+            var blockHash = BlockHash.FromString("0123456789012345678901234567890123456789012345678901234567890123");
+            var stateRootHash =
+                HashDigest<SHA256>.FromString("0123456789012345678901234567890123456789012345678901234567890123");
+            cache.Add(0, blockHash, stateRootHash);
+            Assert.IsTrue(cache.TryGet(0, out var outBlockHash, out var outStateRootHash));
+            Assert.AreEqual(blockHash, outBlockHash);
+            Assert.AreEqual(stateRootHash, outStateRootHash);
+            cache.Add(1, blockHash, stateRootHash);
+            Assert.IsFalse(cache.TryGet(0, out _, out _));
+            Assert.IsTrue(cache.TryGet(1, out outBlockHash, out outStateRootHash));
+            Assert.AreEqual(blockHash, outBlockHash);
+            Assert.AreEqual(stateRootHash, outStateRootHash);
+        }
+
+        [Test]
+        public void TryGetWithBlockHash()
+        {
+            var cache = new BlockHashCache(1);
+            var blockHash1 = BlockHash.FromString("0123456789012345678901234567890123456789012345678901234567890123");
+            var stateRootHash1 =
+                HashDigest<SHA256>.FromString("0123456789012345678901234567890123456789012345678901234567890123");
+            Assert.IsFalse(cache.TryGet(blockHash1, out _, out _));
+            cache.Add(0, blockHash1, stateRootHash1);
+            Assert.IsTrue(cache.TryGet(blockHash1, out var outBlockIndex1, out var outStateRootHash1));
+            Assert.AreEqual(0, outBlockIndex1);
+            Assert.AreEqual(stateRootHash1, outStateRootHash1);
+            var blockHash2 = BlockHash.FromString("1123456789012345678901234567890123456789012345678901234567890123");
+            var stateRootHash2 =
+                HashDigest<SHA256>.FromString("1123456789012345678901234567890123456789012345678901234567890123");
+            cache.Add(1, blockHash2, stateRootHash2);
+            Assert.IsFalse(cache.TryGet(blockHash1, out _, out _));
+            Assert.IsTrue(cache.TryGet(blockHash2, out var outBlockIndex2, out var outStateRootHash2));
+            Assert.AreEqual(1, outBlockIndex2);
+            Assert.AreEqual(stateRootHash2, outStateRootHash2);
+        }
+
+        [Test]
+        public void TryGetWithStateRootHash()
+        {
+            var cache = new BlockHashCache(1);
+            var blockHash1 = BlockHash.FromString("0123456789012345678901234567890123456789012345678901234567890123");
+            var stateRootHash1 =
+                HashDigest<SHA256>.FromString("0123456789012345678901234567890123456789012345678901234567890123");
+            Assert.IsFalse(cache.TryGet(stateRootHash1, out _, out _));
+            cache.Add(0, blockHash1, stateRootHash1);
+            Assert.IsTrue(cache.TryGet(stateRootHash1, out var outBlockIndex1, out var outBlockHash1));
+            Assert.AreEqual(0, outBlockIndex1);
+            Assert.AreEqual(blockHash1, outBlockHash1);
+            var blockHash2 = BlockHash.FromString("1123456789012345678901234567890123456789012345678901234567890123");
+            var stateRootHash2 =
+                HashDigest<SHA256>.FromString("1123456789012345678901234567890123456789012345678901234567890123");
+            cache.Add(1, blockHash2, stateRootHash2);
+            Assert.IsFalse(cache.TryGet(stateRootHash1, out _, out _));
+            Assert.IsTrue(cache.TryGet(stateRootHash2, out var outBlockIndex2, out var outBlockHash2));
+            Assert.AreEqual(1, outBlockIndex2);
+            Assert.AreEqual(blockHash2, outBlockHash2);
+        }
+
+        [Test]
+        public void Clear()
+        {
+            var cache = new BlockHashCache(3);
+            cache.Add(
+                0,
+                BlockHash.FromString("0123456789012345678901234567890123456789012345678901234567890123"),
+                HashDigest<SHA256>.FromString("0123456789012345678901234567890123456789012345678901234567890123"));
+            cache.Clear();
+            Assert.IsFalse(cache.TryGet(0, out _, out _));
+        }
+    }
+}

--- a/nekoyume/Assets/Tests/EditMode/Blockchain/BlockHashCacheTest.cs.meta
+++ b/nekoyume/Assets/Tests/EditMode/Blockchain/BlockHashCacheTest.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: b9df14e81c8d4d21a0e6d72490ff3a53
+timeCreated: 1697165911

--- a/nekoyume/Assets/Tests/EditMode/Blockchain/BlockchainCacheTest.cs
+++ b/nekoyume/Assets/Tests/EditMode/Blockchain/BlockchainCacheTest.cs
@@ -1,0 +1,100 @@
+using System.Security.Cryptography;
+using Libplanet.Common;
+using Libplanet.Crypto;
+using Libplanet.Types.Assets;
+using Libplanet.Types.Blocks;
+using Nekoyume.Blockchain;
+using NUnit.Framework;
+
+namespace Tests.EditMode.Blockchain
+{
+    public class BlockchainCacheTest
+    {
+        private Currency _currency1;
+        private Currency _currency2;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _currency1 = Currency.Capped("C1", 0, (100, 0), minters: null);
+            _currency2 = Currency.Capped("C2", 0, (100, 0), minters: null);
+        }
+
+        [Test]
+        public void Add()
+        {
+            var cache = new BlockchainCache(3);
+            var addr = new PrivateKey().ToAddress();
+            cache.Add(addr, _currency1 * 100, 0);
+            cache.Add(addr, _currency1 * 100, 1);
+            cache.Add(addr, _currency1 * 100, 2);
+            cache.Add(addr, _currency2 * 100, 2);
+        }
+
+        [Test]
+        public void TryGetBalance()
+        {
+            var cache = new BlockchainCache(1);
+            var addr = new PrivateKey().ToAddress();
+            Assert.IsFalse(cache.TryGetBalance(addr, _currency1, out _));
+            cache.Add(addr, _currency1 * 100, blockIndex: 0);
+            Assert.IsTrue(cache.TryGetBalance(addr, _currency1,
+                out var outBalance,
+                out var outBlockIndex,
+                out var outBlockHash,
+                out var outStateRootHash));
+
+            Assert.IsTrue(cache.TryGetBalance(0, addr, _currency1,
+                out outBalance,
+                out outBlockHash,
+                out outStateRootHash));
+            Assert.AreEqual(_currency1 * 100, outBalance);
+            Assert.IsNull(outBlockHash);
+            Assert.IsNull(outStateRootHash);
+
+            var blockHash = BlockHash.FromString("0123456789012345678901234567890123456789012345678901234567890123");
+            cache.Add(addr, _currency1 * 100, blockHash: blockHash);
+            Assert.IsTrue(cache.TryGetBalance(blockHash, addr, _currency1,
+                out outBalance,
+                out outBlockIndex,
+                out outStateRootHash));
+            Assert.AreEqual(_currency1 * 100, outBalance);
+            Assert.IsNull(outBlockIndex);
+            Assert.IsNull(outStateRootHash);
+
+            var stateRootHash =
+                HashDigest<SHA256>.FromString("0123456789012345678901234567890123456789012345678901234567890123");
+            cache.Add(addr, _currency1 * 100, stateRootHash: stateRootHash);
+            Assert.IsTrue(cache.TryGetBalance(stateRootHash, addr, _currency1,
+                out outBalance,
+                out outBlockIndex,
+                out outBlockHash));
+            Assert.AreEqual(_currency1 * 100, outBalance);
+            Assert.IsNull(outBlockIndex);
+            Assert.IsNull(outBlockHash);
+
+            Assert.IsFalse(cache.TryGetBalance(addr, _currency2, out _));
+            cache.Add(addr, _currency2 * 100, blockIndex: 1);
+            Assert.IsFalse(cache.TryGetBalance(addr, _currency1, out _));
+            Assert.IsTrue(cache.TryGetBalance(addr, _currency2,
+                out outBalance,
+                out outBlockIndex,
+                out outBlockHash,
+                out outStateRootHash));
+            Assert.AreEqual(_currency2 * 100, outBalance);
+            Assert.AreEqual(1, outBlockIndex);
+            Assert.IsNull(outBlockHash);
+            Assert.IsNull(outStateRootHash);
+        }
+
+        [Test]
+        public void ClearBalance()
+        {
+            var cache = new BlockchainCache(1);
+            var addr = new PrivateKey().ToAddress();
+            cache.Add(addr, _currency1 * 100, 0);
+            cache.ClearBalance();
+            Assert.IsFalse(cache.TryGetBalance(addr, _currency1, out _));
+        }
+    }
+}

--- a/nekoyume/Assets/Tests/EditMode/Blockchain/BlockchainCacheTest.cs.meta
+++ b/nekoyume/Assets/Tests/EditMode/Blockchain/BlockchainCacheTest.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 6da20edfdc704e34b112733dcafef680
+timeCreated: 1697159693

--- a/nekoyume/Assets/_Scripts/Blockchain/BlockHashCache.cs
+++ b/nekoyume/Assets/_Scripts/Blockchain/BlockHashCache.cs
@@ -1,52 +1,118 @@
+using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography;
+using Libplanet.Common;
 using Libplanet.Types.Blocks;
 
 namespace Nekoyume.Blockchain
 {
     public class BlockHashCache
     {
-        private readonly Dictionary<long, BlockHash> _dict;
-        private readonly Queue<long> _keys;
-        public int MaxCapacity { get; }
+        private readonly int _capacity;
 
-        public BlockHashCache(int maxCapacity)
-        {
-            _dict = new Dictionary<long, BlockHash>(maxCapacity);
-            _keys = new Queue<long>(maxCapacity);
-            MaxCapacity = maxCapacity;
-        }
+        private readonly int _evictCount;
 
-        public void Add(long blockIndex, BlockHash blockHash)
+        // TODO: fix stateRootHash to non-nullable with IBlockChainService.
+        private readonly List<(long blockIndex, BlockHash blockHash, HashDigest<SHA256>? stateRootHash)> _cache;
+
+        public BlockHashCache(int capacity)
         {
-            if (_dict.ContainsKey(blockIndex))
+            if (capacity < 1)
             {
-                return;
+                throw new ArgumentOutOfRangeException(
+                    nameof(capacity),
+                    capacity,
+                    "Must be greater than 0."
+                );
             }
 
-            if (_dict.Count >= MaxCapacity)
+            _capacity = capacity;
+            _evictCount = Math.Max(1, capacity / 10);
+            _cache = new List<(long blockIndex, BlockHash blockHash, HashDigest<SHA256>?)>(_capacity);
+        }
+
+        public void Add(long blockIndex, BlockHash blockHash, HashDigest<SHA256>? stateRootHash)
+        {
+            if (_cache.Count >= _capacity)
             {
-                var key = _keys.Dequeue();
-                _dict.Remove(key);
+                Evict();
             }
 
-            _dict.Add(blockIndex, blockHash);
-            _keys.Enqueue(blockIndex);
+            _cache.Add((blockIndex, blockHash, stateRootHash));
         }
 
-        public bool TryGetBlockHash(long blockIndex, out BlockHash blockHash)
+        public bool TryGet(
+            long blockIndex,
+            out BlockHash blockHash,
+            out HashDigest<SHA256>? stateRootHash)
         {
-            return _dict.TryGetValue(blockIndex, out blockHash);
+            try
+            {
+                (_, blockHash, stateRootHash) = _cache.First(t => t.blockIndex == blockIndex);
+                return true;
+            }
+            catch
+            {
+                blockHash = default;
+                stateRootHash = default;
+                return false;
+            }
         }
 
-        public bool Remove(long blockIndex)
+        public bool TryGet(
+            BlockHash blockHash,
+            out long blockIndex,
+            out HashDigest<SHA256>? stateRootHash)
         {
-            return _dict.Remove(blockIndex);
+            try
+            {
+                (blockIndex, _, stateRootHash) = _cache.First(t => t.blockHash.Equals(blockHash));
+                return true;
+            }
+            catch
+            {
+                blockIndex = default;
+                stateRootHash = default;
+                return false;
+            }
+        }
+
+        public bool TryGet(
+            HashDigest<SHA256> stateRootHash,
+            out long blockIndex,
+            out BlockHash blockHash)
+        {
+            try
+            {
+                (blockIndex, blockHash, _) = _cache.First(t => t.stateRootHash.Equals(stateRootHash));
+                return true;
+            }
+            catch
+            {
+                blockIndex = default;
+                blockHash = default;
+                return false;
+            }
         }
 
         public void Clear()
         {
-            _dict.Clear();
-            _keys.Clear();
+            _cache.Clear();
+        }
+
+        private void Evict()
+        {
+            if (_cache.Count <= _evictCount)
+            {
+                _cache.Clear();
+                return;
+            }
+
+            for (var i = 0; i < _evictCount; i++)
+            {
+                _cache.RemoveAt(0);
+            }
         }
     }
 }

--- a/nekoyume/Assets/_Scripts/Blockchain/BlockchainCache.cs
+++ b/nekoyume/Assets/_Scripts/Blockchain/BlockchainCache.cs
@@ -1,0 +1,262 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using Bencodex.Types;
+using Libplanet.Common;
+using Libplanet.Crypto;
+using Libplanet.Types.Assets;
+using Libplanet.Types.Blocks;
+
+namespace Nekoyume.Blockchain
+{
+    public class BlockchainCache
+    {
+        private class BlockchainData
+        {
+            /// <summary>
+            /// block index of cached data.
+            /// </summary>
+            public long? BlockIndex;
+
+            /// <summary>
+            /// block hash of cached data.
+            /// </summary>
+            public BlockHash? BlockHash;
+
+            /// <summary>
+            /// state root hash of cached data.
+            /// </summary>
+            public HashDigest<SHA256>? StateRootHash;
+        }
+
+        private class BalanceData : BlockchainData
+        {
+            /// <summary>
+            /// cached balance. it can be null.
+            /// </summary>
+            public FungibleAssetValue? Balance;
+        }
+
+        private class StateData : BlockchainData
+        {
+            /// <summary>
+            /// cached state. it can be null.
+            /// </summary>
+            public IValue? State;
+        }
+
+        private readonly int _balanceCapacity;
+        private readonly int _balanceEvictCount;
+        private readonly Queue<(Address address, Currency currency)> _balanceKeyCache;
+        private readonly Dictionary<Address, Dictionary<Currency, BalanceData>> _balanceDict;
+
+        public BlockchainCache(int balanceCapacity)
+        {
+            if (balanceCapacity < 1)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(balanceCapacity),
+                    balanceCapacity,
+                    "Must be greater than 0.");
+            }
+
+            _balanceCapacity = balanceCapacity;
+            _balanceEvictCount = Math.Max(1, balanceCapacity / 10);
+            _balanceKeyCache = new Queue<(Address, Currency)>(_balanceCapacity);
+            _balanceDict = new Dictionary<Address, Dictionary<Currency, BalanceData>>();
+        }
+
+        public void Add(
+            Address address,
+            FungibleAssetValue balance,
+            long? blockIndex = null,
+            BlockHash? blockHash = null,
+            HashDigest<SHA256>? stateRootHash = null)
+        {
+            if (blockIndex == null && blockHash == null && stateRootHash == null)
+            {
+                throw new ArgumentException(
+                    "At least one of blockIndex, blockHash, stateRootHash must be specified.");
+            }
+
+            if (_balanceKeyCache.Count >= _balanceCapacity)
+            {
+                EvictBalance();
+            }
+
+            var data = new BalanceData
+            {
+                Balance = balance,
+                BlockIndex = blockIndex,
+                BlockHash = blockHash,
+                StateRootHash = stateRootHash,
+            };
+            _balanceKeyCache.Enqueue((address, balance.Currency));
+            if (!_balanceDict.ContainsKey(address))
+            {
+                _balanceDict[address] = new Dictionary<Currency, BalanceData>();
+            }
+
+            _balanceDict[address][balance.Currency] = data;
+        }
+
+        #region TryGetBalance
+
+        public bool TryGetBalance(
+            Address address,
+            Currency currency,
+            out FungibleAssetValue? balance,
+            out long? blockIndex,
+            out BlockHash? blockHash,
+            out HashDigest<SHA256>? stateRootHash)
+        {
+            if (_balanceDict.TryGetValue(address, out var dict) &&
+                dict.TryGetValue(currency, out var info))
+            {
+                balance = info.Balance;
+                blockIndex = info.BlockIndex;
+                blockHash = info.BlockHash;
+                stateRootHash = info.StateRootHash;
+                return true;
+            }
+
+            balance = null;
+            blockIndex = null;
+            blockHash = null;
+            stateRootHash = null;
+            return false;
+        }
+
+        public bool TryGetBalance(
+            Address address,
+            Currency currency,
+            out FungibleAssetValue? balance) =>
+            TryGetBalance(address, currency, out balance, out _, out _, out _);
+
+        public bool TryGetBalance(
+            long blockIndex,
+            Address address,
+            Currency currency,
+            out FungibleAssetValue? balance,
+            out BlockHash? blockHash,
+            out HashDigest<SHA256>? stateRootHash)
+        {
+            if (_balanceDict.TryGetValue(address, out var dict) &&
+                dict.TryGetValue(currency, out var info) &&
+                info.BlockIndex.HasValue &&
+                info.BlockIndex == blockIndex)
+            {
+                balance = info.Balance;
+                blockHash = info.BlockHash;
+                stateRootHash = info.StateRootHash;
+                return true;
+            }
+
+            balance = null;
+            blockHash = null;
+            stateRootHash = null;
+            return false;
+        }
+
+        public bool TryGetBalance(
+            long blockIndex,
+            Address address,
+            Currency currency,
+            out FungibleAssetValue? balance) =>
+            TryGetBalance(blockIndex, address, currency, out balance, out _, out _);
+
+        public bool TryGetBalance(
+            BlockHash blockHash,
+            Address address,
+            Currency currency,
+            out FungibleAssetValue? balance,
+            out long? blockIndex,
+            out HashDigest<SHA256>? stateRootHash)
+        {
+            if (_balanceDict.TryGetValue(address, out var dict) &&
+                dict.TryGetValue(currency, out var info) &&
+                info.BlockHash.HasValue &&
+                info.BlockHash.Value.Equals(blockHash))
+            {
+                balance = info.Balance;
+                blockIndex = info.BlockIndex;
+                stateRootHash = info.StateRootHash;
+                return true;
+            }
+
+            balance = null;
+            blockIndex = default;
+            stateRootHash = null;
+            return false;
+        }
+
+        public bool TryGetBalance(
+            BlockHash blockHash,
+            Address address,
+            Currency currency,
+            out FungibleAssetValue? balance) =>
+            TryGetBalance(blockHash, address, currency, out balance, out _, out _);
+
+        public bool TryGetBalance(
+            HashDigest<SHA256> stateRootHash,
+            Address address,
+            Currency currency,
+            out FungibleAssetValue? balance,
+            out long? blockIndex,
+            out BlockHash? blockHash)
+        {
+            if (_balanceDict.TryGetValue(address, out var dict) &&
+                dict.TryGetValue(currency, out var info) &&
+                info.StateRootHash.HasValue &&
+                info.StateRootHash.Value.Equals(stateRootHash))
+            {
+                balance = info.Balance;
+                blockIndex = info.BlockIndex;
+                blockHash = info.BlockHash;
+                return true;
+            }
+
+            balance = null;
+            blockIndex = default;
+            blockHash = null;
+            return false;
+        }
+
+        public bool TryGetBalance(
+            HashDigest<SHA256> stateRootHash,
+            Address address,
+            Currency currency,
+            out FungibleAssetValue? balance) =>
+            TryGetBalance(stateRootHash, address, currency, out balance, out _, out _);
+
+        #endregion
+
+        public void ClearBalance()
+        {
+            _balanceKeyCache.Clear();
+            _balanceDict.Clear();
+        }
+
+        private void EvictBalance()
+        {
+            for (var i = 0; i < _balanceEvictCount; i++)
+            {
+                if (!_balanceKeyCache.TryDequeue(out var key))
+                {
+                    break;
+                }
+
+                if (_balanceDict.TryGetValue(key.address, out var dict))
+                {
+                    dict.Remove(key.currency);
+                    if (dict.Count == 0)
+                    {
+                        _balanceDict.Remove(key.address);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/nekoyume/Assets/_Scripts/Blockchain/BlockchainCache.cs.meta
+++ b/nekoyume/Assets/_Scripts/Blockchain/BlockchainCache.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 9e54796ef3be4d2d95a052bbe2e6d1f2
+timeCreated: 1697096119


### PR DESCRIPTION
This pull request based on https://github.com/planetarium/NineChronicles/pull/3192.

# Context
We have many `Currency`. But those `Currencies`'s handling is all different.
For the future proof, we need to make robust state handling.

# Rationale
In this PR, as the first step, to overhaul the state cache, we introduce `BlockChainCache`.
Do not have a usage in this PR but we prepared a follow-up PR which using this.

<img width="325" alt="image" src="https://github.com/planetarium/NineChronicles/assets/6128868/f67b64b1-a217-45b6-895c-f31a297a207d">

relate proposal: [internal notion](https://www.notion.so/planetarium/3a64d250faca4a4c9d8eb2cba46ad794?pvs=4#c85fa6f1e3a64d96b233e59ba4fa650b)

