### PR TITLE
find all assembly and check field

### DIFF
--- a/nekoyume/Assets/Editor/OpenAPIGenerator.cs
+++ b/nekoyume/Assets/Editor/OpenAPIGenerator.cs
@@ -248,10 +248,35 @@ namespace Nekoyume
             return type.IsClass && type != typeof(string);
         }
 
+        private static Type FindTypeInAllAssemblies(string className)
+        {
+            foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                foreach (var type in assembly.GetTypes())
+                {
+                    if (type.Name == className && HasField(type, "Url", typeof(string)) && HasField(type, "_client"))
+                    {
+                        return type;
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        private static bool HasField(Type type, string fieldName, Type fieldType = null)
+        {
+            var field = type.GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance);
+            if(fieldType == null)
+            {
+                return field != null;
+            }
+            return field != null && field.FieldType == fieldType;
+        }
+
         private void CreateClientInstance()
         {
-            Assembly assembly = Assembly.GetExecutingAssembly();
-            Type clientType = assembly.GetType(className);
+            Type clientType = FindTypeInAllAssemblies(className);
 
             if (clientType != null)
             {


### PR DESCRIPTION
OpenApiGenerator.cs의 폴더가 에디터 하위로 수정되면서 어셈블리도 에디터로 바뀌어 클레스이름으로 타입검색에 실패하는 문제입니다. 
전체 어셈블리를 돌면서 동일한 클레스네임에 제너레이션된 코드가 가지고있어야하는 필드 _client, url 조건 체크를 하는방식으로 타입검색하도록 수정하였습니다.