### PR TITLE
change level tap l10n key

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Widget/Collection.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Collection.cs
@@ -476,9 +476,9 @@ namespace Nekoyume.UI
                 case ItemType.Consumable:
                     return L10nManager.Localize("UI_COUNT");
                 case ItemType.Costume:
-                    return L10nManager.Localize("UI_LEVEL");
+                    return L10nManager.Localize("UI_EQUIPMENTLEVEL");
                 case ItemType.Equipment:
-                    return L10nManager.Localize("UI_LEVEL");
+                    return L10nManager.Localize("UI_EQUIPMENTLEVEL");
                 case ItemType.Material:
                     return L10nManager.Localize("UI_COUNT");
                 default:

--- a/nekoyume/Assets/_Scripts/UI/Widget/Collection.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Collection.cs
@@ -476,7 +476,7 @@ namespace Nekoyume.UI
                 case ItemType.Consumable:
                     return L10nManager.Localize("UI_COUNT");
                 case ItemType.Costume:
-                    return L10nManager.Localize("UI_EQUIPMENTLEVEL");
+                    return L10nManager.Localize("UI_COUNT");
                 case ItemType.Equipment:
                     return L10nManager.Localize("UI_EQUIPMENTLEVEL");
                 case ItemType.Material:


### PR DESCRIPTION
### Description

1. 장비 레벨순 정렬에 대한 탭 아이템의 텍스트 키를 변경합니다.

### How to test

1. 컬랙션에서 장비 레벨순 정렬 텍스트를 확인합니다. 

### Related Links

https://github.com/planetarium/NineChronicles/issues/4503

### Screenshot

![image](https://github.com/planetarium/NineChronicles/assets/58686228/f63b010f-9158-4510-a53b-f124f442c5a5)
