### PR TITLE
fix material count in material navigation popup

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Widget/Popup/MaterialNavigationPopup.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Popup/MaterialNavigationPopup.cs
@@ -139,8 +139,11 @@ namespace Nekoyume.UI
             _callback = callback;
             itemImage.sprite = itemIcon;
             itemNameText.text = itemName;
-            var split = itemCount.Split('.');
-            itemCountText.text = L10nManager.Localize("UI_COUNT_FORMAT", split[0]);
+
+            if (itemCount.Contains(".") && float.TryParse(itemCount, out var floatCount))
+                itemCount = $"{floatCount:0.####}";
+            itemCountText.text = L10nManager.Localize("UI_COUNT_FORMAT", itemCount);
+
             contentText.text = content;
             actionButtonText.text = buttonText;
             infoText.infoText.gameObject.SetActive(infoText.infoText.text != string.Empty);


### PR DESCRIPTION
### Description

재화 popup ui에 소수점이 있는 경우 무시하지 않고 보여줍니다

### How to test

화면 상단의 소지중인 재화 혹은 포인트 UI를 클릭해서 팝업창을 확인합니다

### Related Links

https://github.com/planetarium/NineChronicles/issues/4212