### PR TITLE
clear upgrade description branch

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Widget/Enhancement.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Enhancement.cs
@@ -626,40 +626,29 @@ namespace Nekoyume.UI
                     var skillRow = itemOptionInfo.SkillOptions[skillIndex].skillRow;
                     var chanceText = $"<color=#FBF0B8>({itemOptionInfo.SkillOptions[skillIndex].chance}% > <color=#E3C32C>{skillChancesMin[skillIndex]}~{skillChancesMax[skillIndex]}%</color><sprite name=icon_Arrow>)</color>";
                     string valueText = string.Empty;
-                    switch (skillRow.SkillType)
-                    {
-                        case Nekoyume.Model.Skill.SkillType.Attack:
-                        case Nekoyume.Model.Skill.SkillType.Heal:
-                            valueText = $"<color=#FBF0B8>({itemOptionInfo.SkillOptions[skillIndex].power} > <color=#E3C32C>{skillPowersMin[skillIndex]}~{skillPowersMax[skillIndex]}</color><sprite name=icon_Arrow>)</color>";
-                            break;
-                        case Nekoyume.Model.Skill.SkillType.Buff:
-                        case Nekoyume.Model.Skill.SkillType.Debuff:
-                            var currentEffect = SkillExtensions.EffectToString(
-                                                            skillRow.Id,
-                                                            skillRow.SkillType,
-                                                            itemOptionInfo.SkillOptions[skillIndex].power,
-                                                            itemOptionInfo.SkillOptions[skillIndex].statPowerRatio,
-                                                            itemOptionInfo.SkillOptions[skillIndex].refStatType);
 
-                            var targetEffectMin = SkillExtensions.EffectToString(
-                                                            skillRow.Id,
-                                                            skillRow.SkillType,
-                                                            skillPowersMin[skillIndex],
-                                                            skillStatPowerRatioMin[skillIndex],
-                                                            itemOptionInfo.SkillOptions[skillIndex].refStatType);
+                    var currentEffect = SkillExtensions.EffectToString(
+                                skillRow.Id,
+                                skillRow.SkillType,
+                                itemOptionInfo.SkillOptions[skillIndex].power,
+                                itemOptionInfo.SkillOptions[skillIndex].statPowerRatio,
+                                itemOptionInfo.SkillOptions[skillIndex].refStatType);
 
-                            var targetEffectMax = SkillExtensions.EffectToString(
-                                                            skillRow.Id,
-                                                            skillRow.SkillType,
-                                                            skillPowersMax[skillIndex],
-                                                            skillStatPowerRatioMax[skillIndex],
-                                                            itemOptionInfo.SkillOptions[skillIndex].refStatType);
+                    var targetEffectMin = SkillExtensions.EffectToString(
+                                                    skillRow.Id,
+                                                    skillRow.SkillType,
+                                                    skillPowersMin[skillIndex],
+                                                    skillStatPowerRatioMin[skillIndex],
+                                                    itemOptionInfo.SkillOptions[skillIndex].refStatType);
 
-                            valueText = $"<color=#FBF0B8>({currentEffect} > <color=#E3C32C>{targetEffectMin.Replace("%", "")}~{targetEffectMax}</color><sprite name=icon_Arrow>)</color>";
-                            break;
-                        default:
-                            break;
-                    }
+                    var targetEffectMax = SkillExtensions.EffectToString(
+                                                    skillRow.Id,
+                                                    skillRow.SkillType,
+                                                    skillPowersMax[skillIndex],
+                                                    skillStatPowerRatioMax[skillIndex],
+                                                    itemOptionInfo.SkillOptions[skillIndex].refStatType);
+                    valueText = $"<color=#FBF0B8>({currentEffect} > <color=#E3C32C>{targetEffectMin.Replace("%", "")}~{targetEffectMax}</color><sprite name=icon_Arrow>)</color>";
+
                     skillViews[skillIndex].Set(skillRow.GetLocalizedName(), skillRow.SkillType, skillRow.Id, skillRow.Cooldown, chanceText, valueText);
                 }
             }


### PR DESCRIPTION
EffectToString 에서 스킬관련 변환을 모두 해주기 때문에 따로 SkillType 분기를 타지않도록 수정.
PowerRatio대신 Power가 표기되어 0이 나오던 문제 수정.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206088796073259