### PR TITLE
add slot update timing

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Module/Item/EquipmentSlot.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/Item/EquipmentSlot.cs
@@ -209,6 +209,11 @@ namespace Nekoyume.UI.Module
                 default:
                     throw new ArgumentOutOfRangeException();
             }
+            var avatarState = States.Instance.CurrentAvatarState;
+            if (avatarState != null)
+            {
+                Set(avatarState.level);
+            }
         }
 
         public void Set(


### PR DESCRIPTION
awake 시점이 달라져서 슬롯 요구래밸 세팅이 되기전 렌더링되버리는 이슈로 확인되었습니다.
요구래밸 세팅직후에 lock 렌더세팅을 한번더해주는것으로 수정하였습니다.