### PR TITLE
set first touch handler obj

### DIFF
--- a/nekoyume/Assets/_Scripts/Game/Character/TouchHandler.cs
+++ b/nekoyume/Assets/_Scripts/Game/Character/TouchHandler.cs
@@ -64,6 +64,14 @@ namespace Nekoyume.Game.Character
 
         public static GameObject currentSelectedGameObject { get; private set; }
 
+        private void OnEnable()
+        {
+            if(currentSelectedGameObject == null)
+            {   
+                currentSelectedGameObject = gameObject;
+            }
+        }
+
         public void OnPointerClick(PointerEventData eventData)
         {
             switch (eventData.button)


### PR DESCRIPTION
처음 접속시 선택된 터치핸들러가 없어서 툴팁 닫는것에 실패하는 문제로 확인되었습니다.
일단 터치핸들러가 활성화될때 선택된 터치핸들러가 없다면 본인을 넣도록 수정하여 문제해결된것 확인했습니다.
시즌패스에서 여는 툴팁말고도 다른곳에서도 동일한 문제 발생하는부분 다같이 수정될것으로 예상됩니다.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206089527062271