### PR TITLE
fix combination slot null exception

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Module/CombinationSlot.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/CombinationSlot.cs
@@ -241,12 +241,15 @@ namespace Nekoyume.UI.Module
 
                 case SlotType.WaitingReceive:
                     SetContainer(false, false, false, true);
-                    waitingReceiveItemView.SetData(new Item(state.Result.itemUsable));
-                    waitingReceiveText.text = string.Format(
-                        L10nManager.Localize("UI_SENDING_THROUGH_MAIL"),
-                        state.Result.itemUsable.GetLocalizedName(
-                            useElementalIcon: false,
-                            ignoreLevel: true));
+                    if(state != null)
+                    {
+                        waitingReceiveItemView.SetData(new Item(state.Result.itemUsable));
+                        waitingReceiveText.text = string.Format(
+                            L10nManager.Localize("UI_SENDING_THROUGH_MAIL"),
+                            state.Result.itemUsable.GetLocalizedName(
+                                useElementalIcon: false,
+                                ignoreLevel: true));
+                    }
                     break;
             }
         }


### PR DESCRIPTION
fix combination slot null exception
모래시계 사용시 제작슬롯에서 state가 없어서 null exception이나는 부분 처리입니다.
case SlotType.Appraise: 부분에서도 state 관련 null체크가 있어서 동일하게 체크 추가해주었습니다.