### PR TITLE
change collection materialinfo active condition

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Module/CollectionMaterialInfo.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/CollectionMaterialInfo.cs
@@ -78,8 +78,9 @@ namespace Nekoyume.UI.Module
             iconArea.gradeAndSubTypeSpacer.color = gradeColor;
 
             iconArea.skillRequiredObject.SetActive(row.SkillContains);
-            iconArea.requiredAmountText.gameObject.SetActive(row.Count > 1 || row.SkillContains);
-            iconArea.currentAmountText.gameObject.SetActive(collectionMaterial.HasItem);
+            var isOnRequiredAmount = row.Count > 1 || row.Level > 0;
+            iconArea.requiredAmountText.gameObject.SetActive(isOnRequiredAmount);
+            iconArea.currentAmountText.gameObject.SetActive(isOnRequiredAmount && collectionMaterial.HasItem);
             var levelRequired = row.Level > 1;
             if (levelRequired)
             {


### PR DESCRIPTION
### Description

컬랙션에서 메터리얼 아이템 상세정보의 텍스트 표시 방법을 변경합니다.

1. 업그레이드가 필요 없는 장비 / 칭호 / 코스튬의 경우 보유수량 / 필요업그레이드에 대한 텍스트가 표시되지 않습니다.
2. 필요 텍스트 표기 조건: 도감을 활성화하기 위한 아이템의 갯수가 2개 이상이거나 필요 강화수치가 1 이상
3. 현재 보유 수량 텍스트 표기 조건: 필요 텍스트 조건이 표시된 상태에서 해당 아이템을 갖고 있는 경우

### How to test

컬랙션에서 아이템 정보를 확인합니다

### Related Links

https://github.com/planetarium/NineChronicles/issues/4485

### Screenshot

![image](https://github.com/planetarium/NineChronicles/assets/58686228/b5c79ad1-03b0-4ed2-8ee7-5bf7cefeed09)
