### PR TITLE
remove UnityWebRequestTexture.GetTexture function for disable mipmap

### DIFF
--- a/nekoyume/Assets/_Scripts/Game/LiveAsset/LiveAssetManager.cs
+++ b/nekoyume/Assets/_Scripts/Game/LiveAsset/LiveAssetManager.cs
@@ -215,14 +215,14 @@ namespace Nekoyume.Game.LiveAsset
                 LanguageType.Japanese => JapaneseImagePostfix,
                 _ => string.Empty
             };
-            return await GetTexture(
+            return await Helper.Util.DownloadTexture(
                 $"{_endpoint.ImageRootUrl}/{textureType}/{imageName}{postfix}.png");
         }
 
         private async UniTaskVoid InitializeStakingResource()
         {
-            StakingLevelSprite = await GetTexture($"{_endpoint.ImageRootUrl}/{StakingLevelImageUrl}");
-            StakingRewardSprite = await GetTexture($"{_endpoint.ImageRootUrl}/{StakingRewardImageUrl}");
+            StakingLevelSprite = await Helper.Util.DownloadTexture($"{_endpoint.ImageRootUrl}/{StakingLevelImageUrl}");
+            StakingRewardSprite = await Helper.Util.DownloadTexture($"{_endpoint.ImageRootUrl}/{StakingRewardImageUrl}");
             RequestManager.instance
                 .GetJson(StakingArenaBonusUrl, response =>
                 {
@@ -230,23 +230,6 @@ namespace Nekoyume.Game.LiveAsset
                 })
                 .ToUniTask()
                 .Forget();
-        }
-        private async UniTask<Sprite> GetTexture(string url)
-        {
-            var www = UnityWebRequestTexture.GetTexture(url);
-            await www.SendWebRequest();
-
-            if (www.result != UnityWebRequest.Result.Success)
-            {
-                Debug.LogError(www.error);
-                return null;
-            }
-
-            var myTexture = ((DownloadHandlerTexture)www.downloadHandler).texture;
-            return Sprite.Create(
-                myTexture,
-                new Rect(0, 0, myTexture.width, myTexture.height),
-                Pivot);
         }
     }
 }


### PR DESCRIPTION
https://forum.unity.com/threads/unitywebrequesttexture-gettexture-need-mipmaps-option.1514849/
UnityWebRequestTexture.GetTexture 의 경우 자체 mipmap을 생성하여 저해상도 이미지가 나올수있는문제 확인하였습니다.
관련한 추가옵션이 아직 없기 때문에 UnityWebRequestTexture.GetTexture를 사용하지않고 이미지바이너리를 그대로 받아서 사용하는방식으로 수정합니다.

추가로 url로 이미지를 다운받는 부분 모두 캐싱을 사용하도록 구조를 변경합니다.