### PR TITLE
fix seasonpass iap item refresh failed

### DIFF
--- a/nekoyume/Assets/_Scripts/Helper/Util.cs
+++ b/nekoyume/Assets/_Scripts/Helper/Util.cs
@@ -620,5 +620,18 @@ namespace Nekoyume.Helper
         {
             return CachedDownloadTextures.GetValueOrDefault(url);
         }
+
+
+        public static void SetActiveSafe(this GameObject obj, bool active)
+        {
+            if (obj != null)
+            {
+                obj.SetActive(active);
+            }
+            else
+            {
+                Debug.LogWarning("[SetActiveSafe] fail");
+            }
+        }
     }
 }

--- a/nekoyume/Assets/_Scripts/UI/Module/Item/EquipmentInventoryItemView.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/Item/EquipmentInventoryItemView.cs
@@ -42,7 +42,7 @@ namespace Nekoyume.UI.Module
             baseItemView.TradableObject.SetActive(false);
             baseItemView.NotificationObject.SetActive(false);
             baseItemView.LoadingObject.SetActive(false);
-            baseItemView.RuneNotificationObj.SetActive(false);
+            baseItemView.RuneNotificationObj.SetActiveSafe(false);
 
             baseItemView.ItemImage.overrideSprite = BaseItemView.GetItemIcon(model.ItemBase);
 

--- a/nekoyume/Assets/_Scripts/UI/Module/Item/InventoryItemView.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/Item/InventoryItemView.cs
@@ -57,7 +57,7 @@ namespace Nekoyume.UI.Module
             baseItemView.ShadowObject.SetActive(false);
             baseItemView.PriceText.gameObject.SetActive(false);
             baseItemView.LoadingObject.SetActive(false);
-            baseItemView.RuneNotificationObj.SetActive(false);
+            baseItemView.RuneNotificationObj.SetActiveSafe(false);
 
             baseItemView.ItemImage.overrideSprite =
                 BaseItemView.GetItemIcon(model.ItemBase);
@@ -137,7 +137,7 @@ namespace Nekoyume.UI.Module
             baseItemView.LevelLimitObject.SetActive(false);
             baseItemView.TradableObject.SetActive(false);
             baseItemView.GrindingCountObject.SetActive(false);
-            baseItemView.RuneNotificationObj.SetActive(false);
+            baseItemView.RuneNotificationObj.SetActiveSafe(false);
 
             if (RuneFrontHelper.TryGetRuneIcon(model.RuneState.RuneId, out var icon))
             {
@@ -213,7 +213,7 @@ namespace Nekoyume.UI.Module
             baseItemView.EnhancementImage.gameObject.SetActive(false);
             baseItemView.OptionTag.gameObject.SetActive(false);
             baseItemView.CountText.gameObject.SetActive(true);
-            baseItemView.RuneNotificationObj.SetActive(false);
+            baseItemView.RuneNotificationObj.SetActiveSafe(false);
 
             baseItemView.CountText.text = model.FungibleAssetValue.GetQuantityString();
             baseItemView.ItemImage.overrideSprite = model.FungibleAssetValue.GetIconSprite();

--- a/nekoyume/Assets/_Scripts/UI/Module/Item/MailRewardItemView.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/Item/MailRewardItemView.cs
@@ -41,7 +41,7 @@ namespace Nekoyume
             baseItemView.NotificationObject.SetActive(false);
             baseItemView.GrindingCountObject.SetActive((false));
             baseItemView.LevelLimitObject.SetActive(false);
-            baseItemView.RuneNotificationObj.SetActive(false);
+            baseItemView.RuneNotificationObj.SetActiveSafe(false);
 
             if (mailReward.ItemBase is not null)
             {

--- a/nekoyume/Assets/_Scripts/UI/Module/Item/ShopCartItemView.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/Item/ShopCartItemView.cs
@@ -44,7 +44,7 @@ namespace Nekoyume.UI.Module
             baseItemView.ExpiredObject.SetActive(false);
             baseItemView.PriceText.gameObject.SetActive(false);
             baseItemView.LoadingObject.SetActive(false);
-            baseItemView.RuneNotificationObj.SetActive(false);
+            baseItemView.RuneNotificationObj.SetActiveSafe(false);
 
             if (model.ItemBase is not null)
             {

--- a/nekoyume/Assets/_Scripts/UI/Module/Item/ShopItemView.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/Item/ShopItemView.cs
@@ -40,7 +40,7 @@ namespace Nekoyume.UI.Module
             baseItemView.DimObject.SetActive(false);
             baseItemView.EquippedObject.SetActive(false);
             baseItemView.LoadingObject.SetActive(false);
-            baseItemView.RuneNotificationObj.SetActive(false);
+            baseItemView.RuneNotificationObj.SetActiveSafe(false);
 
             if (model.ItemBase is not null)
             {

--- a/nekoyume/Assets/_Scripts/UI/Module/Item/SweepItemView.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/Item/SweepItemView.cs
@@ -5,6 +5,7 @@ using UnityEngine;
 
 namespace Nekoyume.UI.Module
 {
+    using Nekoyume.Helper;
     using UniRx;
     [RequireComponent(typeof(BaseItemView))]
     public class SweepItemView : MonoBehaviour
@@ -57,7 +58,7 @@ namespace Nekoyume.UI.Module
             baseItemView.LockObject.SetActive(false);
             baseItemView.ShadowObject.SetActive(false);
             baseItemView.LoadingObject.SetActive(false);
-            baseItemView.RuneNotificationObj.SetActive(false);
+            baseItemView.RuneNotificationObj.SetActiveSafe(false);
         }
     }
 }

--- a/nekoyume/Assets/_Scripts/UI/Module/Item/TooltipItemView.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/Item/TooltipItemView.cs
@@ -59,6 +59,7 @@ namespace Nekoyume.UI.Module
             baseItemView.ItemImage.gameObject.SetActive(true);
             baseItemView.SpineItemImage.gameObject.SetActive(false);
             baseItemView.LoadingObject.SetActive(false);
+            baseItemView.RuneNotificationObj.SetActiveSafe(false);
 
             baseItemView.ItemImage.overrideSprite = BaseItemView.GetItemIcon(itemBase);
 

--- a/nekoyume/Assets/_Scripts/UI/Module/SeasonPass/SeasonPassRewardCell.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/SeasonPass/SeasonPassRewardCell.cs
@@ -58,7 +58,7 @@ namespace Nekoyume.UI.Module
                 ItemView.GrindingCountObject.SetActive((false));
                 ItemView.LevelLimitObject.SetActive(false);
                 ItemView.RewardReceived.SetActive(false);
-                ItemView.RuneNotificationObj.SetActive(false);
+                ItemView.RuneNotificationObj.SetActiveSafe(false);
 
                 disposable?.Dispose();
 

--- a/nekoyume/Assets/_Scripts/UI/Scroller/RuneStoneEnhancementInventoryCell.cs
+++ b/nekoyume/Assets/_Scripts/UI/Scroller/RuneStoneEnhancementInventoryCell.cs
@@ -39,7 +39,7 @@ namespace Nekoyume.UI.Scroller
             view.LevelLimitObject.SetActive(false);
             view.TradableObject.SetActive(false);
             view.GrindingCountObject.SetActive(false);
-            view.RuneNotificationObj.SetActive(false);
+            view.RuneNotificationObj.SetActiveSafe(false);
 
             if (RuneFrontHelper.TryGetRuneIcon(viewModel.SheetData.Id, out var icon))
             {
@@ -78,7 +78,7 @@ namespace Nekoyume.UI.Scroller
                 .Subscribe(Context.OnClick.OnNext)
                 .AddTo(_disposables);
 
-            view.RuneNotificationObj.SetActive(viewModel.item.HasNotification);
+            view.RuneNotificationObj.SetActiveSafe(viewModel.item.HasNotification);
 
             viewModel.item.IsSelected.Subscribe(b => view.RuneSelectMove.SetActive(b)).AddTo(_disposables);
             viewModel.item.IsSelected.Value = false;

--- a/nekoyume/Assets/_Scripts/UI/Widget/Popup/SeasonPassPremiumPopup.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Popup/SeasonPassPremiumPopup.cs
@@ -193,7 +193,7 @@ namespace Nekoyume.UI
             baseItem.LevelLimitObject.SetActive(false);
             baseItem.RewardReceived.SetActive(false);
             baseItem.LevelLimitObject.SetActive(false);
-            baseItem.RuneNotificationObj.SetActive(false);
+            baseItem.RuneNotificationObj.SetActiveSafe(false);
         }
 
         private void RefreshIcons(SeasonPassServiceClient.UserSeasonPassSchema seasonPassInfo)


### PR DESCRIPTION
신규로 프리팹에 추가된 RuneNotificationObj의 래퍼런스가없는 아이템 뷰에서 참조시 에러가나는부분 수정.
시즌패스 IAP 상품 갱신이 정상적으로되지않던 문제의 원인.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206378987676419