### PR TITLE
fix staking menu UI update logic and vfx

### DIFF
--- a/nekoyume/Assets/AddressableAssets/UI/Module/Lobby/StakingBtn.prefab
+++ b/nekoyume/Assets/AddressableAssets/UI/Module/Lobby/StakingBtn.prefab
@@ -2073,8 +2073,7 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 2725475525590947450}
+  m_Children: []
   m_Father: {fileID: 7702144876723794782}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -2870,7 +2869,7 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 3317755364091931427}
+    m_TransformParent: {fileID: 2911564669222515296}
     m_Modifications:
     - target: {fileID: 23246119758516985, guid: 8588ed37f97d0364a8a8b90bf428c3e0,
         type: 3}
@@ -3015,12 +3014,12 @@ PrefabInstance:
     - target: {fileID: 4804230841145495767, guid: 8588ed37f97d0364a8a8b90bf428c3e0,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0.7594365
+      value: -75.54061
       objectReference: {fileID: 0}
     - target: {fileID: 4804230841145495767, guid: 8588ed37f97d0364a8a8b90bf428c3e0,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -1.1151347
+      value: -50.5151
       objectReference: {fileID: 0}
     - target: {fileID: 4804230841145495767, guid: 8588ed37f97d0364a8a8b90bf428c3e0,
         type: 3}
@@ -3064,9 +3063,3 @@ PrefabInstance:
       objectReference: {fileID: 2100000, guid: d37fa2b5ace854514ab5208343258822, type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 8588ed37f97d0364a8a8b90bf428c3e0, type: 3}
---- !u!224 &2725475525590947450 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 4804230841145495767, guid: 8588ed37f97d0364a8a8b90bf428c3e0,
-    type: 3}
-  m_PrefabInstance: {fileID: 7457639873515259565}
-  m_PrefabAsset: {fileID: 0}

--- a/nekoyume/Assets/_Scripts/UI/Module/Lobby/StakingMenu.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/Lobby/StakingMenu.cs
@@ -32,13 +32,6 @@ namespace Nekoyume.UI.Module.Lobby
 
         private readonly List<IDisposable> _disposables = new();
 
-        protected override void Awake()
-        {
-            base.Awake();
-            Game.Game.instance.Agent.BlockIndexSubject.Subscribe(OnEveryUpdateBlockIndex)
-                .AddTo(gameObject);
-        }
-
         private void OnEnable()
         {
             _disposables.DisposeAllAndClear();
@@ -46,8 +39,11 @@ namespace Nekoyume.UI.Module.Lobby
                 .AddTo(_disposables);
             StakingSubject.StakedNCG.Subscribe(OnUpdateStakedBalance)
                 .AddTo(_disposables);
+            Game.Game.instance.Agent.BlockIndexSubject.Subscribe(OnEveryUpdateBlockIndex)
+                .AddTo(_disposables);
             OnUpdateStakingLevel(States.Instance.StakingLevel);
             OnUpdateStakedBalance(States.Instance.StakedBalanceState.Gold);
+            OnEveryUpdateBlockIndex(Game.Game.instance.Agent.BlockIndex);
         }
 
         private void OnDisable()


### PR DESCRIPTION
### Description

1. 인게임 몬스터콜렉션 메뉴의 VFX가 알림이 있을때만 뜨도록 변경했습니다.
2. 블록인덱스를 구독하여 정보를 업데이트하던 부분을 enable 되어있을때만 처리하게 disposable 관리를 추가했고, 매 OnEnable마다 다음 BlockIndexSubject의 OnNext를 기다리지 않고 tip을 가져다가 한번씩 업데이트를 하도록 바꿨습니다.

### Related Links

resolve #4592 , #4615 

### Screenshot
![image](https://github.com/planetarium/NineChronicles/assets/48484989/2a12bd8d-4a13-44a5-bd2e-c310850190e1)
![image](https://github.com/planetarium/NineChronicles/assets/48484989/a308f4be-f1ac-46d5-8d87-6aa75c3a188f)
