### PR TITLE
change seasonpass menu level text

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Module/Lobby/SeasonPassMenu.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/Lobby/SeasonPassMenu.cs
@@ -32,8 +32,17 @@ namespace Nekoyume.UI.Module.Lobby
 
                 premiumIcon.SetActive(info.IsPremium);
                 premiumPlusIcon.SetActive(info.IsPremiumPlus);
-                levelText.text = $"Lv.{info.Level}";
                 notificationObj.SetActive(info.LastNormalClaim != info.Level);
+
+                if (info.Level >= SeasonPass.SeasonPassMaxLevel)
+                {
+                    levelText.text = "MAX";
+                }
+                else
+                {
+                    levelText.text = $"Lv.{info.Level}";
+                }
+
             }).AddTo(gameObject);
 
             Game.Game.instance.SeasonPassServiceManager.RemainingDateTime.Subscribe((endDate) =>

--- a/nekoyume/Assets/_Scripts/UI/Widget/SeasonPass.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/SeasonPass.cs
@@ -64,7 +64,6 @@ namespace Nekoyume.UI
                     levelText.text = "MAX";
                     expText.text = $"{seasonPassInfo.Exp - minExp} / {maxExp - minExp}";
                     expLineImage.fillAmount = (float)(seasonPassInfo.Exp - minExp) / (float)(maxExp - minExp);
-                    receiveBtn.Interactable = seasonPassInfo.Exp >= seasonPassManager.LevelInfos.Last().Exp;
                     lastRewardCell.SetData(seasonPassManager.CurrentSeasonPassData.RewardList[SeasonPassMaxLevel]);
                 }
                 else
@@ -72,11 +71,10 @@ namespace Nekoyume.UI
                     levelText.text = seasonPassInfo.Level.ToString();
                     expText.text = $"{seasonPassInfo.Exp - minExp} / {maxExp - minExp}";
                     expLineImage.fillAmount = (float)(seasonPassInfo.Exp - minExp) / (float)(maxExp - minExp);
-                    receiveBtn.Interactable = seasonPassInfo.Level > seasonPassInfo.LastNormalClaim
-                        || (seasonPassInfo.IsPremium && seasonPassInfo.Level > seasonPassInfo.LastPremiumClaim);
-
                     lastRewardCell.SetData(seasonPassManager.CurrentSeasonPassData.RewardList[SeasonPassMaxLevel-1]);
                 }
+                receiveBtn.Interactable = seasonPassInfo.Level > seasonPassInfo.LastNormalClaim
+                    || (seasonPassInfo.IsPremium && seasonPassInfo.Level > seasonPassInfo.LastPremiumClaim);
 
                 lineImage.fillAmount = (float)(seasonPassInfo.Level - 1) / (float)(seasonPassManager.CurrentSeasonPassData.RewardList.Count - 1);
 


### PR DESCRIPTION
-시즌패스 매뉴 레벨텍스트 Max나오지않는문제 수정.
-시즌패스 30달성시 받기버튼 비활성화 버그 수정

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205912551311626