### PR TITLE
Fix stat value string at recipe view

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Module/Recipe/RecipeView.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/Recipe/RecipeView.cs
@@ -57,13 +57,17 @@ namespace Nekoyume.UI.Module
                 case EquipmentItemSheet.Row equipmentRow:
                     var equipmentStat = equipmentRow.GetUniqueStat();
                     normalLevelText.text = string.Format(
-                        LevelTextFormat, equipmentStat.StatType, equipmentStat.TotalValue);
+                        LevelTextFormat,
+                        equipmentStat.StatType,
+                        equipmentStat.StatType.ValueToString((int)equipmentStat.TotalValue));
                     normalLevelText.gameObject.SetActive(true);
                     break;
                 case ConsumableItemSheet.Row consumableRow:
                     var consumableStat = consumableRow.GetUniqueStat();
                     normalLevelText.text = string.Format(
-                        LevelTextFormat, consumableStat.StatType, consumableStat.TotalValue);
+                        LevelTextFormat,
+                        consumableStat.StatType,
+                        consumableStat.StatType.ValueToString((int)consumableStat.TotalValue));
                     normalLevelText.gameObject.SetActive(true);
                     break;
                 case MaterialItemSheet.Row:


### PR DESCRIPTION
### Description

[공방 레시피에서 스피드가 메인 스탯인 장비 아이콘에서 /100 처리가 안된 문제](https://app.asana.com/0/958521740385861/1206134962292318/f)

### Screenshot

<img width="950" alt="image" src="https://github.com/planetarium/NineChronicles/assets/63496908/52553178-c28b-48b1-ae91-95e7221bf157">
