### PR TITLE
feat: apply `BalanceModifier`

### DIFF
--- a/nekoyume/Assets/_Scripts/Blockchain/ActionManager.cs
+++ b/nekoyume/Assets/_Scripts/Blockchain/ActionManager.cs
@@ -370,7 +370,7 @@ namespace Nekoyume.Blockchain
             var avatarState = States.Instance.CurrentAvatarState;
             var avatarAddress = avatarState.address;
 
-            LocalLayerModifier.ModifyAgentGold(agentAddress, -recipeInfo.CostNCG);
+            LocalLayerModifier.ModifyBalance(agentAddress, -recipeInfo.CostNCG * States.Instance.NCG);
             LocalLayerModifier.ModifyAvatarActionPoint(agentAddress, -recipeInfo.CostAP);
 
             foreach (var pair in recipeInfo.Materials)
@@ -449,7 +449,7 @@ namespace Nekoyume.Blockchain
             var avatarState = States.Instance.CurrentAvatarState;
             var avatarAddress = avatarState.address;
 
-            LocalLayerModifier.ModifyAgentGold(agentAddress, -recipeInfo.CostNCG);
+            LocalLayerModifier.ModifyBalance(agentAddress, -recipeInfo.CostNCG * States.Instance.NCG);
             LocalLayerModifier.ModifyAvatarActionPoint(agentAddress, -recipeInfo.CostAP);
 
             foreach (var pair in recipeInfo.Materials)
@@ -717,9 +717,7 @@ namespace Nekoyume.Blockchain
             var buyerAgentAddress = States.Instance.AgentState.address;
             foreach (var info in productInfos)
             {
-                LocalLayerModifier
-                    .ModifyAgentGoldAsync(buyerAgentAddress, -info.Price)
-                    .Forget();
+                LocalLayerModifier.ModifyBalance(buyerAgentAddress, -info.Price);
             }
 
             var action = new BuyProduct
@@ -742,9 +740,7 @@ namespace Nekoyume.Blockchain
             var buyerAgentAddress = States.Instance.AgentState.address;
             foreach (var purchaseInfo in purchaseInfos)
             {
-                LocalLayerModifier
-                    .ModifyAgentGoldAsync(buyerAgentAddress, -purchaseInfo.Price)
-                    .Forget();
+                LocalLayerModifier.ModifyBalance(buyerAgentAddress, -purchaseInfo.Price);
             }
 
             var action = new Buy
@@ -796,7 +792,7 @@ namespace Nekoyume.Blockchain
             var agentAddress = States.Instance.AgentState.address;
             var avatarAddress = States.Instance.CurrentAvatarState.address;
 
-            LocalLayerModifier.ModifyAgentGold(agentAddress, -costNCG);
+            LocalLayerModifier.ModifyBalance(agentAddress, -costNCG * States.Instance.NCG);
             LocalLayerModifier.ModifyAvatarActionPoint(avatarAddress, -GameConfig.EnhanceEquipmentCostAP);
             LocalLayerModifier.ModifyAvatarActionPoint(avatarAddress, -GameConfig.EnhanceEquipmentCostAP);
 
@@ -1030,7 +1026,7 @@ namespace Nekoyume.Blockchain
             var avatarState = States.Instance.CurrentAvatarState;
             var avatarAddress = avatarState.address;
 
-            LocalLayerModifier.ModifyAgentGold(agentAddress, -recipeInfo.CostNCG);
+            LocalLayerModifier.ModifyBalance(agentAddress, -recipeInfo.CostNCG * States.Instance.NCG);
             LocalLayerModifier.ModifyAvatarActionPoint(agentAddress, -recipeInfo.CostAP);
             if (useHammerPoint)
             {

--- a/nekoyume/Assets/_Scripts/Blockchain/ActionManager.cs
+++ b/nekoyume/Assets/_Scripts/Blockchain/ActionManager.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Numerics;
 using Bencodex.Types;
 using Cysharp.Threading.Tasks;
+using Lib9c;
 using Lib9c.Renderers;
 using Libplanet.Crypto;
 using Libplanet.Types.Assets;
@@ -1253,18 +1254,15 @@ namespace Nekoyume.Blockchain
             List<int> recipeIdList,
             BigInteger openCost)
         {
-            LocalLayerModifier
-                .ModifyAgentCrystalAsync(
-                    States.Instance.AgentState.address,
-                    -openCost)
-                .Forget();
+            var agentAddr = States.Instance.AgentState.address;
+            LocalLayerModifier.ModifyBalance(agentAddr, -openCost * Currencies.Crystal);
 
             var avatarAddress = States.Instance.CurrentAvatarState.address;
-            var sentryTrace = Analyzer.Instance.Track("Unity/UnlockEquipmentRecipe", new Dictionary<string, Value>()
+            var sentryTrace = Analyzer.Instance.Track("Unity/UnlockEquipmentRecipe", new Dictionary<string, Value>
             {
                 ["BurntCrystal"] = (long) openCost,
                 ["AvatarAddress"] = avatarAddress.ToString(),
-                ["AgentAddress"] = States.Instance.AgentState.address.ToString(),
+                ["AgentAddress"] = agentAddr.ToString(),
             }, true);
             var action = new UnlockEquipmentRecipe
             {

--- a/nekoyume/Assets/_Scripts/Blockchain/ActionRenderHandler.cs
+++ b/nekoyume/Assets/_Scripts/Blockchain/ActionRenderHandler.cs
@@ -786,7 +786,7 @@ namespace Nekoyume.Blockchain
                     return;
                 }
 
-                LocalLayerModifier.ModifyAgentGold(agentAddress, result.gold);
+                LocalLayerModifier.ModifyBalance(agentAddress, result.gold * States.Instance.NCG);
                 LocalLayerModifier.ModifyAvatarActionPoint(avatarAddress, result.actionPoint);
                 foreach (var pair in result.materials)
                 {
@@ -918,7 +918,7 @@ namespace Nekoyume.Blockchain
                     return;
                 }
 
-                LocalLayerModifier.ModifyAgentGold(agentAddress, result.gold);
+                LocalLayerModifier.ModifyBalance(agentAddress, result.gold * States.Instance.NCG);
                 LocalLayerModifier.ModifyAvatarActionPoint(avatarAddress, result.actionPoint);
                 foreach (var pair in result.materials)
                 {
@@ -967,7 +967,7 @@ namespace Nekoyume.Blockchain
             var result = (CombinationConsumable5.ResultModel)slot.Result;
             var itemUsable = result.itemUsable;
 
-            LocalLayerModifier.ModifyAgentGold(agentAddress, result.gold);
+            LocalLayerModifier.ModifyBalance(agentAddress, result.gold * States.Instance.NCG);
             LocalLayerModifier.ModifyAvatarActionPoint(avatarAddress, result.actionPoint);
             foreach (var pair in result.materials)
             {
@@ -1053,7 +1053,7 @@ namespace Nekoyume.Blockchain
                     return;
                 }
 
-                LocalLayerModifier.ModifyAgentGold(agentAddress, result.gold);
+                LocalLayerModifier.ModifyBalance(agentAddress, result.gold * States.Instance.NCG);
                 LocalLayerModifier.ModifyAgentCrystalAsync(agentAddress, -result.CRYSTAL.MajorUnit)
                     .Forget();
 
@@ -1476,7 +1476,7 @@ namespace Nekoyume.Blockchain
                     }
 
                     var price = info.Price;
-                    LocalLayerModifier.ModifyAgentGoldAsync(agentAddress, price).Forget();
+                    LocalLayerModifier.ModifyBalance(agentAddress, price);
                     LocalLayerModifier.AddNewMail(avatarAddress, info.ProductId);
 
                     string message;
@@ -1519,7 +1519,7 @@ namespace Nekoyume.Blockchain
                     }
 
                     var taxedPrice = info.Price.DivRem(100, out _) * Buy.TaxRate;
-                    LocalLayerModifier.ModifyAgentGoldAsync(agentAddress, -taxedPrice).Forget();
+                    LocalLayerModifier.ModifyBalance(agentAddress, -taxedPrice);
                     LocalLayerModifier.AddNewMail(avatarAddress, info.ProductId);
 
                     string message;

--- a/nekoyume/Assets/_Scripts/Blockchain/ActionRenderHandler.cs
+++ b/nekoyume/Assets/_Scripts/Blockchain/ActionRenderHandler.cs
@@ -1054,8 +1054,7 @@ namespace Nekoyume.Blockchain
                 }
 
                 LocalLayerModifier.ModifyBalance(agentAddress, result.gold * States.Instance.NCG);
-                LocalLayerModifier.ModifyAgentCrystalAsync(agentAddress, -result.CRYSTAL.MajorUnit)
-                    .Forget();
+                LocalLayerModifier.ModifyBalance(agentAddress, -result.CRYSTAL);
 
                 if (itemUsable.ItemSubType == ItemSubType.Aura)
                 {
@@ -2231,13 +2230,12 @@ namespace Nekoyume.Blockchain
             }
 
             var sheet = TableSheets.Instance.EquipmentItemRecipeSheet;
-            var cost = CrystalCalculator.CalculateRecipeUnlockCost(recipeIds, sheet);
+            LocalLayerModifier.ModifyBalance(
+                States.Instance.AgentState.address,
+                CrystalCalculator.CalculateRecipeUnlockCost(recipeIds, sheet));
             await UniTask.WhenAll(
-                LocalLayerModifier.ModifyAgentCrystalAsync(
-                    States.Instance.AgentState.address,
-                    cost.MajorUnit),
-                UpdateCurrentAvatarStateAsync(eval),
-                UpdateAgentStateAsync(eval));
+                UpdateAgentStateAsync(eval),
+                UpdateCurrentAvatarStateAsync(eval));
 
             foreach (var id in recipeIds)
             {

--- a/nekoyume/Assets/_Scripts/State/LocalLayer.cs
+++ b/nekoyume/Assets/_Scripts/State/LocalLayer.cs
@@ -1,10 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Lib9c;
 using Libplanet.Crypto;
 using Libplanet.Types.Assets;
-using Nekoyume.Helper;
 using Nekoyume.Model.Stake;
 using Nekoyume.Model.State;
 using Nekoyume.State.Modifiers;
@@ -39,10 +37,6 @@ namespace Nekoyume.State
 
         private ModifierInfo<AgentStateModifier> _agentModifierInfo;
 
-        private ModifierInfo<AgentNCGModifier> _agentNCGModifierInfo;
-
-        private ModifierInfo<AgentCrystalModifier> _agentCrystalModifierInfo;
-
         private ModifierInfo<BalanceModifier> _agentBalanceModifierInfo;
         
         private ModifierInfo<BalanceModifier> _agentStakedNCGModifierInfo;
@@ -73,18 +67,13 @@ namespace Nekoyume.State
             }
 
             var address = agentState.address;
-            // 이미 초기화되어 있는 에이전트와 같을 경우.
-            if (!(_agentModifierInfo is null) &&
+            if (_agentModifierInfo is not null &&
                 _agentModifierInfo.Address.Equals(address))
             {
                 return;
             }
 
-            // _agentModifierInfo 초기화하기.
-            _agentModifierInfo =
-                new ModifierInfo<AgentStateModifier>(address);
-            _agentNCGModifierInfo = new ModifierInfo<AgentNCGModifier>(address);
-            _agentCrystalModifierInfo = new ModifierInfo<AgentCrystalModifier>(address);
+            _agentModifierInfo = new ModifierInfo<AgentStateModifier>(address);
             _agentBalanceModifierInfo = new ModifierInfo<BalanceModifier>(address);
             _agentStakedNCGModifierInfo =
                 new ModifierInfo<BalanceModifier>(StakeStateV2.DeriveAddress(address));
@@ -260,57 +249,6 @@ namespace Nekoyume.State
             else
             {
                 modifiers.Add(modifier);
-            }
-        }
-
-        public void Add(Address agentAddress, AgentNCGModifier modifier)
-        {
-            // FIXME: 다른 Add() 오버로드와 겹치는 로직이 아주 많음.
-            if (modifier is null || modifier.IsEmpty)
-            {
-                return;
-            }
-
-            if (agentAddress.Equals(_agentNCGModifierInfo.Address))
-            {
-                var modifiers = _agentNCGModifierInfo.Modifiers;
-                if (TryGetSameTypeModifier(modifier, modifiers, out var outModifier))
-                {
-                    outModifier.Add(modifier);
-                    if (outModifier.IsEmpty)
-                    {
-                        modifiers.Remove(outModifier);
-                    }
-                }
-                else
-                {
-                    modifiers.Add(modifier);
-                }
-            }
-        }
-
-        public void Add(Address agentAddress, AgentCrystalModifier modifier)
-        {
-            if (modifier is null || modifier.IsEmpty)
-            {
-                return;
-            }
-
-            if (agentAddress.Equals(_agentCrystalModifierInfo.Address))
-            {
-                var modifiers = _agentCrystalModifierInfo.Modifiers;
-                if (TryGetSameTypeModifier(modifier, modifiers, out var outModifier))
-                {
-                    outModifier.Add(modifier);
-                    if (outModifier.IsEmpty)
-                    {
-                        modifiers.Remove(outModifier);
-                    }
-                }
-                else
-                {
-                    modifiers.Add(modifier);
-                }
             }
         }
 

--- a/nekoyume/Assets/_Scripts/State/LocalLayer.cs
+++ b/nekoyume/Assets/_Scripts/State/LocalLayer.cs
@@ -550,16 +550,6 @@ namespace Nekoyume.State
             return ncg;
         }
 
-        public FungibleAssetValue ModifyNCG(FungibleAssetValue ncg)
-        {
-            return PostModifyValue(ncg, _agentNCGModifierInfo);
-        }
-
-        public FungibleAssetValue ModifyCrystal(FungibleAssetValue crystal)
-        {
-            return PostModifyValue(crystal, _agentCrystalModifierInfo);
-        }
-
         /// <summary>
         /// 인자로 받은 아바타 상태에 로컬 세팅을 반영한다.
         /// </summary>

--- a/nekoyume/Assets/_Scripts/State/LocalLayerModifier.cs
+++ b/nekoyume/Assets/_Scripts/State/LocalLayerModifier.cs
@@ -19,6 +19,28 @@ namespace Nekoyume.State
     {
         #region Agent, Avatar / Currency
 
+        public static void ModifyBalance(
+            Address address,
+            FungibleAssetValue value,
+            bool applyToStates = true)
+        {
+            if (value.Sign == 0)
+            {
+                return;
+            }
+
+            var modifier = new BalanceModifier(value);
+            LocalLayer.Instance.Add(address, modifier);
+
+            if (!applyToStates)
+            {
+                return;
+            }
+
+            var balance = States.Instance.GetBalance(address, value.Currency);
+            States.Instance.SetBalance(address, balance + value, useLocalLayer: false);
+        }
+
         /// <summary>
         /// Modify the agent's gold.
         /// </summary>

--- a/nekoyume/Assets/_Scripts/State/LocalLayerModifier.cs
+++ b/nekoyume/Assets/_Scripts/State/LocalLayerModifier.cs
@@ -41,37 +41,6 @@ namespace Nekoyume.State
             States.Instance.SetBalance(address, balance + value, useLocalLayer: false);
         }
 
-        /// <summary>
-        /// Modify the agent's gold.
-        /// </summary>
-        /// <param name="agentAddress"></param>
-        /// <param name="gold"></param>
-        public static async UniTask ModifyAgentGoldAsync(Address agentAddress, FungibleAssetValue gold)
-        {
-            if (gold.Sign == 0)
-            {
-                return;
-            }
-
-            var modifier = new AgentNCGModifier(gold);
-            LocalLayer.Instance.Add(agentAddress, modifier);
-
-            //FIXME Avoid LocalLayer duplicate modify gold.
-            var ncg = await Game.Game.instance.Agent.GetBalanceAsync(agentAddress, gold.Currency);
-            States.Instance.SetAgentNCG(ncg);
-        }
-
-        public static void ModifyAgentGold(Address agentAddress, BigInteger gold)
-        {
-            if (gold == 0)
-            {
-                return;
-            }
-
-            var fav = new FungibleAssetValue(States.Instance.NCG, gold, 0);
-            ModifyAgentGoldAsync(agentAddress, fav).Forget();
-        }
-
         public static async UniTask ModifyAgentCrystalAsync(Address agentAddress, BigInteger crystal)
         {
             if (crystal == 0)

--- a/nekoyume/Assets/_Scripts/State/LocalLayerModifier.cs
+++ b/nekoyume/Assets/_Scripts/State/LocalLayerModifier.cs
@@ -1,11 +1,9 @@
 using System;
-using System.Numerics;
 using System.Security.Cryptography;
 using Cysharp.Threading.Tasks;
 using Libplanet.Common;
 using Libplanet.Crypto;
 using Libplanet.Types.Assets;
-using Nekoyume.Helper;
 using Nekoyume.Model.Item;
 using Nekoyume.Model.State;
 using Nekoyume.State.Modifiers;
@@ -39,26 +37,6 @@ namespace Nekoyume.State
 
             var balance = States.Instance.GetBalance(address, value.Currency);
             States.Instance.SetBalance(address, balance + value, useLocalLayer: false);
-        }
-
-        public static async UniTask ModifyAgentCrystalAsync(Address agentAddress, BigInteger crystal)
-        {
-            if (crystal == 0)
-            {
-                return;
-            }
-
-            var fav = new FungibleAssetValue(
-                CrystalCalculator.CRYSTAL,
-                crystal,
-                0);
-            var modifier = new AgentCrystalModifier(fav);
-            LocalLayer.Instance.Add(agentAddress, modifier);
-            var crystalBalance
-                = await Game.Game.instance.Agent.GetBalanceAsync(
-                    agentAddress,
-                    CrystalCalculator.CRYSTAL);
-            States.Instance.SetAgentCrystal(crystalBalance);
         }
 
         /// <summary>

--- a/nekoyume/Assets/_Scripts/State/Modifiers/BalanceModifier.cs
+++ b/nekoyume/Assets/_Scripts/State/Modifiers/BalanceModifier.cs
@@ -1,0 +1,55 @@
+using System;
+using Libplanet.Types.Assets;
+using UnityEngine;
+using UnityEngine.Serialization;
+
+namespace Nekoyume.State.Modifiers
+{
+    [Serializable]
+    public class BalanceModifier : IAccumulatableValueModifier<FungibleAssetValue>
+    {
+        [FormerlySerializedAs("value")]
+        [SerializeField]
+        private FungibleAssetValue balance;
+
+        public bool IsEmpty => balance.Sign == 0;
+
+        public BalanceModifier(FungibleAssetValue value)
+        {
+            balance = value;
+        }
+
+        public FungibleAssetValue Modify(FungibleAssetValue value)
+        {
+            if (!value.Currency.Equals(balance.Currency))
+            {
+                Debug.Log($"{value.Currency} != {balance.Currency}");
+                return value;
+            }
+
+            return value + balance;
+        }
+
+        public void Add(IAccumulatableValueModifier<FungibleAssetValue> modifier)
+        {
+            if (modifier is not BalanceModifier m)
+            {
+                return;
+            }
+
+            balance += m.balance;
+        }
+
+        public void Remove(IAccumulatableValueModifier<FungibleAssetValue> modifier)
+        {
+            if (modifier is not BalanceModifier m)
+            {
+                return;
+            }
+
+            balance -= m.balance;
+        }
+
+        public override string ToString() => balance.ToString();
+    }
+}

--- a/nekoyume/Assets/_Scripts/State/Modifiers/BalanceModifier.cs.meta
+++ b/nekoyume/Assets/_Scripts/State/Modifiers/BalanceModifier.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 177a853f53fc4e519945bd0ccbbe1c14
+timeCreated: 1697681605

--- a/nekoyume/Assets/_Scripts/State/States.cs
+++ b/nekoyume/Assets/_Scripts/State/States.cs
@@ -328,7 +328,7 @@ namespace Nekoyume.State
                 return;
             }
 
-            ncg = LocalLayer.Instance.ModifyNCG(ncg);
+            ncg = LocalLayer.Instance.ModifyBalance(AgentState.address, ncg);
             AgentBalances[NCG] = ncg;
             AgentStateSubject.OnNextGold(AgentNCG);
         }
@@ -341,7 +341,7 @@ namespace Nekoyume.State
                 return;
             }
 
-            crystal = LocalLayer.Instance.ModifyCrystal(crystal);
+            crystal = LocalLayer.Instance.ModifyBalance(AgentState.address, crystal);
             AgentBalances[Currencies.Crystal] = crystal;
             AgentStateSubject.OnNextCrystal(AgentCrystal);
         }

--- a/nekoyume/Assets/_Scripts/State/States.cs
+++ b/nekoyume/Assets/_Scripts/State/States.cs
@@ -48,6 +48,17 @@ namespace Nekoyume.State
 
         private readonly Dictionary<Address, Dictionary<Currency, FungibleAssetValue>> _balances = new();
 
+        public FungibleAssetValue GetBalance(Address address, Currency currency)
+        {
+            if (!_balances.ContainsKey(address) ||
+                !_balances[address].ContainsKey(currency))
+            {
+                return 0 * currency;
+            }
+
+            return _balances[address][currency];
+        }
+
         #region Agent
 
         public AgentState AgentState { get; private set; }
@@ -256,6 +267,25 @@ namespace Nekoyume.State
         {
             GameConfigState = state;
             GameConfigStateSubject.OnNext(state);
+        }
+
+        public void SetBalance(
+            Address address,
+            FungibleAssetValue balance,
+            bool useLocalLayer = true)
+        {
+            if (useLocalLayer)
+            {
+                balance = LocalLayer.Instance.ModifyBalance(address, balance);    
+            }
+
+            if (!_balances.ContainsKey(address))
+            {
+                _balances[address] = new Dictionary<Currency, FungibleAssetValue>();
+            }
+
+            _balances[address][balance.Currency] = balance;
+            BalanceSubject.OnNextBalance(address, balance);
         }
 
         /// <summary>

--- a/nekoyume/Assets/_Scripts/State/Subjects/BalanceSubject.cs
+++ b/nekoyume/Assets/_Scripts/State/Subjects/BalanceSubject.cs
@@ -1,0 +1,23 @@
+using System;
+using Libplanet.Crypto;
+using Libplanet.Types.Assets;
+using UniRx;
+
+namespace Nekoyume.State.Subjects
+{
+    public static class BalanceSubject
+    {
+        private static readonly Subject<(Address address, FungibleAssetValue balance)> Subject = new();
+
+        public static IObservable<FungibleAssetValue> Observe(
+            Address address,
+            Currency currency) => Subject
+            .Where(tuple =>
+                tuple.address.Equals(address) &&
+                tuple.balance.Currency.Equals(currency))
+            .Select(tuple => tuple.balance);
+
+        public static void OnNextBalance(Address address, FungibleAssetValue balance) =>
+            Subject.OnNext((address, balance));
+    }
+}

--- a/nekoyume/Assets/_Scripts/State/Subjects/BalanceSubject.cs.meta
+++ b/nekoyume/Assets/_Scripts/State/Subjects/BalanceSubject.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 13fb988a01ca41b3b74d61c4dd93944c
+timeCreated: 1697692884

--- a/nekoyume/Assets/_Scripts/UI/Widget/Popup/MailPopup.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Popup/MailPopup.cs
@@ -586,9 +586,9 @@ namespace Nekoyume.UI
             {
                 if (itemEnhanceMail.attachment is ItemEnhancement.ResultModel result)
                 {
-                    await LocalLayerModifier.ModifyAgentCrystalAsync(
+                    LocalLayerModifier.ModifyBalance(
                         States.Instance.AgentState.address,
-                        result.CRYSTAL.MajorUnit);
+                        result.CRYSTAL);
                 }
 
                 if (itemUsable.ItemSubType == ItemSubType.Aura)
@@ -609,15 +609,14 @@ namespace Nekoyume.UI
                         false);
                 }
 
-                LocalLayerModifier.RemoveNewAttachmentMail(avatarAddress, itemEnhanceMail.id,
+                LocalLayerModifier.RemoveNewAttachmentMail(
+                    avatarAddress,
+                    itemEnhanceMail.id,
                     false);
                 var (exist, avatarState) = await States.TryGetAvatarStateAsync(avatarAddress);
-                if (!exist)
-                {
-                    return null;
-                }
-
-                return avatarState;
+                return exist
+                    ? avatarState
+                    : null;
             }).ToObservable().SubscribeOnMainThread().Subscribe(async avatarState =>
             {
                 Debug.Log("ItemEnhanceMail LocalLayer task completed");

--- a/nekoyume/Assets/_Scripts/UI/Widget/Popup/MailPopup.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Popup/MailPopup.cs
@@ -461,7 +461,7 @@ namespace Nekoyume.UI
             var agentAddress = States.Instance.AgentState.address;
             var order = await Util.GetOrder(orderSellerMail.OrderId);
             var taxedPrice = order.Price - order.GetTax();
-            LocalLayerModifier.ModifyAgentGoldAsync(agentAddress, taxedPrice).Forget();
+            LocalLayerModifier.ModifyBalance(agentAddress, taxedPrice);
             LocalLayerModifier.RemoveNewMail(avatarAddress, orderSellerMail.id);
         }
 
@@ -522,8 +522,8 @@ namespace Nekoyume.UI
             var currency = States.Instance.NCG;
             var price = itemProduct?.Price ?? favProduct.Price;
             var fav = new FungibleAssetValue(currency, (int)price, 0);
-            var taxedPrice = fav.DivRem(100, out _) * Action.Buy.TaxRate;
-            LocalLayerModifier.ModifyAgentGoldAsync(agentAddress, taxedPrice).Forget();
+            var taxedPrice = fav.DivRem(100, out _) * Buy.TaxRate;
+            LocalLayerModifier.ModifyBalance(agentAddress, taxedPrice);
             LocalLayerModifier.RemoveNewMail(avatarAddress, productSellerMail.id);
         }
 


### PR DESCRIPTION
This is a follow-up pull request of #3226 and based on it.

- use `LocalLayerModifier.ModifyBalance` instead of `ModifyAgentGold`.
- use `LocalLayerModifier.ModifyBalance` instead of `ModifyAgentCrystalAsync`.
- use `LocalLayer.ModifyBalance` instead of `ModifyNCG` or `ModifyCrystal`.
- remove useless fields and methods.
