### PR TITLE
Fix headmenu inventory to check cleared stage for notification(red-dot)

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Module/Inventory.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/Inventory.cs
@@ -647,13 +647,32 @@ namespace Nekoyume.UI.Module
 
         public bool HasNotification()
         {
+            var clearedStageId = States.Instance.CurrentAvatarState
+                .worldInformation.TryGetLastClearedStageId(out var id) ? id : 1;
             var equipments = GetBestEquipments();
             foreach (var guid in equipments)
             {
                 var slots = States.Instance.CurrentItemSlotStates.Values;
-                if (slots.Any(x => !x.Equipments.Exists(x => x == guid)))
+                foreach (var slotState in slots.Where(x => !x.Equipments.Exists(x => x == guid)))
                 {
-                    return true;
+                    if (slotState.BattleType == BattleType.Arena)
+                    {
+                        if (clearedStageId >= Game.LiveAsset.GameConfig.RequiredStage.Arena)
+                        {
+                            return true;
+                        }
+                    }
+                    else if (slotState.BattleType == BattleType.Raid)
+                    {
+                        if (clearedStageId >= Game.LiveAsset.GameConfig.RequiredStage.Arena)
+                        {
+                            return true;
+                        }
+                    }
+                    else
+                    {
+                        return true;
+                    }
                 }
             }
 
@@ -666,7 +685,24 @@ namespace Nekoyume.UI.Module
                     var slots = States.Instance.CurrentRuneSlotStates[battleType].GetRuneSlot();
                     if (!slots.Exists(x => x.RuneId == inventoryItem.RuneState.RuneId))
                     {
-                        return true;
+                        if (battleType == BattleType.Arena)
+                        {
+                            if (clearedStageId >= Game.LiveAsset.GameConfig.RequiredStage.Arena)
+                            {
+                                return true;
+                            }
+                        }
+                        else if (battleType == BattleType.Raid)
+                        {
+                            if (clearedStageId >= Game.LiveAsset.GameConfig.RequiredStage.Arena)
+                            {
+                                return true;
+                            }
+                        }
+                        else
+                        {
+                            return true;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
### Description

[갈아낄 장비가 없는데 레드닷을 계속 띄워주는 문제](https://app.asana.com/0/958521740385861/1205988121943677/f)


