### PR TITLE
feat: introduce and apply `States.NCG`

### DIFF
--- a/nekoyume/Assets/Plugins/StateViewer/Editor/StateViewerWindow.cs
+++ b/nekoyume/Assets/Plugins/StateViewer/Editor/StateViewerWindow.cs
@@ -129,7 +129,7 @@ namespace StateViewer.Editor
                 return null;
             }
 
-            return _ncg ??= Game.instance.States?.GoldBalanceState?.Gold.Currency;
+            return _ncg ??= Game.instance.States?.NCG;
         }
 
         public TableSheets? GetTableSheets()
@@ -167,7 +167,7 @@ namespace StateViewer.Editor
                 _stateProxy.RegisterAlias("me", states.CurrentAvatarState.address);
             }
 
-            _ncg = states.GoldBalanceState.Gold.Currency;
+            _ncg = states.NCG;
         }
     }
 }

--- a/nekoyume/Assets/_Scripts/Blockchain/ActionHandler.cs
+++ b/nekoyume/Assets/_Scripts/Blockchain/ActionHandler.cs
@@ -23,7 +23,6 @@ namespace Nekoyume.Blockchain
     public abstract class ActionHandler
     {
         public bool Pending { get; set; }
-        public Currency GoldCurrency { get; internal set; }
 
         public abstract void Start(ActionRenderer renderer);
 
@@ -51,7 +50,7 @@ namespace Nekoyume.Blockchain
 
             return StateGetter.GetGoldBalanceState(
                 agentAddress,
-                GoldCurrency,
+                States.Instance.NCG,
                 evaluation.OutputState);
         }
 
@@ -80,7 +79,7 @@ namespace Nekoyume.Blockchain
                     return (stakeAddr, null, new FungibleAssetValue(), 0, null, null);
                 }
 
-                var balance = await agent.GetBalanceAsync(stakeAddr, GoldCurrency);
+                var balance = await agent.GetBalanceAsync(stakeAddr, States.Instance.NCG);
                 var sheetAddrArr = new[]
                 {
                     Addresses.GetSheetAddress(

--- a/nekoyume/Assets/_Scripts/Blockchain/ActionManager.cs
+++ b/nekoyume/Assets/_Scripts/Blockchain/ActionManager.cs
@@ -318,9 +318,7 @@ namespace Nekoyume.Blockchain
                     ? TableSheets.Instance.EventScheduleSheet.TryGetValue(
                         eventScheduleId,
                         out var scheduleRow)
-                        ? scheduleRow.GetDungeonTicketCost(
-                            numberOfTicketPurchases,
-                            States.Instance.GoldBalanceState.Gold.Currency)
+                        ? scheduleRow.GetDungeonTicketCost(numberOfTicketPurchases, States.Instance.NCG)
                             .GetQuantityString(true)
                         : "0"
                     : "0",

--- a/nekoyume/Assets/_Scripts/Blockchain/ActionRenderHandler.cs
+++ b/nekoyume/Assets/_Scripts/Blockchain/ActionRenderHandler.cs
@@ -2943,7 +2943,7 @@ namespace Nekoyume.Blockchain
                             balanceAddr,
                             value.Currency,
                             states);
-                        if (value.Currency.Equals(GoldCurrency))
+                        if (value.Currency.Equals(States.Instance.NCG))
                         {
                             var goldState = new GoldBalanceState(balanceAddr, balance);
                             gameStates.SetGoldBalanceState(goldState);

--- a/nekoyume/Assets/_Scripts/Blockchain/Agent.cs
+++ b/nekoyume/Assets/_Scripts/Blockchain/Agent.cs
@@ -465,7 +465,6 @@ namespace Nekoyume.Blockchain
                 {
                     var goldCurrencyState = new GoldCurrencyState(goldDict);
                     States.Instance.SetGoldCurrencyState(goldCurrencyState);
-                    ActionRenderHandler.Instance.GoldCurrency = goldCurrencyState.Currency;
                 }
                 else
                 {

--- a/nekoyume/Assets/_Scripts/Blockchain/BlockRenderHandler.cs
+++ b/nekoyume/Assets/_Scripts/Blockchain/BlockRenderHandler.cs
@@ -79,7 +79,7 @@ namespace Nekoyume.Blockchain
                         FungibleAssetValue garage;
                         try
                         {
-                            var ncg = States.Instance.GoldBalanceState.Gold.Currency;
+                            var ncg = States.Instance.NCG;
                             var favArr = await Task.WhenAll(
                                 agent.GetBalanceAsync(agentState.address, ncg),
                                 agent.GetBalanceAsync(agentState.address, Currencies.Crystal),

--- a/nekoyume/Assets/_Scripts/Blockchain/RPCAgent.cs
+++ b/nekoyume/Assets/_Scripts/Blockchain/RPCAgent.cs
@@ -546,21 +546,27 @@ namespace Nekoyume.Blockchain
             // 에이전트의 상태를 한 번 동기화 한다.
             var currencyTask = Task.Run(async () =>
             {
-                var goldCurrency = new GoldCurrencyState(
-                    (Dictionary)await GetStateAsync(GoldCurrencyState.Address)
-                ).Currency;
-                ActionRenderHandler.Instance.GoldCurrency = goldCurrency;
-
                 await States.Instance.SetAgentStateAsync(
                     await GetStateAsync(Address) is Dictionary agentDict
                         ? new AgentState(agentDict)
                         : new AgentState(Address));
+                var ncg = States.Instance.NCG;
                 States.Instance.SetGoldBalanceState(
                     new GoldBalanceState(
                         Address,
-                        await GetBalanceAsync(Address, goldCurrency)));
+                        await GetBalanceAsync(Address, ncg)));
                 States.Instance.SetCrystalBalance(
                     await GetBalanceAsync(Address, Currencies.Crystal));
+                if (await GetStateAsync(GoldCurrencyState.Address) is Dictionary goldDict)
+                {
+                    var goldCurrencyState = new GoldCurrencyState(goldDict);
+                    States.Instance.SetGoldCurrencyState(goldCurrencyState);
+                    ActionRenderHandler.Instance.GoldCurrency = goldCurrencyState.Currency;
+                }
+                else
+                {
+                    throw new FailedToInstantiateStateException<GoldCurrencyState>();
+                }
 
                 if (await GetStateAsync(GameConfigState.Address) is Dictionary configDict)
                 {
@@ -584,13 +590,13 @@ namespace Nekoyume.Blockchain
                     }
                     else
                     {
-                        var balance = new FungibleAssetValue(goldCurrency);
+                        var balance = new FungibleAssetValue(ncg);
                         var level = 0;
                         var stakeRegularFixedRewardSheet = new StakeRegularFixedRewardSheet();
                         var stakeRegularRewardSheet = new StakeRegularRewardSheet();
                         try
                         {
-                            balance = await GetBalanceAsync(stakeAddr, goldCurrency);
+                            balance = await GetBalanceAsync(stakeAddr, ncg);
                             var sheetAddrArr = new[]
                             {
                                 Addresses.GetSheetAddress(

--- a/nekoyume/Assets/_Scripts/Blockchain/RPCAgent.cs
+++ b/nekoyume/Assets/_Scripts/Blockchain/RPCAgent.cs
@@ -561,7 +561,6 @@ namespace Nekoyume.Blockchain
                 {
                     var goldCurrencyState = new GoldCurrencyState(goldDict);
                     States.Instance.SetGoldCurrencyState(goldCurrencyState);
-                    ActionRenderHandler.Instance.GoldCurrency = goldCurrencyState.Currency;
                 }
                 else
                 {

--- a/nekoyume/Assets/_Scripts/Extensions/LocalizationExtensions.cs
+++ b/nekoyume/Assets/_Scripts/Extensions/LocalizationExtensions.cs
@@ -215,10 +215,10 @@ namespace Nekoyume
                     var price = item?.Price ?? fav?.Price ?? 0;
                     var tax = decimal.Divide(price, 100) * Buy.TaxRate;
                     var tp = price - tax;
-                    var currency = States.Instance.GoldBalanceState.Gold.Currency;
+                    var ncg = States.Instance.NCG;
                     var majorUnit = (int)tp;
                     var minorUnit = (int)((tp - majorUnit) * 100);
-                    var fungibleAsset = new FungibleAssetValue(currency, majorUnit, minorUnit);
+                    var fungibleAsset = new FungibleAssetValue(ncg, majorUnit, minorUnit);
                     return L10nManager.Localize("UI_SELLER_MAIL_FORMAT", fungibleAsset,
                         sellProductName);
                 case UnloadFromMyGaragesRecipientMail unloadFromMyGaragesRecipientMail:
@@ -698,8 +698,7 @@ namespace Nekoyume
             BigInteger cost)
         {
             // NCG
-            if (asset.Currency.Equals(
-                    Game.Game.instance.States.GoldBalanceState.Gold.Currency))
+            if (asset.Currency.Equals(States.Instance.NCG))
             {
                 var ncgText = L10nManager.Localize("UI_NCG");
                 return L10nManager.Localize(

--- a/nekoyume/Assets/_Scripts/Helper/PetFrontHelper.cs
+++ b/nekoyume/Assets/_Scripts/Helper/PetFrontHelper.cs
@@ -91,7 +91,8 @@ namespace Nekoyume.Helper
                 return false;
             }
 
-            var ncgCost = States.Instance.GoldBalanceState.Gold.Currency * nextCost.NcgQuantity;
+            var ncg = States.Instance.NCG;
+            var ncgCost = ncg * nextCost.NcgQuantity;
             var soulStoneCost =
                 PetHelper.GetSoulstoneCurrency(TableSheets.Instance.PetSheet[id].SoulStoneTicker) *
                 nextCost.SoulStoneQuantity;

--- a/nekoyume/Assets/_Scripts/State/LocalLayerModifier.cs
+++ b/nekoyume/Assets/_Scripts/State/LocalLayerModifier.cs
@@ -53,10 +53,7 @@ namespace Nekoyume.State
                 return;
             }
 
-            var fav = new FungibleAssetValue(
-                States.Instance.GoldBalanceState.Gold.Currency,
-                gold,
-                0);
+            var fav = new FungibleAssetValue(States.Instance.NCG, gold, 0);
             ModifyAgentGoldAsync(agentAddress, fav).Forget();
         }
 

--- a/nekoyume/Assets/_Scripts/State/States.cs
+++ b/nekoyume/Assets/_Scripts/State/States.cs
@@ -29,13 +29,17 @@ using Event = Nekoyume.Game.Event;
 namespace Nekoyume.State
 {
     /// <summary>
-    /// 클라이언트가 참조할 상태를 포함한다.
-    /// 체인의 상태를 Setter를 통해서 받은 후, 로컬의 상태로 필터링해서 사용한다.
+    /// The blockchain state for game client.
+    /// - Set blockchain state by setter methods here.
+    /// - The blockchain state modified by <see cref="LocalLayer"/> in setter methods.
+    /// - Get modified blockchain state by getter methods here.
     /// </summary>
     public class States
     {
         public static States Instance => Game.Game.instance.States;
 
+        public GoldCurrencyState GoldCurrencyState { get; private set; }
+        public Currency NCG => GoldCurrencyState.Currency;
         public AgentState AgentState { get; private set; }
 
         public GoldBalanceState GoldBalanceState { get; private set; }
@@ -103,6 +107,11 @@ namespace Nekoyume.State
         }
 
         #region Setter
+
+        public void SetGoldCurrencyState(GoldCurrencyState state)
+        {
+            GoldCurrencyState = state;
+        }
 
         /// <summary>
         /// 에이전트 상태를 할당한다.

--- a/nekoyume/Assets/_Scripts/State/Subjects/AgentStateSubject.cs
+++ b/nekoyume/Assets/_Scripts/State/Subjects/AgentStateSubject.cs
@@ -30,7 +30,7 @@ namespace Nekoyume.State.Subjects
 
         public static void OnNextGold(FungibleAssetValue gold)
         {
-            if (gold.Currency.Equals(States.Instance.GoldBalanceState.Gold.Currency))
+            if (gold.Currency.Equals(States.Instance.NCG))
             {
                 _gold.OnNext(gold);
             }

--- a/nekoyume/Assets/_Scripts/UI/Model/ItemCountAndPricePopup.cs
+++ b/nekoyume/Assets/_Scripts/UI/Model/ItemCountAndPricePopup.cs
@@ -14,7 +14,7 @@ namespace Nekoyume.UI.Model
 
         public ItemCountAndPricePopup()
         {
-            var currency = States.Instance.GoldBalanceState.Gold.Currency;
+            var currency = States.Instance.NCG;
             Price = new ReactiveProperty<FungibleAssetValue>(new FungibleAssetValue(currency, 10, 0));
         }
 

--- a/nekoyume/Assets/_Scripts/UI/Shop/CartView.cs
+++ b/nekoyume/Assets/_Scripts/UI/Shop/CartView.cs
@@ -68,8 +68,9 @@ namespace Nekoyume.UI.Module
                 return;
             }
 
+            var ncg = States.Instance.NCG;
             var sortedItems = selectedItems.Where(x => !x.Expired.Value).ToList();
-            var price = new FungibleAssetValue(States.Instance.GoldBalanceState.Gold.Currency, 0 ,0);
+            var price = new FungibleAssetValue(ncg, 0 ,0);
             for (var i = 0; i < cartItems.Count; i++)
             {
                 if (i < sortedItems.Count)
@@ -77,7 +78,7 @@ namespace Nekoyume.UI.Module
                     var p = sortedItems[i].ItemBase is not null
                         ? (BigInteger)sortedItems[i].Product.Price
                         : (BigInteger)sortedItems[i].FungibleAssetProduct.Price;
-                    price += p * States.Instance.GoldBalanceState.Gold.Currency;
+                    price += p * ncg;
                     cartItems[i].gameObject.SetActive(true);
                     cartItems[i].Set(sortedItems[i], (item) =>
                     {

--- a/nekoyume/Assets/_Scripts/UI/Widget/BattlePreparation.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/BattlePreparation.cs
@@ -426,7 +426,7 @@ namespace Nekoyume.UI
                     var cost = RxProps.EventScheduleRowForDungeon.Value
                         .GetDungeonTicketCost(
                             RxProps.EventDungeonInfo.Value?.NumberOfTicketPurchases ?? 0,
-                            States.Instance.GoldBalanceState.Gold.Currency);
+                            States.Instance.NCG);
                     var purchasedCount = RxProps.EventDungeonInfo.Value?.NumberOfTicketPurchases ?? 0;
 
                     Find<TicketPurchasePopup>().Show(

--- a/nekoyume/Assets/_Scripts/UI/Widget/Menu.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Menu.cs
@@ -768,10 +768,7 @@ namespace Nekoyume.UI
                         {
                             (
                                 states.AgentState.address,
-                                new FungibleAssetValue(
-                                    states.GoldBalanceState.Gold.Currency,
-                                    9,
-                                    99)
+                                new FungibleAssetValue(states.NCG, 9, 99)
                             ),
                             (states.CurrentAvatarState.address, 99 * Currencies.Crystal),
                         },

--- a/nekoyume/Assets/_Scripts/UI/Widget/Popup/BattleResultPopup.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Popup/BattleResultPopup.cs
@@ -248,7 +248,7 @@ namespace Nekoyume.UI
                     var cost = RxProps.EventScheduleRowForDungeon.Value
                         .GetDungeonTicketCost(
                             RxProps.EventDungeonInfo.Value?.NumberOfTicketPurchases ?? 0,
-                            States.Instance.GoldBalanceState.Gold.Currency);
+                            States.Instance.NCG);
                     var purchasedCount =
                         RxProps.EventDungeonInfo.Value?.NumberOfTicketPurchases ?? 0;
 
@@ -295,7 +295,7 @@ namespace Nekoyume.UI
                     var cost = RxProps.EventScheduleRowForDungeon.Value
                         .GetDungeonTicketCost(
                             RxProps.EventDungeonInfo.Value?.NumberOfTicketPurchases ?? 0,
-                            States.Instance.GoldBalanceState.Gold.Currency);
+                            States.Instance.NCG);
                     var purchasedCount =
                         RxProps.EventDungeonInfo.Value?.NumberOfTicketPurchases ?? 0;
 

--- a/nekoyume/Assets/_Scripts/UI/Widget/Popup/MailPopup.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Popup/MailPopup.cs
@@ -519,7 +519,7 @@ namespace Nekoyume.UI
             var avatarAddress = States.Instance.CurrentAvatarState.address;
             var agentAddress = States.Instance.AgentState.address;
             var (_, itemProduct, favProduct) = await Game.Game.instance.MarketServiceClient.GetProductInfo(productSellerMail.ProductId);
-            var currency = States.Instance.GoldBalanceState.Gold.Currency;
+            var currency = States.Instance.NCG;
             var price = itemProduct?.Price ?? favProduct.Price;
             var fav = new FungibleAssetValue(currency, (int)price, 0);
             var taxedPrice = fav.DivRem(100, out _) * Action.Buy.TaxRate;

--- a/nekoyume/Assets/_Scripts/UI/Widget/Popup/PetEnhancementPopup.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Popup/PetEnhancementPopup.cs
@@ -226,7 +226,7 @@ namespace Nekoyume.UI
             }
 
             soulStoneCostText.text = soulStone.ToString();
-            var ncgCost = States.Instance.GoldBalanceState.Gold.Currency * ncg;
+            var ncgCost = States.Instance.NCG * ncg;
             var soulStoneCost =
                 PetHelper.GetSoulstoneCurrency(_petRow.SoulStoneTicker) *
                 soulStone;

--- a/nekoyume/Assets/_Scripts/UI/Widget/RaidPreparation.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/RaidPreparation.cs
@@ -373,7 +373,7 @@ namespace Nekoyume.UI
 
             var avatarState = States.Instance.CurrentAvatarState;
             var raiderState = WorldBossStates.GetRaiderState(avatarState.address);
-            var cur = States.Instance.GoldBalanceState.Gold.Currency;
+            var cur = States.Instance.NCG;
             var cost = WorldBossHelper.CalculateTicketPrice(row, raiderState, cur);
             var balance = States.Instance.GoldBalanceState;
             Find<TicketPurchasePopup>().Show(

--- a/nekoyume/Assets/_Scripts/UI/Widget/ShopBuy.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/ShopBuy.cs
@@ -178,11 +178,11 @@ namespace Nekoyume.UI
             {
                 if (model.ItemBase is not null)
                 {
-                    sumPrice += (BigInteger)model.Product.Price * States.Instance.GoldBalanceState.Gold.Currency;
+                    sumPrice += (BigInteger)model.Product.Price * States.Instance.NCG;
                 }
                 else
                 {
-                    sumPrice += (BigInteger)model.FungibleAssetProduct.Price * States.Instance.GoldBalanceState.Gold.Currency;
+                    sumPrice += (BigInteger)model.FungibleAssetProduct.Price * States.Instance.NCG;
                 }
             }
 
@@ -207,7 +207,7 @@ namespace Nekoyume.UI
         {
             var productInfos = new List<IProductInfo>();
             var avatarAddress = States.Instance.CurrentAvatarState.address;
-            var currency = States.Instance.GoldBalanceState.Gold.Currency;
+            var currency = States.Instance.NCG;
             foreach (var model in models)
             {
                 var itemProduct = model.Product;

--- a/nekoyume/Assets/_Scripts/UI/Widget/ShopSell.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/ShopSell.cs
@@ -298,7 +298,7 @@ namespace Nekoyume.UI
             }
 
             var data = SharedModel.ItemCountableAndPricePopup.Value;
-            var currency = States.Instance.GoldBalanceState.Gold.Currency;
+            var currency = States.Instance.NCG;
             data.Price.Value = new FungibleAssetValue(currency, Shop.MinimumPrice, 0);
             data.UnitPrice.Value = new FungibleAssetValue(currency, Shop.MinimumPrice, 0);
             data.Count.Value = 1;
@@ -343,7 +343,7 @@ namespace Nekoyume.UI
                 var unitPrice = price / model.Product.Quantity;
                 var majorUnit = (int)unitPrice;
                 var minorUnit = (int)((unitPrice - majorUnit) * 100);
-                var currency = States.Instance.GoldBalanceState.Gold.Currency;
+                var currency = States.Instance.NCG;
                 data.UnitPrice.Value = new FungibleAssetValue(currency, majorUnit, minorUnit);
 
                 data.ProductId.Value = model.Product.ProductId;
@@ -367,7 +367,7 @@ namespace Nekoyume.UI
                 var unitPrice = price / model.FungibleAssetProduct.Quantity;
                 var majorUnit = (int)unitPrice;
                 var minorUnit = (int)((unitPrice - majorUnit) * 100);
-                var currency = States.Instance.GoldBalanceState.Gold.Currency;
+                var currency = States.Instance.NCG;
                 data.UnitPrice.Value = new FungibleAssetValue(currency, majorUnit, minorUnit);
 
                 data.ProductId.Value = model.FungibleAssetProduct.ProductId;
@@ -470,7 +470,7 @@ namespace Nekoyume.UI
             }
 
             var avatarAddress = States.Instance.CurrentAvatarState.address;
-            var goldCurrency = States.Instance.GoldBalanceState.Gold.Currency;
+            var goldCurrency = States.Instance.NCG;
 
             var oneLineSystemInfos = new List<(string name, int count)>();
             var productInfos = new List<IProductInfo>();
@@ -556,7 +556,7 @@ namespace Nekoyume.UI
             SharedModel.ItemCountAndPricePopup.Value.CountEnabled.Value = true;
             SharedModel.ItemCountAndPricePopup.Value.ProductId.Value = productId;
             SharedModel.ItemCountAndPricePopup.Value.Price.Value = (BigInteger)price *
-                States.Instance.GoldBalanceState.Gold.Currency;
+                States.Instance.NCG;
             SharedModel.ItemCountAndPricePopup.Value.PriceInteractable.Value = false;
             SharedModel.ItemCountAndPricePopup.Value.ChargeAp.Value = chargeAp;
             var itemCount = (int)quantity;
@@ -703,7 +703,7 @@ namespace Nekoyume.UI
         private static (IProductInfo, IRegisterInfo) GetReRegisterInfo(Guid productId, int newPrice)
         {
             var avatarAddress = States.Instance.CurrentAvatarState.address;
-            var goldCurrency = States.Instance.GoldBalanceState.Gold.Currency;
+            var goldCurrency = States.Instance.NCG;
             var itemProduct = ReactiveShopState.GetSellItemProduct(productId);
             if (itemProduct is not null)
             {

--- a/nekoyume/Assets/_Scripts/UI/Widget/Tooltip/FungibleAssetTooltip.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Tooltip/FungibleAssetTooltip.cs
@@ -115,7 +115,7 @@ namespace Nekoyume.UI
             registerButton.gameObject.SetActive(false);
             buy.gameObject.SetActive(true);
             sell.gameObject.SetActive(false);
-            buy.Set((BigInteger)item.FungibleAssetProduct.Price * States.Instance.GoldBalanceState.Gold.Currency,
+            buy.Set((BigInteger)item.FungibleAssetProduct.Price * States.Instance.NCG,
                 ()=>
                 {
                     onBuy?.Invoke();

--- a/nekoyume/Assets/_Scripts/UI/Widget/Tooltip/ItemTooltip.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Tooltip/ItemTooltip.cs
@@ -238,7 +238,7 @@ namespace Nekoyume.UI
             if (item.Product.Legacy)
             {
                 buy.Set(item.Product.RegisteredBlockIndex + Order.ExpirationInterval,
-                    (BigInteger)item.Product.Price * States.Instance.GoldBalanceState.Gold.Currency,
+                    (BigInteger)item.Product.Price * States.Instance.NCG,
                     () =>
                     {
                         onBuy?.Invoke();
@@ -247,7 +247,7 @@ namespace Nekoyume.UI
             }
             else
             {
-                buy.Set((BigInteger)item.Product.Price * States.Instance.GoldBalanceState.Gold.Currency,
+                buy.Set((BigInteger)item.Product.Price * States.Instance.NCG,
                     () =>
                     {
                         onBuy?.Invoke();


### PR DESCRIPTION
# Background

There is the [GoldCurrencyState] which is contains the `NCG` currency of a Nine Chronicles blockchain network.
It means the `NCG` currency can be different between another networks.([ref][mainnet-ncg])
For this reason, clients need to get the `NCG` currency that are stored in the blockchain state each time.

[GoldCurrencyState]: https://github.com/planetarium/lib9c/blob/1.3.0/Lib9c/Model/State/GoldCurrencyState.cs
[mainnet-ncg]: https://github.com/planetarium/lib9c/blob/1.3.0/Lib9c.Utils/BlockHelper.cs#L60C49-L60C59

# Features

- Get the `NCG` currency from blockchain state and store to `States` each time.
- Remove `ActionHandler.GoldCurrency`.
- Use `States.NCG` instead of others.
