### PR TITLE
Issue/4501

### DIFF
--- a/nekoyume/Assets/AddressableAssets/UI/Module/Button/FilterButtonCell.prefab
+++ b/nekoyume/Assets/AddressableAssets/UI/Module/Button/FilterButtonCell.prefab
@@ -104,13 +104,13 @@ MonoBehaviour:
     m_SelectOnDown: {fileID: 0}
     m_SelectOnLeft: {fileID: 0}
     m_SelectOnRight: {fileID: 0}
-  m_Transition: 0
+  m_Transition: 1
   m_Colors:
     m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
-    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_HighlightedColor: {r: 1, g: 1, b: 1, a: 1}
+    m_PressedColor: {r: 1, g: 1, b: 1, a: 1}
     m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_DisabledColor: {r: 0.6509804, g: 0.6509804, b: 0.6509804, a: 1}
     m_ColorMultiplier: 1
     m_FadeDuration: 0.1
   m_SpriteState:
@@ -143,6 +143,14 @@ MonoBehaviour:
   onClickObsoletedToggle:
     m_PersistentCalls:
       m_Calls: []
+  colorTransitionGraphics:
+  - {fileID: 1948950897118125260}
+  - {fileID: 2497503261091017315}
+  - {fileID: 4284816055060628786}
+  - {fileID: 1194009376064283112}
+  - {fileID: 2190381729053741736}
+  - {fileID: 8289959519446652823}
+  - {fileID: 392599885188928398}
 --- !u!114 &5307176768018527626
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1521,7 +1529,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 16
+  m_fontSize: 8
   m_fontSizeBase: 16
   m_fontWeight: 400
   m_enableAutoSizing: 1

--- a/nekoyume/Assets/Editor/ToggleEditor.cs
+++ b/nekoyume/Assets/Editor/ToggleEditor.cs
@@ -14,6 +14,7 @@ namespace Editor
             EditorGUILayout.PropertyField(serializedObject.FindProperty("offObject"));
             EditorGUILayout.PropertyField(serializedObject.FindProperty("onObject"));
             EditorGUILayout.PropertyField(serializedObject.FindProperty("onClickToggle"));
+            EditorGUILayout.PropertyField(serializedObject.FindProperty("colorTransitionGraphics"));
             EditorGUILayout.PropertyField(serializedObject.FindProperty("allowSwitchOffWhenIsOn"));
             EditorGUILayout.PropertyField(serializedObject.FindProperty("obsolete"));
             EditorGUILayout.PropertyField(serializedObject.FindProperty("onClickObsoletedToggle"));

--- a/nekoyume/Assets/_Scripts/UI/Widget/Collection.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Collection.cs
@@ -110,6 +110,19 @@ namespace Nekoyume.UI
 
         private readonly List<CollectionModel> _models = new List<CollectionModel>();
 
+        private ItemType CurrentItemType
+        {
+            get => _currentItemType;
+            set
+            {
+                _currentItemType = value;
+                if (TryFind<CollectionItemFilterPopup>(out var filterPopup))
+                {
+                    filterPopup.SetItemTypeTap(_currentItemType);
+                }
+            }
+        }
+
         private readonly Dictionary<ItemType, Dictionary<StatType, bool>> _filter = new();
         private static readonly StatType[] TabStatTypes =
         {
@@ -156,7 +169,7 @@ namespace Nekoyume.UI
                     .Where(isOn => isOn)
                     .Subscribe(_ =>
                     {
-                        _currentItemType = itemTypeToggle.type;
+                        CurrentItemType = itemTypeToggle.type;
 
                         var toggle = statToggles.First().toggle;
                         toggle.isOn = !toggle.isOn;
@@ -202,6 +215,8 @@ namespace Nekoyume.UI
             var toggle = itemTypeToggles.First().toggle;
             toggle.isOn = !toggle.isOn;
 
+            Find<CollectionItemFilterPopup>().SetItemTypeTap(_currentItemType);
+            RefreshDropDownText();
             UpdateToggleView();
             UpdateStatToggleView();
             UpdateItems();

--- a/nekoyume/Assets/_Scripts/UI/Widget/Popup/ItemFilterPopupBase.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Popup/ItemFilterPopupBase.cs
@@ -306,6 +306,39 @@ namespace Nekoyume.UI
             Close(true);
         }
 
+        /// <summary>
+        /// 현재 선택된 아이템 탭에 따라 적용할 필터 옵션을 활성화/비활성화 시킨다.
+        /// 현재 gradeToggles를 제외한 모든 필터 토글이 Equipment 탭에서만 활성화 된다.
+        /// </summary>
+        /// <param name="itemType">현재 활성화된 아이템 탭</param>
+        public void SetItemTypeTap(Nekoyume.Model.Item.ItemType itemType)
+        {
+            foreach (var elementalToggle in elementalToggles)
+            {
+                elementalToggle.toggle.interactable = itemType == Nekoyume.Model.Item.ItemType.Equipment;
+            }
+
+            foreach (var itemTypeToggle in itemTypeToggles)
+            {
+                itemTypeToggle.toggle.interactable = itemType == Nekoyume.Model.Item.ItemType.Equipment;
+            }
+
+            foreach (var upgradeLevelToggle in upgradeLevelToggles)
+            {
+                upgradeLevelToggle.toggle.interactable = itemType == Nekoyume.Model.Item.ItemType.Equipment;
+            }
+
+            foreach (var optionCountToggle in optionCountToggles)
+            {
+                optionCountToggle.toggle.interactable = itemType == Nekoyume.Model.Item.ItemType.Equipment;
+            }
+
+            foreach (var withSkillToggle in withSkillToggles)
+            {
+                withSkillToggle.toggle.interactable = itemType == Nekoyume.Model.Item.ItemType.Equipment;
+            }
+        }
+
         protected void ApplyItemFilterOptionFromToggle()
         {
             var itemFilterOptionType = new ItemFilterOptions();


### PR DESCRIPTION
### Description

아이템 필터 옵션을 현재 사용하는 탭에서만 변경할 수 있도록 수정합니다.

### How to test

현재 활성화된 탭에서 사용할 수 없는 필터옵션이 비활성화 되어있는지 확인합니다.

### Related Links

https://github.com/planetarium/NineChronicles/issues/4501

### Screenshot

![image](https://github.com/planetarium/NineChronicles/assets/58686228/fd509695-920b-4a1b-ad7d-69013595c16d)

현재 아이템 탭에서 사용할 수 없는 필터 옵션들을 비활성화 처리합니다.

위 스크린샷에서는 현재 Class를 제외한 모든 탭이 비활성화되어있는 상태입니다. 