### PR TITLE
disable area attack cutscene

### DIFF
--- a/nekoyume/Assets/_Scripts/Game/Character/Player.cs
+++ b/nekoyume/Assets/_Scripts/Game/Character/Player.cs
@@ -384,6 +384,8 @@ namespace Nekoyume.Game.Character
 
         protected override void ShowCutscene()
         {
+            // TODO: Change this after fixing the cutscene resource
+            return;
             AreaAttackCutscene.Show(Helper.Util.GetArmorId());
         }
 

--- a/nekoyume/Assets/_Scripts/UI/Widget/Hud/AreaAttackCutscene.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Hud/AreaAttackCutscene.cs
@@ -29,7 +29,7 @@ namespace Nekoyume.UI
         {
             var sprite = SpriteHelper.GetAreaAttackCutsceneSprite(armorId);
 
-            var shader = Shader.Find("Sprites/Default");
+            var shader = Shader.Find("Spine/Skeleton");
             var material = new Material(shader);
 
             var slot       = cutscene.SkeletonAnimation.skeleton.FindSlot(SlotName);


### PR DESCRIPTION
### Description

1. 컷씬 연출을 비활성화합니다.
2. 임시처리로 컷씬 리소스 수정 후 복구시키겠습니다.

### How to test

1. 전투 연출에 문제가 없는지 확인합니다
