### PR TITLE
모바일 워크샵 팝업에서 펫 버튼 활성화

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Widget/Popup/CombinationSlotsPopup.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Popup/CombinationSlotsPopup.cs
@@ -93,12 +93,7 @@ namespace Nekoyume.UI
 
         public void TogglePetPopup(int slotIndex)
         {
-#if UNITY_ANDROID || UNITY_IOS
-            Find<TitleOneButtonSystem>().Show("UI_ALERT_NOT_IMPLEMENTED_TITLE",
-                "UI_ALERT_NOT_IMPLEMENTED_CONTENT");
-#else
             petInventory.Toggle(slotIndex);
-#endif
         }
 
         private void UpdateSlots(long blockIndex)


### PR DESCRIPTION
### Description

1모바일 빌드의 워크샵 팝업에서 펫 버튼을 활성화합니다.

### How to test

모바일 빌드의 워크샵 팝업을 활성화한 후, 펫 버튼을 터치합니다.

### Screenshot
![image](https://github.com/planetarium/NineChronicles/assets/58686228/902f9b63-4aa0-48c7-b945-915bf3195d3c)

수정 전 이미지입니다
