### PR TITLE
resolve #4183 - reset consumableClick trigger on set equipment trigger

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Widget/Craft.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Craft.cs
@@ -446,6 +446,7 @@ namespace Nekoyume.UI
             if (Animator.GetBool(FirstClicked))
             {
                 Animator.SetTrigger(EquipmentClick);
+                Animator.ResetTrigger(ConsumableClick);
             }
         }
 


### PR DESCRIPTION
### Description

1. 장비 제작 탭으로 이동시 기존의 애니메이션 트리거 상태를 초기화시킵니다

### How to test

1. 관련 이슈에 상세히 적혀있습니다

https://github.com/planetarium/NineChronicles/issues/4183
