### PR TITLE
use RuneEnhancementResultScreen anyway

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Widget/Rune.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Rune.cs
@@ -269,7 +269,11 @@ namespace Nekoyume.UI
             Animator.Play(HashToMaterialUse);
             ActionManager.Instance.RuneEnhancement(runeId, TryCount.Value);
             LoadingHelper.RuneEnhancement.Value = true;
-            StartCoroutine(CoShowLoadingScreen());
+            if (RuneFrontHelper.TryGetRuneIcon(_selectedRuneItem.Row.Id, out var runeIcon))
+            {
+                var quote = L10nManager.Localize("UI_RUNE_COMBINE_START");
+                Find<RuneCombineResultScreen>().Show(runeIcon, quote);
+            }
         }
 
         private void Set(RuneItem item)
@@ -486,22 +490,6 @@ namespace Nekoyume.UI
                     },
                     _maxTryCount > 0,
                     true);
-            }
-        }
-
-        private IEnumerator CoShowLoadingScreen()
-        {
-            if (RuneFrontHelper.TryGetRuneIcon(_selectedRuneItem.Row.Id, out var runeIcon))
-            {
-                var loadingScreen = Find<CombinationLoadingScreen>();
-                loadingScreen.Show();
-                loadingScreen.SpeechBubbleWithItem.SetRune(runeIcon);
-                loadingScreen.SetCloseAction(null);
-                yield return new WaitForSeconds(.5f);
-
-                var format = L10nManager.Localize("UI_COST_BLOCK");
-                var quote = string.Format(format, 1);
-                loadingScreen.AnimateNPC(CombinationLoadingScreen.SpeechBubbleItemType.Rune, quote);
             }
         }
 

--- a/nekoyume/Assets/_Scripts/UI/Widget/Rune.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Rune.cs
@@ -208,25 +208,12 @@ namespace Nekoyume.UI
 
         public void OnActionRender(IRandom random, FungibleAssetValue fav)
         {
-            if (_selectedRuneItem.Level == 0)
-            {
-                if (!RuneFrontHelper.TryGetRuneIcon(_selectedRuneItem.Row.Id, out var runeIcon))
-                {
-                    return;
-                }
-
-                var quote = L10nManager.Localize("UI_RUNE_COMBINE_START");
-                Find<RuneCombineResultScreen>().Show(runeIcon, quote);
-            }
-            else
-            {
-                Find<RuneEnhancementResultScreen>().Show(
-                    _selectedRuneItem,
-                    States.Instance.GoldBalanceState.Gold,
-                    States.Instance.CrystalBalance,
-                    TryCount.Value,
-                    random);
-            }
+            Find<RuneEnhancementResultScreen>().Show(
+                _selectedRuneItem,
+                States.Instance.GoldBalanceState.Gold,
+                States.Instance.CrystalBalance,
+                TryCount.Value,
+                random);
 
             States.Instance.UpdateRuneSlotState();
             _selectedRuneItem.RuneStone = fav;


### PR DESCRIPTION
### Description

1. resolve #4196 
2. remove usecase of RuneCombineResultScreen when render RuneEnhancement. anyway use RuneEnhancementResultScreen
3. use RuneCombineResultScreen when send RuneEnhancement action.

### Screenshot


https://github.com/planetarium/NineChronicles/assets/48484989/6387e1ce-7469-44d5-aae5-e789bd4062ee


https://github.com/planetarium/NineChronicles/assets/48484989/e7af0c97-ac82-4d00-b41b-bfad880a7923

