### PR TITLE
[WIP]package: add `9c-unity-mod-ares`

### DIFF
--- a/nekoyume/Packages/manifest.json
+++ b/nekoyume/Packages/manifest.json
@@ -12,6 +12,7 @@
     "com.laicasaane.texttyper": "https://github.com/laicasaane/unity-text-typer.git?path=Assets/TextTyper#3.1.0",
     "com.mixpanel.unity": "https://github.com/mixpanel/mixpanel-unity.git#master",
     "com.neuecc.unirx": "https://github.com/starikcetin/unirx.git#f93af89f2aafeccfc7aff9dee2cecc6d60ede06b",
+    "com.planetariumlabs.9c-unity-mod-ares": "https://github.com/planetarium/9c-unity-mod-ares.git?path=/nekoyume/Assets/MOD#9c-unity-mod-ares",
     "com.unity.2d.sprite": "1.0.0",
     "com.unity.addressables": "1.19.19",
     "com.unity.analytics": "3.6.12",

--- a/nekoyume/Packages/packages-lock.json
+++ b/nekoyume/Packages/packages-lock.json
@@ -85,6 +85,13 @@
       "dependencies": {},
       "hash": "f93af89f2aafeccfc7aff9dee2cecc6d60ede06b"
     },
+    "com.planetariumlabs.9c-unity-mod-ares": {
+      "version": "https://github.com/planetarium/9c-unity-mod-ares.git?path=/nekoyume/Assets/MOD#9c-unity-mod-ares",
+      "depth": 0,
+      "source": "git",
+      "dependencies": {},
+      "hash": "321077be5473bb7aca348eedcd91ae2e1ac6cf2a"
+    },
     "com.unity.2d.sprite": {
       "version": "1.0.0",
       "depth": 0,


### PR DESCRIPTION
# 이 풀 리퀘스트를 병합하지 않습니다.

이 풀 리퀘스트는 https://github.com/planetarium/9c-unity-mod-ares 저장소의 `9c-unity-mod-ares` 브랜치에 구성되어 있는 `com.planetariumlabs.9c-unity-mod-ares` 유니티 패키지를 추가합니다.

이 풀 리퀘스트는 정규 CI/CD를 통해서 빌드된 모드 클라이언트가 잘 동작하는지 확인하는 목적으로 만들어졌습니다.

# Do not merge this pull request.

This pull request adds the `com.planetariumlabs.9c-unity-mod-ares` Unity package, which is configured in the `9c-unity-mod-ares` branch of the https://github.com/planetarium/9c-unity-mod-ares repository.

This pull request was created to verify that modded clients built through regular CI/CD are working well.