### PR TITLE
remove redundant avatar init logic

### DIFF
--- a/nekoyume/Assets/_Scripts/Blockchain/ActionRenderHandler.cs
+++ b/nekoyume/Assets/_Scripts/Blockchain/ActionRenderHandler.cs
@@ -743,11 +743,6 @@ namespace Nekoyume.Blockchain
                 {
                     await UpdateAgentStateAsync(eval);
                     await UpdateAvatarState(eval, eval.Action.index);
-                    await States.Instance.SelectAvatarAsync(eval.Action.index);
-                    await States.Instance.InitAvatarBalancesAsync();
-                    States.Instance.SetRuneStates(TableSheets.Instance.RuneListSheet.Select(pair => new RuneState(pair.Value.Id)));
-                    await States.Instance.InitItemSlotStates();
-                    await States.Instance.InitRuneSlotStates();
                     await RxProps.SelectAvatarAsync(eval.Action.index);
                 }).ToObservable()
                 .ObserveOnMainThread()


### PR DESCRIPTION
### Description

아바타 생성시 'await RxProps.SelectAvatarAsync(eval.Action.index);' 를 추가적으로 호출해줌에 따라 불필요하게 두번 초기화되는 것같은 로직들을 정리합니다.

#### 주의사항
- 기존 초기화하는 부분이 다릅니다
- 기본 초기화 로직은 현재스레드(매우 높은 확률로 메인스레드)에서 돌지만, 해당 로직들은 스레드 풀에서 돕니다
- 기존 제거한 로직과 RxProps.SelectAvatarAsync메서드 안에서 실행시켜주는 룬 초기화 방식이 다릅니다.

### How to test

캐릭터를 새로 생성하고 상태에 문제가 없는지 확인합니다.

### Related Links

https://github.com/planetarium/NineChronicles/issues/4623
