### PR TITLE
Fix disable unlock shop popup in stage 17, mobile

### DIFF
--- a/nekoyume/Assets/_Scripts/Game/Stage.cs
+++ b/nekoyume/Assets/_Scripts/Game/Stage.cs
@@ -1,3 +1,10 @@
+#if !UNITY_EDITOR && (UNITY_ANDROID || UNITY_IOS)
+#define RUN_ON_MOBILE
+#define ENABLE_FIREBASE
+#endif
+#if !UNITY_EDITOR && UNITY_STANDALONE
+#define RUN_ON_STANDALONE
+#endif
 //#define TEST_LOG
 
 using Cysharp.Threading.Tasks;


### PR DESCRIPTION
### Description

[모바일환경에서 stage 17 클리어 시 shop 언락 언출 나오지 않도록 처리](https://app.asana.com/0/958521740385861/1206125891349824/f)

define `RUN_ON_MOBILE` used this ⬇️

```cs
#if !RUN_ON_MOBILE
            if (stageId == LiveAsset.GameConfig.RequiredStage.Shop)
            {
                menuNames.Add("UI_MAIN_MENU_SHOP");
            }
#endif
```
(Stage.cs, line.1364)