### PR TITLE
add isInWorld check to item of petInventory

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Widget/Popup/CombinationSlotsPopup.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Popup/CombinationSlotsPopup.cs
@@ -2,9 +2,11 @@ using System;
 using System.Collections.Generic;
 using Libplanet;
 using Libplanet.Crypto;
+using Nekoyume.L10n;
 using Nekoyume.Model.Item;
 using Nekoyume.State;
 using Nekoyume.UI.Module;
+using Nekoyume.UI.Scroller;
 using UnityEngine;
 
 namespace Nekoyume.UI
@@ -37,7 +39,13 @@ namespace Nekoyume.UI
                 .Subscribe(_ =>
                 {
                     if (Game.Game.instance.IsInWorld)
+                    {
+                        NotificationSystem.Push(
+                            Nekoyume.Model.Mail.MailType.System,
+                            L10nManager.Localize("UI_BLOCK_EXIT"),
+                            NotificationCell.NotificationType.Alert);
                         return;
+                    }
 
                     Find<DccCollection>().Show();
                     Close(true);

--- a/nekoyume/Assets/_Scripts/UI/Widget/Popup/CombinationSlotsPopup.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Popup/CombinationSlotsPopup.cs
@@ -36,6 +36,9 @@ namespace Nekoyume.UI
             petInventory.OnSelectedSubject
                 .Subscribe(_ =>
                 {
+                    if (Game.Game.instance.IsInWorld)
+                        return;
+
                     Find<DccCollection>().Show();
                     Close(true);
                 })


### PR DESCRIPTION
### Description

전투중에서는 펫 버튼 클릭시 dcc collection으로 이동하지 않도록 막습니다

### How to test

전투중에 제작 슬롯에서 펫 팝업을 활성화시킨 후 펫을 클릭합니다.

### Related Links
https://github.com/planetarium/NineChronicles/issues/4263

