### PR TITLE
remove directly setting mailbox

### DIFF
--- a/nekoyume/Assets/_Scripts/Blockchain/ActionRenderHandler.cs
+++ b/nekoyume/Assets/_Scripts/Blockchain/ActionRenderHandler.cs
@@ -3448,8 +3448,6 @@ namespace Nekoyume.Blockchain
 
                 if (mail is not null)
                 {
-                    mail.New = true;
-                    gameStates.CurrentAvatarState.mailBox = mailBox;
                     LocalLayerModifier.AddNewMail(avatarAddr, mail.id);
                     if (mail.Memo != null && mail.Memo.Contains("season_pass"))
                     {
@@ -3585,7 +3583,10 @@ namespace Nekoyume.Blockchain
                 }
 
                 mailBox = new MailBox(mailBoxList);
-                var sameBlockIndexMailList = mailBox.OfType<ClaimItemsMail>().Where(m => m.blockIndex == eval.BlockIndex);
+                var sameBlockIndexMailList = mailBox
+                    .OfType<ClaimItemsMail>()
+                    .Where(m => m.blockIndex == eval.BlockIndex)
+                    .ToList();
                 if (sameBlockIndexMailList.Any())
                 {
                     var memoCheckedMail = sameBlockIndexMailList.FirstOrDefault(m => m.Memo == eval.Action.Memo);
@@ -3593,8 +3594,6 @@ namespace Nekoyume.Blockchain
                 }
                 if (mail is not null)
                 {
-                    mail.New = true;
-                    gameStates.CurrentAvatarState.mailBox = mailBox;
                     LocalLayerModifier.AddNewMail(avatarAddr, mail.id);
                     if (mail.Memo != null && mail.Memo.Contains("season_pass"))
                     {
@@ -3694,7 +3693,10 @@ namespace Nekoyume.Blockchain
             var avatar = gameStates.CurrentAvatarState;
             var mailBox = avatar.mailBox;
             UnloadFromMyGaragesRecipientMail mail = null;
-            var sameBlockIndexMailList = mailBox.OfType<UnloadFromMyGaragesRecipientMail>().Where(m => m.blockIndex == eval.BlockIndex);
+            var sameBlockIndexMailList = mailBox
+                .OfType<UnloadFromMyGaragesRecipientMail>()
+                .Where(m => m.blockIndex == eval.BlockIndex)
+                .ToList();
             if (sameBlockIndexMailList.Any())
             {
                 var memoCheckedMail = sameBlockIndexMailList.FirstOrDefault(m => m.Memo == eval.Action.Memo);
@@ -3703,8 +3705,6 @@ namespace Nekoyume.Blockchain
 
             if (mail is not null)
             {
-                mail.New = true;
-                gameStates.CurrentAvatarState.mailBox = mailBox;
                 LocalLayerModifier.AddNewMail(avatar.address, mail.id);
             }
             if (Widget.Find<MobileShop>() != null && Widget.Find<MobileShop>().IsActive())


### PR DESCRIPTION
### Description

기존 IAP 등에서 만들어주는 ClaimItemsMail 등이 새 메일이 추가될 경우 기존 메일이 날아가는듯한 모습을 보이고 있었습니다. 이를 직접 mailbox를 set하는 코드의 문제로 보고, `currentAvatarState.Mailbox = variable` 과 같은 형태의 코드를 삭제했습니다.

### How to test

1. modify `ClaimItems` action for test.
2. execute it.
3. check mailbox and mail popup ui.

### Related Links

https://app.asana.com/0/958521740385861/1206261558282586/f

### Screenshot
check asana issue