### PR TITLE
feat: provide planet data

### DIFF
--- a/nekoyume/Assets/_Scripts/Blockchain/ActionManager.cs
+++ b/nekoyume/Assets/_Scripts/Blockchain/ActionManager.cs
@@ -1512,9 +1512,9 @@ namespace Nekoyume.Blockchain
                 .Where(eval => eval.Signer.Equals(States.Instance.AgentState.address))
                 .First()
                 .ObserveOnMainThread()
-                .DoOnError(e =>
+                .DoOnError(_ =>
                 {
-
+                    // NOTE: Handle exception outside of this method.
                 });
         }
 

--- a/nekoyume/Assets/_Scripts/Extensions/GraphQlHttpClientExtensions.cs
+++ b/nekoyume/Assets/_Scripts/Extensions/GraphQlHttpClientExtensions.cs
@@ -1,0 +1,85 @@
+#nullable enable
+
+using System;
+using System.Text;
+using Cysharp.Threading.Tasks;
+using GraphQL;
+using GraphQL.Client.Http;
+using Libplanet.Crypto;
+using Nekoyume.GraphQL.GraphTypes;
+using UnityEngine;
+
+namespace Nekoyume
+{
+    public static class GraphQlHttpClientExtensions
+    {
+        public static async UniTask<T> StateQueryAsync<T>(
+            this GraphQLHttpClient client,
+            string query)
+        {
+            Debug.Log("[GraphQl] StateQueryAsync()..." +
+                      $" Endpoint: {client.Options.EndPoint?.AbsoluteUri ?? "null"}" +
+                      $" Query: {query}");
+            var request = new GraphQLRequest(query);
+            var response = await client.SendQueryAsync<StateQueryGraphType<T>>(request);
+            if (response.Errors != null)
+            {
+                foreach (var error in response.Errors)
+                {
+                    Debug.LogError(error.Message);
+                }
+            }
+
+            return response.Data.StateQuery;
+        }
+
+        public static async UniTask<AgentGraphType> QueryAgentAsync(
+            this GraphQLHttpClient client,
+            Address agentAddress)
+        {
+            var sb = new StringBuilder("query { stateQuery { agent(address: ");
+            sb.Append($"\"{agentAddress.ToString()}\"");
+            sb.Append(") { address avatarStates { address name level } } } }");
+            var query = sb.ToString();
+            return await client.StateQueryAsync<AgentGraphType>(query);
+        }
+
+        public static async UniTask<AvatarsGraphType> QueryAvatarsAsync(
+            this GraphQLHttpClient client,
+            params string[] avatarAddresses)
+        {
+            if (avatarAddresses.Length == 0)
+            {
+                return new AvatarsGraphType
+                {
+                    Avatars = Array.Empty<AvatarGraphType>(),
+                };
+            }
+
+            var sb = new StringBuilder("query { stateQuery { avatars(addresses: [");
+            foreach (var avatarAddress in avatarAddresses)
+            {
+                sb.Append($"\"{avatarAddress}\", ");
+            }
+
+            sb.Remove(sb.Length - 2, 2);
+            sb.Append("]) { address name level } } }");
+            var query = sb.ToString();
+            return await client.StateQueryAsync<AvatarsGraphType>(query);
+        }
+
+        public static async UniTask<AvatarsGraphType> QueryAvatarsByAgentAddressAsync(
+            this GraphQLHttpClient client,
+            string agentAddress)
+        {
+            var addr = new Address(agentAddress);
+            var avatarAddresses = new[]
+            {
+                Addresses.GetAvatarAddress(addr, 0).ToString(),
+                Addresses.GetAvatarAddress(addr, 1).ToString(),
+                Addresses.GetAvatarAddress(addr, 2).ToString(),
+            };
+            return await client.QueryAvatarsAsync(avatarAddresses);
+        }
+    }
+}

--- a/nekoyume/Assets/_Scripts/Extensions/GraphQlHttpClientExtensions.cs.meta
+++ b/nekoyume/Assets/_Scripts/Extensions/GraphQlHttpClientExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4c33f0ffc1874c1995c30f2f69433d58
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/nekoyume/Assets/_Scripts/Game/Game.cs
+++ b/nekoyume/Assets/_Scripts/Game/Game.cs
@@ -268,7 +268,7 @@ namespace Nekoyume.Game
             //       It should do after load CommandLineOptions.
             //       And it should do before initialize Agent.
             var planetContext = new PlanetContext(_commandLineOptions);
-            yield return PlanetSelector.InitializeAsync(planetContext).ToCoroutine();
+            yield return PlanetSelector.InitializePlanetsAsync(planetContext).ToCoroutine();
             if (planetContext.HasError)
             {
                 Debug.LogError(planetContext.Error);
@@ -361,7 +361,7 @@ namespace Nekoyume.Game
             yield return new WaitUntil(() => agentInitialized);
 
 #if !UNITY_EDITOR && (UNITY_ANDROID || UNITY_IOS)
-            if (planetContext.CurrentPlanetInfo is null)
+            if (planetContext.SelectedPlanetInfo is null)
             {
                 QuitWithMessage("planetContext.CurrentPlanetInfo is null in mobile.");
                 yield break;
@@ -405,7 +405,7 @@ namespace Nekoyume.Game
             var initializeSecondWidgetsCoroutine = StartCoroutine(CoInitializeSecondWidget());
 
 #if !UNITY_EDITOR && (UNITY_ANDROID || UNITY_IOS)
-            yield return StartCoroutine(CoCheckPledge(planetContext.CurrentPlanetInfo.ID));    
+            yield return StartCoroutine(CoCheckPledge(planetContext.SelectedPlanetInfo.ID));    
 #endif
 
 #if UNITY_EDITOR_WIN

--- a/nekoyume/Assets/_Scripts/GraphQL/GraphTypes.meta
+++ b/nekoyume/Assets/_Scripts/GraphQL/GraphTypes.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: ce72c0f26fef4116a6728dcc5fa1dce2
+timeCreated: 1698817501

--- a/nekoyume/Assets/_Scripts/GraphQL/GraphTypes/AgentGraphType.cs
+++ b/nekoyume/Assets/_Scripts/GraphQL/GraphTypes/AgentGraphType.cs
@@ -1,0 +1,35 @@
+#nullable enable
+
+using System.Linq;
+using System.Text.Json.Serialization;
+using Libplanet.Crypto;
+
+namespace Nekoyume.GraphQL.GraphTypes
+{
+    public class AgentGraphType
+    {
+        public class InnerType
+        {
+            [JsonPropertyName("address")]
+            public Address Address;
+
+            [JsonPropertyName("avatarAddress")]
+            public AvatarGraphType[] AvatarStates;
+
+            public override string ToString()
+            {
+                return $"Address: {Address}, AvatarStates({AvatarStates.Length}):" +
+                       $" [{string.Join(", ", AvatarStates.Select(e => e.ToString()))}]";
+            }
+        }
+
+        [JsonPropertyName("agent")]
+        public InnerType? Agent;
+
+        public override string ToString()
+        {
+            var inner = Agent is null ? "null" : Agent.ToString();
+            return $"Agent: {{ {inner} }}";
+        }
+    }
+}

--- a/nekoyume/Assets/_Scripts/GraphQL/GraphTypes/AgentGraphType.cs.meta
+++ b/nekoyume/Assets/_Scripts/GraphQL/GraphTypes/AgentGraphType.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 93652533fb71425abd52077994fc1bde
+timeCreated: 1698927417

--- a/nekoyume/Assets/_Scripts/GraphQL/GraphTypes/AvatarGraphType.cs
+++ b/nekoyume/Assets/_Scripts/GraphQL/GraphTypes/AvatarGraphType.cs
@@ -1,0 +1,21 @@
+using System.Text.Json.Serialization;
+
+namespace Nekoyume.GraphQL.GraphTypes
+{
+    public class AvatarGraphType
+    {
+        [JsonPropertyName("address")]
+        public string Address;
+
+        [JsonPropertyName("name")]
+        public string Name;
+
+        [JsonPropertyName("level")]
+        public int Level;
+
+        public override string ToString()
+        {
+            return $"Avatar: {{ Address({Address}), Name({Name}), Level({Level}) }}";
+        }
+    }
+}

--- a/nekoyume/Assets/_Scripts/GraphQL/GraphTypes/AvatarGraphType.cs.meta
+++ b/nekoyume/Assets/_Scripts/GraphQL/GraphTypes/AvatarGraphType.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 773a4752e5ab4d04b68eb168c776db2b
+timeCreated: 1698817513

--- a/nekoyume/Assets/_Scripts/GraphQL/GraphTypes/AvatarsGraphType.cs
+++ b/nekoyume/Assets/_Scripts/GraphQL/GraphTypes/AvatarsGraphType.cs
@@ -1,0 +1,19 @@
+#nullable enable
+
+using System.Linq;
+using System.Text.Json.Serialization;
+
+namespace Nekoyume.GraphQL.GraphTypes
+{
+    public class AvatarsGraphType
+    {
+        [JsonPropertyName("avatars")]
+        public AvatarGraphType?[] Avatars;
+
+        public override string ToString()
+        {
+            return $"Avatars({Avatars.Length}):" +
+                   $" [ {string.Join(", ", Avatars.Select(e => e is null ? "null" : $"{{ {e} }}"))} ]";
+        }
+    }
+}

--- a/nekoyume/Assets/_Scripts/GraphQL/GraphTypes/AvatarsGraphType.cs.meta
+++ b/nekoyume/Assets/_Scripts/GraphQL/GraphTypes/AvatarsGraphType.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 9ee812c6eb1646cc93102f53658a0d8a
+timeCreated: 1698860968

--- a/nekoyume/Assets/_Scripts/GraphQL/GraphTypes/StateQueryGraphType.cs
+++ b/nekoyume/Assets/_Scripts/GraphQL/GraphTypes/StateQueryGraphType.cs
@@ -1,0 +1,10 @@
+using System.Text.Json.Serialization;
+
+namespace Nekoyume.GraphQL.GraphTypes
+{
+    public class StateQueryGraphType<T>
+    {
+        [JsonPropertyName("stateQuery")]
+        public T StateQuery;
+    }
+}

--- a/nekoyume/Assets/_Scripts/GraphQL/GraphTypes/StateQueryGraphType.cs.meta
+++ b/nekoyume/Assets/_Scripts/GraphQL/GraphTypes/StateQueryGraphType.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 420503c7f840475b823b64382445c546
+timeCreated: 1698866119

--- a/nekoyume/Assets/_Scripts/Helper/CommandLineParser.cs
+++ b/nekoyume/Assets/_Scripts/Helper/CommandLineParser.cs
@@ -34,7 +34,7 @@ namespace Nekoyume.Helper
 
         private string _planetRegistryUrl;
 
-        private PlanetId? _planetId;
+        private PlanetId? _defaultPlanetId;
 
         private string privateKey;
 
@@ -112,13 +112,18 @@ namespace Nekoyume.Helper
             }
         }
 
-        [Option("planet-id", Required = false, HelpText = "planet id")]
-        public PlanetId? PlanetId
+        /// <summary>
+        /// Default Planet Id.
+        /// Use this if there is no selected planet id in the player prefs.
+        /// PlayerPrefs key: <see cref="PlanetSelector.SelectedPlanetIdHexStringKey"/>
+        /// </summary>
+        [Option("default-planet-id", Required = false, HelpText = "planet id")]
+        public PlanetId? DefaultPlanetId
         {
-            get => _planetId;
+            get => _defaultPlanetId;
             set
             {
-                _planetId = value;
+                _defaultPlanetId = value;
                 Empty = false;
             }
         }
@@ -396,6 +401,9 @@ namespace Nekoyume.Helper
             }
         }
 
+        /// <summary>
+        /// DataProvider Host.
+        /// </summary>
         [Option("api-server-host", Required = false, HelpText = "Host for the internal api client.")]
         public string ApiServerHost
         {

--- a/nekoyume/Assets/_Scripts/Planet/PlanetAccountInfo.cs
+++ b/nekoyume/Assets/_Scripts/Planet/PlanetAccountInfo.cs
@@ -1,0 +1,28 @@
+#nullable enable
+
+using System.Collections.Generic;
+using Libplanet.Crypto;
+using Nekoyume.GraphQL.GraphTypes;
+
+namespace Nekoyume.Planet
+{
+    public class PlanetAccountInfo
+    {
+        public readonly PlanetId PlanetId;
+
+        public Address? AgentAddress { get; private set; }
+        public IEnumerable<AvatarGraphType> AvatarGraphTypes => _avatarGraphTypes;
+
+        private readonly AvatarGraphType[] _avatarGraphTypes;
+
+        public PlanetAccountInfo(
+            PlanetId planetId,
+            Address? agentAddress,
+            params AvatarGraphType[] avatarGraphTypes)
+        {
+            PlanetId = planetId;
+            AgentAddress = agentAddress;
+            _avatarGraphTypes = avatarGraphTypes;
+        }
+    }
+}

--- a/nekoyume/Assets/_Scripts/Planet/PlanetAccountInfo.cs.meta
+++ b/nekoyume/Assets/_Scripts/Planet/PlanetAccountInfo.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 37ad203e076d42fca1175828a092bab2
+timeCreated: 1698814443

--- a/nekoyume/Assets/_Scripts/Planet/PlanetContext.cs
+++ b/nekoyume/Assets/_Scripts/Planet/PlanetContext.cs
@@ -10,7 +10,17 @@ namespace Nekoyume.Planet
         public bool IsSkipped;
         public string Error = string.Empty;
         public Planets? Planets;
-        public PlanetInfo? CurrentPlanetInfo;
+        public PlanetInfo? SelectedPlanetInfo;
+        public PlanetAccountInfo[]? PlanetAccountInfos;
+        public PlanetAccountInfo? SelectedPlanetAccountInfo;
+
+        // NOTE: This is not kind of planet context, it is authentication context.
+        //       But we have no idea where to put this yet.
+        public bool? NeedToAutoLogin;
+
+        // NOTE: This is not kind of planet context, it is authentication context.
+        //       But we have no idea where to put this yet.
+        public bool? NeedToPledge;
 
         public bool HasError => !string.IsNullOrEmpty(Error);
 

--- a/nekoyume/Assets/_Scripts/Planet/Planets.cs
+++ b/nekoyume/Assets/_Scripts/Planet/Planets.cs
@@ -72,6 +72,10 @@ namespace Nekoyume.Planet
                 }
 
                 _planetInfos = planetInfos;
+                var text = string.Join(", ", _planetInfos.Select(e =>
+                    $"{e.ID.ToString()}({e.Name})"));
+                Debug.Log($"[Planets] initialize succeeded: [{text}]");
+
                 IsInitialized = true;
             }
 
@@ -79,13 +83,21 @@ namespace Nekoyume.Planet
             return IsInitialized;
         }
 
-        public bool TryGetPlanetInfo(PlanetId planetId, out PlanetInfo planetInfo)
+        public bool TryGetPlanetInfoById(PlanetId planetId, out PlanetInfo planetInfo)
         {
             planetInfo = _planetInfos.FirstOrDefault(e => e.ID.Equals(planetId));
             return planetInfo is not null;
         }
-        
-        public bool TryGetPlanetInfo(string planetName, out PlanetInfo planetInfo)
+
+        public bool TryGetPlanetInfoByIdString(
+            string planetIdHexString,
+            out PlanetInfo planetInfo)
+        {
+            planetInfo = _planetInfos.FirstOrDefault(e => e.ID.ToString().Equals(planetIdHexString));
+            return planetInfo is not null;
+        }
+
+        public bool TryGetPlanetInfoByName(string planetName, out PlanetInfo planetInfo)
         {
             planetName = planetName.ToLower();
             planetInfo = _planetInfos.FirstOrDefault(e => e.Name.ToLower().Equals(planetName));

--- a/nekoyume/Assets/_Scripts/PlatformUtility/Platform.cs
+++ b/nekoyume/Assets/_Scripts/PlatformUtility/Platform.cs
@@ -9,7 +9,9 @@ namespace Nekoyume
         {
             get
             {
-#if UNITY_ANDROID
+#if UNITY_EDITOR
+                return Application.persistentDataPath;
+#elif UNITY_ANDROID
                 return "storage/emulated/0/Documents/NineChronicles";
 #else
                 return Application.persistentDataPath;

--- a/nekoyume/Assets/_Scripts/UI/Widget/Screen/IntroScreen.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Screen/IntroScreen.cs
@@ -127,7 +127,7 @@ namespace Nekoyume.UI
                 .AddTo(gameObject);
             heimdallButton.OnClickDisabledSubject.Subscribe(_ =>
             {
-                _planetContext = PlanetSelector.SelectPlanet(_planetContext, heimdallButton.Text);
+                _planetContext = PlanetSelector.SelectPlanetByName(_planetContext, heimdallButton.Text);
                 selectPlanetPopup.SetActive(false);
             }).AddTo(gameObject);
             odinButton.OnClickSubject
@@ -135,7 +135,7 @@ namespace Nekoyume.UI
                 .AddTo(gameObject);
             odinButton.OnClickDisabledSubject.Subscribe(_ =>
             {
-                _planetContext = PlanetSelector.SelectPlanet(_planetContext, odinButton.Text);
+                _planetContext = PlanetSelector.SelectPlanetByName(_planetContext, odinButton.Text);
                 selectPlanetPopup.SetActive(false);
             }).AddTo(gameObject);
             PlanetSelector.CurrentPlanetInfoSubject
@@ -278,7 +278,7 @@ namespace Nekoyume.UI
         private void ApplyCurrentPlanetInfo(PlanetContext planetContext)
         {
             var planets = planetContext.Planets;
-            var planetInfo = planetContext.CurrentPlanetInfo;
+            var planetInfo = planetContext.SelectedPlanetInfo;
             if (planets is null ||
                 planetInfo is null)
             {
@@ -293,14 +293,14 @@ namespace Nekoyume.UI
             var textInfo = CultureInfo.InvariantCulture.TextInfo;
             planetText.text = textInfo.ToTitleCase(planetInfo.Name);
 
-            if (planets.TryGetPlanetInfo(PlanetId.Heimdall, out var heimdallInfo) ||
-                planets.TryGetPlanetInfo(PlanetId.HeimdallInternal, out heimdallInfo))
+            if (planets.TryGetPlanetInfoById(PlanetId.Heimdall, out var heimdallInfo) ||
+                planets.TryGetPlanetInfoById(PlanetId.HeimdallInternal, out heimdallInfo))
             {
                 heimdallButton.Text = textInfo.ToTitleCase(heimdallInfo.Name);
             }
 
-            if (planets.TryGetPlanetInfo(PlanetId.Odin, out var odinInfo) ||
-                planets.TryGetPlanetInfo(PlanetId.OdinInternal, out odinInfo))
+            if (planets.TryGetPlanetInfoById(PlanetId.Odin, out var odinInfo) ||
+                planets.TryGetPlanetInfoById(PlanetId.OdinInternal, out odinInfo))
             {
                 odinButton.Text = textInfo.ToTitleCase(odinInfo.Name);
             }

--- a/nekoyume/nekoyume.sln.DotSettings
+++ b/nekoyume/nekoyume.sln.DotSettings
@@ -15,6 +15,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Fenrir/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Libplanet/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Mimisbrunnr/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=multiplanetary/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Nekoyume/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Offseason/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=previewnet/@EntryIndexedValue">True</s:Boolean>


### PR DESCRIPTION
- update genesis block for `0x000000000001`(Heimdall).
- fix `Planetform.PersistentDataPath` for `UNITY_EDITOR`.
- rename `CommandLineOptions.DefaultPlanetId` w/ comment.(from `PlanetId`)
- introduce `PlanetAccountInfo`.
- introduce several graph types.(Agent, Avatar, Avatars)
- introduce `GraphQlClientExtensions`.
- improve `Planets` and `PlanetSelector` w/ `PlanetContext`.
