### PR TITLE
Caching enemy cp value

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Widget/ArenaBattlePreparation.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/ArenaBattlePreparation.cs
@@ -74,6 +74,8 @@ namespace Nekoyume.UI
 
         private readonly List<IDisposable> _disposables = new();
 
+        private int? _chooseAvatarCp;
+
         public override bool CanHandleInputEvent =>
             base.CanHandleInputEvent &&
             (startButton.Interactable || !EnoughToPlay);
@@ -137,20 +139,23 @@ namespace Nekoyume.UI
             base.Show(ignoreShowAnimation);
             _roundData = roundData;
             _info = info;
-            enemyCp.text = chooseAvatarCp.ToString();
+
+            _chooseAvatarCp = chooseAvatarCp;
+            enemyCp.text = _chooseAvatarCp.ToString();
             UpdateStartButton();
-            information.UpdateInventory(BattleType.Arena, chooseAvatarCp);
+            information.UpdateInventory(BattleType.Arena, _chooseAvatarCp);
             coverToBlockClick.SetActive(false);
             AgentStateSubject.Crystal.Subscribe(_ => ReadyToBattle()).AddTo(_disposables);
         }
 
         public void UpdateInventory()
         {
-            information.UpdateInventory(BattleType.Arena);
+            information.UpdateInventory(BattleType.Arena, _chooseAvatarCp);
         }
 
         public override void Close(bool ignoreCloseAnimation = false)
         {
+            _chooseAvatarCp = null;
             _disposables.DisposeAllAndClear();
             base.Close(ignoreCloseAnimation);
         }


### PR DESCRIPTION
### Description

1. 아레나에서 선택한 상대의 cp값을 캐싱하여, 뷰가 업데이트 될 때 해당 값이 유지되도록 하였습니다.

### How to test

1. 아레나에서 아무 상대나 선택합니다
2. 탑 메뉴에서 장비 팝업을 실행시켰다 종료합니다
3. 나의 cp정보 색상이 정상적인지 확인합니다 

### Related Links
https://github.com/planetarium/NineChronicles/issues/4275

