### PR TITLE
add on force toggle on event tap method

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Widget/Popup/EventReleaseNotePopup.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Popup/EventReleaseNotePopup.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using Nekoyume.Game.LiveAsset;
-using Nekoyume.State;
 using Nekoyume.UI.Model;
 using Nekoyume.UI.Module;
 using UnityEngine;
@@ -176,7 +175,7 @@ namespace Nekoyume.UI
         public override void Show(bool ignoreShowAnimation = false)
         {
             base.Show(ignoreShowAnimation);
-            _tabGroup.SetToggledOn(eventTabButton);
+            OnForceToggleOnEventTab();
             PlayerPrefs.SetString(LastReadingDayKey, DateTime.Today.ToString(DateTimeFormat));
         }
 
@@ -184,12 +183,15 @@ namespace Nekoyume.UI
         {
             base.Show(ignoreStartAnimation);
             if (!eventTabButton.IsToggledOn)
-            {
-                _tabGroup.SetToggledOn(eventTabButton);
-                _tabGroup.OnToggledOn.OnNext(eventTabButton);
-            }
+                OnForceToggleOnEventTab();
 
             OnClickEventNoticeItem(_eventBannerItems[eventNotice.Description]);
+        }
+
+        private void OnForceToggleOnEventTab()
+        {
+            _tabGroup.SetToggledOn(eventTabButton);
+            _tabGroup.OnToggledOn.OnNext(eventTabButton);
         }
 
         private void OnClickEventNoticeItem(EventBannerItem item)


### PR DESCRIPTION
### Description

강제로 이벤트 탭으로 이동시 UI초기화를 위한 메서드를 추가합니다

### How to test

1. 공지 팝업을 열고 release note tap을 활성화합니다
2. 그 상태로 공지 팝업을 닫습니다
3. 다시 공지 팝업을 활성화 했을 때 이벤트 탭이 제대로 렌더링 되고 있는지 확인합니다 

### Related Links
https://github.com/planetarium/NineChronicles/issues/4296