### PR TITLE
fix seasonpass obj hide when worldboss practicemode

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Widget/Popup/WorldBossResultPopup.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Popup/WorldBossResultPopup.cs
@@ -129,6 +129,11 @@ namespace Nekoyume.UI
                     _gradeObject.transform.localScale = Vector3.one;
                 }
             }
+
+            foreach (var item in seasonPassObjs)
+            {
+                item.SetActive(false);
+            }
         }
 
         public override void Close(bool ignoreCloseAnimation = false)


### PR DESCRIPTION
월드보스 연습모드일경우 용기경험치 보이지않도록 수정.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205946068107188