### PR TITLE
fix market page index unreset

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Shop/BuyView.cs
+++ b/nekoyume/Assets/_Scripts/UI/Shop/BuyView.cs
@@ -392,7 +392,7 @@ namespace Nekoyume
         {
             await SetItems(true);
             UpdateView();
-            base.UpdatePage(0);
+            _page.SetValueAndForceNotify(0);
         }
 
         protected override async void UpdatePage(int page)


### PR DESCRIPTION
_page 값이 초기화되지않아서 해당값을참조하고있는곳에서 이전값을 그대로사용하여 발생했던 문제.