### PR TITLE
feat: introduce `BalanceModifier`

### DIFF
--- a/nekoyume/Assets/_Scripts/State/LocalLayerModifier.cs
+++ b/nekoyume/Assets/_Scripts/State/LocalLayerModifier.cs
@@ -19,6 +19,28 @@ namespace Nekoyume.State
     {
         #region Agent, Avatar / Currency
 
+        public static void ModifyBalance(
+            Address address,
+            FungibleAssetValue value,
+            bool applyToStates = true)
+        {
+            if (value.Sign == 0)
+            {
+                return;
+            }
+
+            var modifier = new BalanceModifier(value);
+            LocalLayer.Instance.Add(address, modifier);
+
+            if (!applyToStates)
+            {
+                return;
+            }
+
+            var balance = States.Instance.GetBalance(address, value.Currency);
+            States.Instance.SetBalance(address, balance + value, useLocalLayer: false);
+        }
+
         /// <summary>
         /// Modify the agent's gold.
         /// </summary>

--- a/nekoyume/Assets/_Scripts/State/Modifiers/BalanceModifier.cs
+++ b/nekoyume/Assets/_Scripts/State/Modifiers/BalanceModifier.cs
@@ -1,0 +1,55 @@
+using System;
+using Libplanet.Types.Assets;
+using UnityEngine;
+using UnityEngine.Serialization;
+
+namespace Nekoyume.State.Modifiers
+{
+    [Serializable]
+    public class BalanceModifier : IAccumulatableValueModifier<FungibleAssetValue>
+    {
+        [FormerlySerializedAs("value")]
+        [SerializeField]
+        private FungibleAssetValue balance;
+
+        public bool IsEmpty => balance.Sign == 0;
+
+        public BalanceModifier(FungibleAssetValue value)
+        {
+            balance = value;
+        }
+
+        public FungibleAssetValue Modify(FungibleAssetValue value)
+        {
+            if (!value.Currency.Equals(balance.Currency))
+            {
+                Debug.Log($"{value.Currency} != {balance.Currency}");
+                return value;
+            }
+
+            return value + balance;
+        }
+
+        public void Add(IAccumulatableValueModifier<FungibleAssetValue> modifier)
+        {
+            if (modifier is not BalanceModifier m)
+            {
+                return;
+            }
+
+            balance += m.balance;
+        }
+
+        public void Remove(IAccumulatableValueModifier<FungibleAssetValue> modifier)
+        {
+            if (modifier is not BalanceModifier m)
+            {
+                return;
+            }
+
+            balance -= m.balance;
+        }
+
+        public override string ToString() => balance.ToString();
+    }
+}

--- a/nekoyume/Assets/_Scripts/State/Modifiers/BalanceModifier.cs.meta
+++ b/nekoyume/Assets/_Scripts/State/Modifiers/BalanceModifier.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 177a853f53fc4e519945bd0ccbbe1c14
+timeCreated: 1697681605

--- a/nekoyume/Assets/_Scripts/State/States.cs
+++ b/nekoyume/Assets/_Scripts/State/States.cs
@@ -48,6 +48,17 @@ namespace Nekoyume.State
 
         private readonly Dictionary<Address, Dictionary<Currency, FungibleAssetValue>> _balances = new();
 
+        public FungibleAssetValue GetBalance(Address address, Currency currency)
+        {
+            if (!_balances.ContainsKey(address) ||
+                !_balances[address].ContainsKey(currency))
+            {
+                return 0 * currency;
+            }
+
+            return _balances[address][currency];
+        }
+
         #region Agent
 
         public AgentState AgentState { get; private set; }
@@ -256,6 +267,25 @@ namespace Nekoyume.State
         {
             GameConfigState = state;
             GameConfigStateSubject.OnNext(state);
+        }
+
+        public void SetBalance(
+            Address address,
+            FungibleAssetValue balance,
+            bool useLocalLayer = true)
+        {
+            if (useLocalLayer)
+            {
+                balance = LocalLayer.Instance.ModifyBalance(address, balance);    
+            }
+
+            if (!_balances.ContainsKey(address))
+            {
+                _balances[address] = new Dictionary<Currency, FungibleAssetValue>();
+            }
+
+            _balances[address][balance.Currency] = balance;
+            BalanceSubject.OnNextBalance(address, balance);
         }
 
         /// <summary>

--- a/nekoyume/Assets/_Scripts/State/Subjects/BalanceSubject.cs
+++ b/nekoyume/Assets/_Scripts/State/Subjects/BalanceSubject.cs
@@ -1,0 +1,23 @@
+using System;
+using Libplanet.Crypto;
+using Libplanet.Types.Assets;
+using UniRx;
+
+namespace Nekoyume.State.Subjects
+{
+    public static class BalanceSubject
+    {
+        private static readonly Subject<(Address address, FungibleAssetValue balance)> Subject = new();
+
+        public static IObservable<FungibleAssetValue> Observe(
+            Address address,
+            Currency currency) => Subject
+            .Where(tuple =>
+                tuple.address.Equals(address) &&
+                tuple.balance.Currency.Equals(currency))
+            .Select(tuple => tuple.balance);
+
+        public static void OnNextBalance(Address address, FungibleAssetValue balance) =>
+            Subject.OnNext((address, balance));
+    }
+}

--- a/nekoyume/Assets/_Scripts/State/Subjects/BalanceSubject.cs.meta
+++ b/nekoyume/Assets/_Scripts/State/Subjects/BalanceSubject.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 13fb988a01ca41b3b74d61c4dd93944c
+timeCreated: 1697692884


### PR DESCRIPTION
No where is using this change yet, and I plan to raise a follow-up pull request.

# Background

- In order to elegantly manage the local state of the client, we created a `LocalLayer` that changes the blockchain state accordingly.
- The `LocalLayer` was handling only the agent's NCG and Crystal, out of all the currencies handled by the game.
- Now we need to have the flexibility to handle all the currencies in the game.

# Changes

- introduce `BalanceModifier`: Instead of creating individual modifiers for specific addresses or specific goods, we use one generalized modifier.
- add several `ModifierInfo<BalanceModifier>` to `LocalLayer`.: Create a `ModifierInfo<T>` for each address to match the behavior of the `LocalLayer`.
- introduce `BalanceSubject`: Instead of creating individual subjects for specific addresses or specific goods, we use one generalized subject.
- implement `States.SetBalance` and `GetBalance` methods.
- introduce `LocalLayerModifier.ModifyBalance` method.
