### PR TITLE
insert PlayerArenaInfo to first index of between last Rank

### DIFF
--- a/nekoyume/Assets/_Scripts/State/RxProps.Arena.cs
+++ b/nekoyume/Assets/_Scripts/State/RxProps.Arena.cs
@@ -311,9 +311,11 @@ namespace Nekoyume.State
             var playerArenaInfo = arenaInfo.FirstOrDefault(p => p.AvatarAddr == currentAvatarAddr);
             if (playerArenaInfo is null)
             {
-                playerArenaInf.Rank = arenaInfo.Max(r => r.Rank);
+                var maxRank = arenaInfo.Max(r => r.Rank);
+                var firstMaxRankIndex = arenaInfo.FindIndex(info => info.Rank == maxRank);
+                playerArenaInf.Rank = maxRank;
                 playerArenaInfo = playerArenaInf;
-                arenaInfo.Add(playerArenaInfo);
+                arenaInfo.Insert(firstMaxRankIndex, playerArenaInfo);
             }
             else
             {


### PR DESCRIPTION
### Description

1. resolve #3951 
2. insert PlayerArenaInfo to first index of between last Rank

### How to test

1. Enter to arena board with no-arena-play avatar

### Screenshot
![image](https://github.com/planetarium/NineChronicles/assets/48484989/8f8b890f-d784-4eff-b2b3-2079d468a3d6)
