### PR TITLE
update event dungeon ui

### DIFF
--- a/nekoyume/Assets/_Scripts/Helper/WorldMapDataHelper.cs
+++ b/nekoyume/Assets/_Scripts/Helper/WorldMapDataHelper.cs
@@ -23,8 +23,8 @@ namespace Nekoyume.Helper
 
         public static WorldMapData.StageIcon GetStageIcon(EnumType.BossType bossType, EnumType.EventType eventType)
         {
-            return WorldMapData.eventStageIcons.FirstOrDefault(icon => icon.eventType == eventType) ??
-                   WorldMapData.bossStageIcons.FirstOrDefault(icon => icon.bossType == bossType) ??
+            return WorldMapData.bossStageIcons.FirstOrDefault(icon => icon.bossType == bossType) ??
+                   WorldMapData.eventStageIcons.FirstOrDefault(icon => icon.eventType == eventType) ??
                    WorldMapData.defaultStageIcon;
         }
 

--- a/nekoyume/Assets/_Scripts/UI/Module/WorldMap/WorldMapWorld.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/WorldMap/WorldMapWorld.cs
@@ -193,7 +193,7 @@ namespace Nekoyume.UI.Module
                         var stageModel = new WorldMapStage.ViewModel(
                             SharedViewModel.StageType,
                             stageTuple.stageId,
-                            GetBossType(stageTuple.stageId, stageTuple.hasBoss),
+                            GetBossType(stageTuple.stageId, stageTuple.hasBoss, eventType),
                             eventType,
                             WorldMapStage.State.Normal);
 
@@ -224,11 +224,18 @@ namespace Nekoyume.UI.Module
                     nextPageShouldHide = true;
                 }
 
-                BossType GetBossType(int stageId, bool hasBoss)
+                BossType GetBossType(int stageId, bool hasBoss, EventType eventType)
                 {
                     if (!hasBoss)
                     {
                         return BossType.None;
+                    }
+
+                    if (stageType == StageType.EventDungeon)
+                    {
+                        return stageId % 20 == 0
+                            ? BossType.LastBoss
+                            : BossType.MiddleBoss;
                     }
 
                     return stageId % 50 == 0

--- a/nekoyume/Assets/_Scripts/UI/Module/WorldMap/WorldMapWorld.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/WorldMap/WorldMapWorld.cs
@@ -193,7 +193,7 @@ namespace Nekoyume.UI.Module
                         var stageModel = new WorldMapStage.ViewModel(
                             SharedViewModel.StageType,
                             stageTuple.stageId,
-                            GetBossType(stageTuple.stageId, stageTuple.hasBoss, eventType),
+                            GetBossType(stageTuple.stageId, stageTuple.hasBoss),
                             eventType,
                             WorldMapStage.State.Normal);
 
@@ -224,7 +224,8 @@ namespace Nekoyume.UI.Module
                     nextPageShouldHide = true;
                 }
 
-                BossType GetBossType(int stageId, bool hasBoss, EventType eventType)
+                // todo: Remove this method, Read data from sheet
+                BossType GetBossType(int stageId, bool hasBoss)
                 {
                     if (!hasBoss)
                     {

--- a/nekoyume/Assets/_Scripts/UI/Module/WorldMap/WorldMapWorld.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/WorldMap/WorldMapWorld.cs
@@ -11,6 +11,7 @@ using Nekoyume.TableData.Event;
 using UnityEngine;
 using UnityEngine.UI;
 using UnityEngine.UI.Extensions;
+using EventType = Nekoyume.EnumType.EventType;
 
 namespace Nekoyume.UI.Module
 {
@@ -153,7 +154,7 @@ namespace Nekoyume.UI.Module
             StageType stageType,
             List<(int stageId, bool hasBoss)> stageTuples)
         {
-            var eventType = EventManager.GetEventInfo().EventType;
+            var eventType = stageType == StageType.EventDungeon ? EventManager.GetEventInfo().EventType : EventType.Default;
 
             var stageWaveRowsCount = stageTuples.Count;
             var stageOffset = 0;


### PR DESCRIPTION
### Description

1. 이벤트 던전과 일반 던전의 아이콘을 구분하는 로직을 추가합니다
2. 이벤트 던전의 20번째 스테이지에 최종 보스 아이콘을 적용합니다 (임시)

### How to test

1. 월드맵에서 스테이지 아이콘을 확인합니다.
#4133 
