### PR TITLE
save last stage clear before response and check

### DIFF
--- a/nekoyume/Assets/_Scripts/Game/Stage.cs
+++ b/nekoyume/Assets/_Scripts/Game/Stage.cs
@@ -460,6 +460,10 @@ namespace Nekoyume.Game
             _stageRunningPlayer.Pet.Animator.Play(PetAnimation.Type.BattleStart);
             AudioController.instance.PlayMusic(bgmName);
             IsShowHud = true;
+
+            SelectedPlayer.Model.worldInformation.TryGetLastClearedStageId(out var lastClearedStageIdBeforeResponse);
+            _battleResultModel.LastClearedStageIdBeforeResponse = lastClearedStageIdBeforeResponse;
+
             if (!SelectedPlayer.Model.worldInformation.IsStageCleared(stageId))
             {
                 _tutorialModels = Widget.Find<Tutorial>().TutorialController.GetModelListByStage(stageId);

--- a/nekoyume/Assets/_Scripts/UI/Widget/Popup/BattleResultPopup.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Popup/BattleResultPopup.cs
@@ -56,6 +56,7 @@ namespace Nekoyume.UI
             public bool ActionPointNotEnough;
             public bool IsClear;
             public bool IsEndStage;
+            public int LastClearedStageIdBeforeResponse;
 
             /// <summary>
             /// [0]: The number of times a `BattleLog.clearedWaveNumber` is 0.
@@ -261,7 +262,8 @@ namespace Nekoyume.UI
                 if (SharedModel.IsClear
                     && SharedModel.IsEndStage
                     && lastClearedStageId == SharedModel.StageID
-                    && !Find<WorldMap>().SharedViewModel.UnlockedWorldIds.Contains(SharedModel.WorldID + 1))
+                    && !Find<WorldMap>().SharedViewModel.UnlockedWorldIds.Contains(SharedModel.WorldID + 1)
+                    && SharedModel.StageID - 1 == SharedModel.LastClearedStageIdBeforeResponse)
                 {
                     worldClear = true;
                 }
@@ -418,6 +420,7 @@ namespace Nekoyume.UI
                     ActionPointNotEnough = model.ActionPointNotEnough,
                     IsClear = model.IsClear,
                     IsEndStage = model.IsEndStage,
+                    LastClearedStageIdBeforeResponse = model.LastClearedStageIdBeforeResponse,
                     ClearedCountForEachWaves = ModelForMultiHackAndSlash.ClearedCountForEachWaves,
                 };
                 foreach (var item in ModelForMultiHackAndSlash.Rewards)


### PR DESCRIPTION
결과창이 뜨는 시점에서는 이미 플레이어의 마지막으로 성공한 스테이지의 값이 갱신되어있어서 최초로 월드 마지막을 깬것인지 다시 깬것인지 여부를 확인할수없어서 LastClearedStageIdBeforeResponse 라는 변수를 새로 만들어 수정하였습니다.