### PR TITLE
fix acquisition place icon name

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Module/Button/AcquisitionPlaceButton.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/Button/AcquisitionPlaceButton.cs
@@ -87,7 +87,7 @@ namespace Nekoyume.UI.Module
                 case ShortcutHelper.PlaceType.EventDungeonStage:
                 case ShortcutHelper.PlaceType.Craft:
                 case ShortcutHelper.PlaceType.Summon:
-                    iconName = string.Format(IconNameFormat, $"00{(int)model.Type}");
+                    iconName = string.Format(IconNameFormat, $"{(int)model.Type:000}");
                     break;
                 case ShortcutHelper.PlaceType.MobileShop:
                     iconName = string.Format(IconNameFormat, $"00{(int)ShortcutHelper.PlaceType.PCShop}");


### PR DESCRIPTION
### Description

획득처가 소환인 아이템에 아이콘을 적용합니다.

### How to test

아우라같이 '소환' 으로 획득할 수 있는 아이템의 아이콘을 확인합니다

### Related Links

https://github.com/planetarium/NineChronicles/issues/4510

### Screenshot

![image](https://github.com/planetarium/NineChronicles/assets/58686228/882c3f4a-8e3c-4969-9fdf-317379663d74)

