### PR TITLE
change ios cicd runner to macos-13

### DIFF
--- a/.github/workflows/ios-build-and-release.yml
+++ b/.github/workflows/ios-build-and-release.yml
@@ -119,7 +119,7 @@ jobs:
 
   build-and-upload:      
     name: Build Archive for iOS and Upload to TestFlight
-    runs-on: macos-latest
+    runs-on: macos-13
     timeout-minutes: 60
     needs: build
     if: startsWith(github.ref, 'refs/heads/release/') || startsWith(github.event.ref, 'refs/tags/')|| github.event.inputs.manual_build_option


### PR DESCRIPTION
### Description

1. change ios cicd runner image to `macos-13`
2. resolve #4393 
3. iOS SDK 버전을 17.* 로 올리기 위해 Xcode 버전을 14.* 이상으로 올려야 합니다. Xcode 버전을 올리기 위해선 macos 버전이 올라가야 합니다. macos 13부터 Xcode 14를 지원하는데, 저희가 사용하던 macos-latest는 macos 12인 상태여서 https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources 를 참고하여 runner image를 변경하였습니다.

### How to test

check it https://github.com/planetarium/NineChronicles/actions/runs/8463902410/job/23188203100#step:6:292 and action