### PR TITLE
init avatar state after avatar created

### DIFF
--- a/nekoyume/Assets/_Scripts/Blockchain/ActionRenderHandler.cs
+++ b/nekoyume/Assets/_Scripts/Blockchain/ActionRenderHandler.cs
@@ -748,6 +748,7 @@ namespace Nekoyume.Blockchain
                     States.Instance.SetRuneStates(TableSheets.Instance.RuneListSheet.Select(pair => new RuneState(pair.Value.Id)));
                     await States.Instance.InitItemSlotStates();
                     await States.Instance.InitRuneSlotStates();
+                    await RxProps.SelectAvatarAsync(eval.Action.index);
                 }).ToObservable()
                 .ObserveOnMainThread()
                 .Subscribe(x =>


### PR DESCRIPTION
### Description

아바타 생성시 룬 인벤토리 상태를 초기화해줍니다.

### How to test

아바타를 새로 생성하고 인벤토리를 확인합니다.

### Related Links

https://github.com/planetarium/NineChronicles/issues/4623

