### PR TITLE
apply EventDungeonCourageAmount

### DIFF
--- a/nekoyume/Assets/_Scripts/GeneratedApi/SeasonPassServiceClient.cs
+++ b/nekoyume/Assets/_Scripts/GeneratedApi/SeasonPassServiceClient.cs
@@ -38,6 +38,7 @@ public class SeasonPassServiceClient
         hack_and_slash_sweep,
         battle_arena,
         raid,
+        event_dungeon,
     }
 
     public class ActionTypeTypeConverter : JsonConverter<ActionType>

--- a/nekoyume/Assets/_Scripts/SeasonPassService/SeasonPassServiceManager.cs
+++ b/nekoyume/Assets/_Scripts/SeasonPassService/SeasonPassServiceManager.cs
@@ -15,6 +15,7 @@ namespace Nekoyume
         public int AdventureSweepCourageAmount = 10;
         public int ArenaCourageAmount = 10;
         public int WorldBossCourageAmount = 10;
+        public int EventDungeonCourageAmount = 10;
 
         public SeasonPassServiceClient Client { get; private set; }
 
@@ -89,6 +90,9 @@ namespace Nekoyume
                             break;
                         case SeasonPassServiceClient.ActionType.raid:
                             WorldBossCourageAmount = item.Exp;
+                            break;
+                        case SeasonPassServiceClient.ActionType.event_dungeon:
+                            EventDungeonCourageAmount = item.Exp;
                             break;
                         default:
                             break;

--- a/nekoyume/Assets/_Scripts/UI/Widget/Popup/BattleResultPopup.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Popup/BattleResultPopup.cs
@@ -1088,7 +1088,14 @@ namespace Nekoyume.UI
                     Debug.LogError("SharedModel.ClearedCountForEachWaves Sum Failed");
                 }
 
-                seasonPassCourageAmount.text = $"+{Game.Game.instance.SeasonPassServiceManager.AdventureCourageAmount * playCount}";
+                if (SharedModel.StageType == StageType.EventDungeon)
+                {
+                    seasonPassCourageAmount.text = $"+{Game.Game.instance.SeasonPassServiceManager.EventDungeonCourageAmount * playCount}";
+                }
+                else
+                {
+                    seasonPassCourageAmount.text = $"+{Game.Game.instance.SeasonPassServiceManager.AdventureCourageAmount * playCount}";
+                }
             }
             else
             {

--- a/nekoyume/Assets/_Scripts/UI/Widget/StageInformation.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/StageInformation.cs
@@ -114,7 +114,7 @@ namespace Nekoyume.UI
             Close(true);
         }
 
-        private void RefreshSeasonPassCourageAmount()
+        private void RefreshSeasonPassCourageAmount(bool isEventDungeon = false)
         {
             if(Game.Game.instance.SeasonPassServiceManager.CurrentSeasonPassData != null)
             {
@@ -122,7 +122,15 @@ namespace Nekoyume.UI
                 {
                     item.SetActive(true);
                 }
-                seasonPassCourageAmount.text = $"+{Game.Game.instance.SeasonPassServiceManager.AdventureCourageAmount}";
+
+                if (isEventDungeon)
+                {
+                    seasonPassCourageAmount.text = $"+{Game.Game.instance.SeasonPassServiceManager.EventDungeonCourageAmount}";
+                }
+                else
+                {
+                    seasonPassCourageAmount.text = $"+{Game.Game.instance.SeasonPassServiceManager.AdventureCourageAmount}";
+                }
             }
             else
             {
@@ -211,7 +219,7 @@ namespace Nekoyume.UI
             world.Set(eventDungeonRow);
             world.Set(openedStageId, nextStageId);
             world.ShowByStageId(_sharedViewModel.SelectedStageId.Value, nextStageId);
-            RefreshSeasonPassCourageAmount();
+            RefreshSeasonPassCourageAmount(true);
             base.Show(true);
         }
 


### PR DESCRIPTION
시즌패스 서비스에 event_dungeon Enum값 추가로 필요한 부분 수정한 내용입니다.
기존 배포된 내용에는 Adventure 경험치와 동일하게 계산되어있어 문제없으나 추후 지원을 위해서 추가했습니다.