### PR TITLE
feat: [Android] open native system settings for permission

### DIFF
--- a/nekoyume/Assets/StreamingAssets/Localization/button.csv
+++ b/nekoyume/Assets/StreamingAssets/Localization/button.csv
@@ -3,3 +3,4 @@ BTN_CREATE_ACCOUNT,Create a new account,새 계정 만들기,Create uma nova con
 BTN_IMPORT_KEY,Import key,키 가져 오기,Importar chave,キーをインポートする,Importar clave,นำเข้าคีย์,Impor kunci,Импортировать ключ,导入密钥,Mag-import ng key,
 BTN_QUIT,Quit,종료,Desistir,やめる,Dejar,ออก,Quit,Выйти,退出,Mag-quit,
 BTN_RETRY,Retry,재시도,Repetir,再試行,Reintentar,ลองใหม่,Coba lagi,Повторить,重试,Uulitin,
+BTN_OPEN_SYSTEM_SETTINGS,Open system settings,시스템 설정 열기,Abrir configurações do sistema,システム設定を開く,Abrir configuración del sistema,เปิดการตั้งค่าระบบ,Buka pengaturan sistem,Открыть настройки системы,打开系统设置,Buksan ang mga setting ng system,

--- a/nekoyume/Assets/StreamingAssets/Localization/sentence.csv
+++ b/nekoyume/Assets/StreamingAssets/Localization/sentence.csv
@@ -23,4 +23,15 @@ Atau Anda dapat membuat karakter baru di planet baru.","Ваша учетная 
 Upang maglaro ng isang umiiral na account, i-import ang isang keystore mula sa iyong PC.
 O maaari kang lumikha ng isang bagong character sa isang bagong planeta."
 STC_NO_ACCOUNT,"No account","계정 없음","Nenhuma conta","アカウントなし","Nenhuma conta","ไม่มีบัญชี","Tidak ada akun","Нет аккаунта","没有帐户","沒有帳戶","Walang account"
-STC_REQUIRED_CAMERA_PERMISSION_FOR_IMPORT_ACCOUNT_QR_CODE,"To import an account via QR code, you need to allow camera permission.","QR 코드를 통해 계정을 가져 오려면 카메라 권한을 허용해야합니다.","Para importar uma conta via código QR, você precisa permitir a permissão da câmera.","QRコードを介してアカウントをインポートするには、カメラの許可が必要です。","Para importar uma conta via código QR, você precisa permitir a permissão da câmera.","ในการนำเข้าบัญชีผ่านรหัส QR คุณต้องอนุญาตให้ใช้กล้อง","Untuk mengimpor akun melalui kode QR, Anda perlu mengizinkan izin kamera.","Чтобы импортировать учетную запись через QR-код, вам нужно разрешить использование камеры.","要通过QR码导入帐户，您需要允许使用相机。","要通過QR碼導入帳戶，您需要允許使用相機。","Upang i-import ang isang account sa pamamagitan ng QR code, kailangan mong pahintulutan ang pahintulot ng kamera."
+STC_REQUIRED_CAMERA_PERMISSION_FOR_IMPORT_ACCOUNT_QR_CODE,"To import an account via QR code, you need to allow camera permission.
+You can enable permission in system settings.","QR 코드를 통해 계정을 가져 오려면 카메라 권한을 허용해야합니다.
+시스템 설정에서 권한을 활성화 할 수 있습니다.","Para importar uma conta via código QR, você precisa permitir a permissão da câmera.
+Você pode ativar a permissão nas configurações do sistema.","QRコードを介してアカウントをインポートするには、カメラの許可が必要です。
+システム設定で権限を有効にできます。","Para importar uma conta via código QR, você precisa permitir a permissão da câmera.
+Você pode ativar a permissão nas configurações do sistema.","หากต้องการนำเข้าบัญชีผ่านรหัส QR คุณต้องอนุญาตให้ใช้กล้อง
+คุณสามารถเปิดใช้งานสิทธิ์ในการตั้งค่าระบบได้","Untuk mengimpor akun melalui kode QR, Anda perlu mengizinkan izin kamera.
+Anda dapat mengaktifkan izin di pengaturan sistem.","Чтобы импортировать учетную запись через QR-код, вам нужно разрешить использование камеры.
+Вы можете включить разрешение в настройках системы.","要通过QR码导入帐户，您需要允许使用相机。
+您可以在系统设置中启用权限。","要通過QR碼導入帳戶，您需要允許使用相機。
+您可以在系統設置中啟用權限。","Upang i-import ang isang account sa pamamagitan ng QR code, kailangan mong pahintulutan ang pahintulot ng kamera.
+Maaari mong paganahin ang pahintulot sa mga setting ng system."

--- a/nekoyume/Assets/_Scripts/Native.meta
+++ b/nekoyume/Assets/_Scripts/Native.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: d7a558c20dad4b2ca806b440e56d082b
+timeCreated: 1699838417

--- a/nekoyume/Assets/_Scripts/Native/SystemSettingsOpener.cs
+++ b/nekoyume/Assets/_Scripts/Native/SystemSettingsOpener.cs
@@ -1,0 +1,47 @@
+using System;
+using UnityEngine;
+
+namespace Nekoyume.Native
+{
+    public static class SystemSettingsOpener
+    {
+        public static void Open(string category)
+        {
+            Debug.Log($"[SystemSettingsOpener] Open System Settings: {category}");
+            if (Application.platform != RuntimePlatform.Android)
+            {
+                Debug.LogWarning("SystemSettingOpener is only supported on Android.");
+                return;
+            }
+
+            try
+            {
+                using var unityClass = new AndroidJavaClass("com.unity3d.player.UnityPlayer");
+                using var currentActivityObject = unityClass.GetStatic<AndroidJavaObject>("currentActivity");
+                var packageName = currentActivityObject.Call<string>("getPackageName");
+                using var uriClass = new AndroidJavaClass("android.net.Uri");
+                using var uriObject = uriClass.CallStatic<AndroidJavaObject>(
+                    "fromParts",
+                    "package",
+                    packageName,
+                    null);
+                using var intentObject = new AndroidJavaObject(
+                    "android.content.Intent",
+                    $"android.settings.{category}",
+                    uriObject);
+                intentObject.Call<AndroidJavaObject>("addCategory", "android.intent.category.DEFAULT");
+                intentObject.Call<AndroidJavaObject>("setFlags", 0x10000000);
+                currentActivityObject.Call("startActivity", intentObject);
+            }
+            catch (Exception ex)
+            {
+                Debug.LogException(ex);
+            }
+        }
+
+        public static void OpenApplicationDetailSettings()
+        {
+            Open("APPLICATION_DETAILS_SETTINGS");
+        }
+    }
+}

--- a/nekoyume/Assets/_Scripts/Native/SystemSettingsOpener.cs.meta
+++ b/nekoyume/Assets/_Scripts/Native/SystemSettingsOpener.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: c3b370f17ab04c8599dc76ac720faff8
+timeCreated: 1699615944

--- a/nekoyume/Assets/_Scripts/UI/Login/CodeReaderView.cs
+++ b/nekoyume/Assets/_Scripts/UI/Login/CodeReaderView.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using Nekoyume.L10n;
+using Nekoyume.Native;
 using Nekoyume.Permissions;
 using UnityEngine;
 using UnityEngine.Android;
@@ -125,14 +126,14 @@ namespace Nekoyume.UI
         {
             Debug.Log($"[CodeReaderView] OnPermissionDenied: {permission}");
             _cameraPermissionState = PermissionState.Denied;
-            RetryOrQuit();
+            OpenSystemSettingsAndQuit();
         }
 
         private void OnPermissionDeniedAndDontAskAgain(string permission)
         {
             Debug.Log($"[CodeReaderView] OnPermissionDeniedAndDontAskAgain: {permission}");
             _cameraPermissionState = PermissionState.DeniedAndDontAskAgain;
-            RetryOrQuit();
+            OpenSystemSettingsAndQuit();
         }
 
         private void OnPermissionGranted(string permission)
@@ -141,26 +142,20 @@ namespace Nekoyume.UI
             _cameraPermissionState = PermissionState.Granted;
         }
 
-        private void RetryOrQuit()
+        private static void OpenSystemSettingsAndQuit()
         {
-            if (!Widget.TryFind<TwoButtonSystem>(out var widget))
+            if (!Widget.TryFind<OneButtonSystem>(out var widget))
             {
-                widget = Widget.Create<TwoButtonSystem>();
+                widget = Widget.Create<OneButtonSystem>();
             }
-
+            
             widget.Show(
                 L10nManager.Localize("STC_REQUIRED_CAMERA_PERMISSION_FOR_IMPORT_ACCOUNT_QR_CODE"),
-                confirmText: L10nManager.Localize("BTN_RETRY"),
-                confirmCallback: () => {
-                    Debug.Log("[CodeReaderView] Request camera permission.(Retry)");
-                    Permission.RequestUserPermission(
-                        Permission.Camera,
-                        _permissionCallbacks);
-                },
-                cancelText: L10nManager.Localize("BTN_QUIT"),
-                cancelCallback: () =>
+                confirmText: L10nManager.Localize("BTN_OPEN_SYSTEM_SETTINGS"),
+                confirmCallback: () =>
                 {
-                    Debug.Log("[CodeReaderView] Quit.");
+                    Debug.Log("[CodeReaderView] Open system settings.");
+                    SystemSettingsOpener.OpenApplicationDetailSettings();
 #if UNITY_EDITOR
                     UnityEditor.EditorApplication.isPlaying = false;
 #else


### PR DESCRIPTION
(kor)
- 플레이어가 명시적으로 기능에 대한 권한을 거부하는 경우에 시스템 설정으로 안내합니다.
- `SystemSettingsOpener`를 도입합니다.
- QR 코드 가져오기 과정에서 `SystemSettingsOpener`를 사용합니다.

(eng)
- If a player explicitly denies permission to a feature, direct them to the system settings.
- introduce `SystemSettingsOpener`.
- Use `SystemSettingsOpener` during the QR code import process.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205912720216535