### PR TITLE
reflect Hardforking of DailyReward and ActionPoint

### DIFF
--- a/nekoyume/Assets/_Scripts/Blockchain/ActionHandler.cs
+++ b/nekoyume/Assets/_Scripts/Blockchain/ActionHandler.cs
@@ -404,6 +404,13 @@ namespace Nekoyume.Blockchain
             await UpdateAvatarState(avatarState, States.Instance.CurrentAvatarKey);
         }
 
+        protected static long GetActionPoint<T>(ActionEvaluation<T> evaluation, Address avatarAddress) where T : ActionBase
+        {
+            return (Bencodex.Types.Integer)StateGetter.GetState(evaluation.OutputState,
+                Addresses.ActionPoint,
+                avatarAddress);
+        }
+
         internal static void UpdateCombinationSlotState(
             Address avatarAddress,
             int slotIndex,

--- a/nekoyume/Assets/_Scripts/Blockchain/ActionManager.cs
+++ b/nekoyume/Assets/_Scripts/Blockchain/ActionManager.cs
@@ -775,12 +775,6 @@ namespace Nekoyume.Blockchain
 
         public IObservable<ActionEvaluation<DailyReward>> DailyReward()
         {
-            var blockCount = Game.Game.instance.Agent.BlockIndex -
-                States.Instance.CurrentAvatarState.dailyRewardReceivedIndex + 1;
-            LocalLayerModifier.IncreaseAvatarDailyRewardReceivedIndex(
-                States.Instance.CurrentAvatarState.address,
-                blockCount);
-
             var action = new DailyReward
             {
                 avatarAddress = States.Instance.CurrentAvatarState.address,

--- a/nekoyume/Assets/_Scripts/Blockchain/ActionManager.cs
+++ b/nekoyume/Assets/_Scripts/Blockchain/ActionManager.cs
@@ -355,7 +355,6 @@ namespace Nekoyume.Blockchain
             var avatarAddress = avatarState.address;
 
             LocalLayerModifier.ModifyAgentGold(agentAddress, -recipeInfo.CostNCG);
-            LocalLayerModifier.ModifyAvatarActionPoint(agentAddress, -recipeInfo.CostAP);
 
             foreach (var pair in recipeInfo.Materials)
             {
@@ -447,7 +446,6 @@ namespace Nekoyume.Blockchain
             var avatarAddress = avatarState.address;
 
             LocalLayerModifier.ModifyAgentGold(agentAddress, -recipeInfo.CostNCG);
-            LocalLayerModifier.ModifyAvatarActionPoint(agentAddress, -recipeInfo.CostAP);
 
             foreach (var pair in recipeInfo.Materials)
             {
@@ -566,7 +564,6 @@ namespace Nekoyume.Blockchain
                 worldId = worldId,
                 stageId = stageId,
             };
-            LocalLayerModifier.ModifyAvatarActionPoint(avatarAddress, -actionPoint);
             var apStoneRow = Game.Game.instance.TableSheets.MaterialItemSheet.Values.First(r =>
                 r.ItemSubType == ItemSubType.ApStone);
             LocalLayerModifier.RemoveItem(avatarAddress, apStoneRow.ItemId, apStoneCount);
@@ -610,8 +607,6 @@ namespace Nekoyume.Blockchain
                 var row = Game.Game.instance.TableSheets.MaterialItemSheet.Values
                     .First(r => r.ItemSubType == ItemSubType.ApStone);
                 LocalLayerModifier.RemoveItem(avatarAddress, row.ItemId);
-                LocalLayerModifier.ModifyAvatarActionPoint(avatarAddress,
-                    States.Instance.GameConfigState.ActionPointMax);
             }
 
             if (GameConfigStateSubject.ActionPointState.ContainsKey(avatarAddress))
@@ -661,8 +656,6 @@ namespace Nekoyume.Blockchain
                 var row = Game.Game.instance.TableSheets.MaterialItemSheet.Values
                     .First(r => r.ItemSubType == ItemSubType.ApStone);
                 LocalLayerModifier.RemoveItem(avatarAddress, row.ItemId);
-                LocalLayerModifier.ModifyAvatarActionPoint(avatarAddress,
-                    States.Instance.GameConfigState.ActionPointMax);
             }
 
             if (GameConfigStateSubject.ActionPointState.ContainsKey(avatarAddress))
@@ -700,8 +693,6 @@ namespace Nekoyume.Blockchain
                 var row = Game.Game.instance.TableSheets.MaterialItemSheet.Values
                     .First(r => r.ItemSubType == ItemSubType.ApStone);
                 LocalLayerModifier.RemoveItem(avatarAddress, row.ItemId);
-                LocalLayerModifier.ModifyAvatarActionPoint(avatarAddress,
-                    States.Instance.GameConfigState.ActionPointMax);
             }
 
             if (GameConfigStateSubject.ActionPointState.ContainsKey(avatarAddress))
@@ -816,8 +807,6 @@ namespace Nekoyume.Blockchain
             var avatarAddress = States.Instance.CurrentAvatarState.address;
 
             LocalLayerModifier.ModifyAgentGold(agentAddress, -costNCG);
-            LocalLayerModifier.ModifyAvatarActionPoint(avatarAddress, -GameConfig.EnhanceEquipmentCostAP);
-            LocalLayerModifier.ModifyAvatarActionPoint(avatarAddress, -GameConfig.EnhanceEquipmentCostAP);
 
             if (baseEquipment.ItemSubType == ItemSubType.Aura)
             {
@@ -1072,7 +1061,6 @@ namespace Nekoyume.Blockchain
             var avatarAddress = avatarState.address;
 
             LocalLayerModifier.ModifyAgentGold(agentAddress, -recipeInfo.CostNCG);
-            LocalLayerModifier.ModifyAvatarActionPoint(agentAddress, -recipeInfo.CostAP);
             if (useHammerPoint)
             {
                 var recipeId = recipeInfo.RecipeId;
@@ -1265,8 +1253,6 @@ namespace Nekoyume.Blockchain
                     .OrderedList
                     .First(r => r.ItemSubType == ItemSubType.ApStone);
                 LocalLayerModifier.RemoveItem(avatarAddress, row.ItemId);
-                LocalLayerModifier.ModifyAvatarActionPoint(avatarAddress,
-                    States.Instance.GameConfigState.ActionPointMax);
 
                 var address = States.Instance.CurrentAvatarState.address;
                 if (GameConfigStateSubject.ActionPointState.ContainsKey(address))

--- a/nekoyume/Assets/_Scripts/Blockchain/ActionRenderHandler.cs
+++ b/nekoyume/Assets/_Scripts/Blockchain/ActionRenderHandler.cs
@@ -1843,7 +1843,7 @@ namespace Nekoyume.Blockchain
                     L10nManager.Localize("UI_RECEIVED_DAILY_REWARD"),
                     NotificationCell.NotificationType.Notification);
                 var expectedNotifiedTime = BlockIndexExtensions.BlockToTimeSpan(Mathf.RoundToInt(
-                    States.Instance.GameConfigState.DailyRewardInterval));
+                    Action.DailyReward.DailyRewardInterval));
                 var notificationText = L10nManager.Localize("PUSH_PROSPERITY_METER_CONTENT");
                 PushNotifier.Push(
                     notificationText,

--- a/nekoyume/Assets/_Scripts/Blockchain/ActionRenderHandler.cs
+++ b/nekoyume/Assets/_Scripts/Blockchain/ActionRenderHandler.cs
@@ -987,7 +987,6 @@ namespace Nekoyume.Blockchain
             var avatarState = renderArgs.AvatarState;
 
             LocalLayerModifier.ModifyAgentGold(agentAddress, result.gold);
-            LocalLayerModifier.ModifyAvatarActionPoint(avatarAddress, result.actionPoint);
             foreach (var pair in result.materials)
             {
                 LocalLayerModifier.AddItem(avatarAddress, pair.Key.ItemId, pair.Value);
@@ -1124,7 +1123,6 @@ namespace Nekoyume.Blockchain
             var result = (CombinationConsumable5.ResultModel)slot.Result;
 
             LocalLayerModifier.ModifyAgentGold(agentAddress, result.gold);
-            LocalLayerModifier.ModifyAvatarActionPoint(avatarAddress, result.actionPoint);
             foreach (var pair in result.materials)
             {
                 LocalLayerModifier.AddItem(avatarAddress, pair.Key.ItemId, pair.Value);
@@ -1176,7 +1174,6 @@ namespace Nekoyume.Blockchain
             var itemUsable = result.itemUsable;
 
             LocalLayerModifier.ModifyAgentGold(agentAddress, result.gold);
-            LocalLayerModifier.ModifyAvatarActionPoint(avatarAddress, result.actionPoint);
             foreach (var pair in result.materials)
             {
                 LocalLayerModifier.AddItem(avatarAddress, pair.Key.ItemId, pair.Value);
@@ -2024,9 +2021,6 @@ namespace Nekoyume.Blockchain
             if (eval.Action.apStoneCount > 0)
             {
                 var avatarAddress = eval.Action.avatarAddress;
-                LocalLayerModifier.ModifyAvatarActionPoint(
-                    avatarAddress,
-                    eval.Action.actionPoint);
                 var row = TableSheets.Instance.MaterialItemSheet.Values.First(r =>
                     r.ItemSubType == ItemSubType.ApStone);
                 LocalLayerModifier.AddItem(avatarAddress, row.ItemId, eval.Action.apStoneCount);

--- a/nekoyume/Assets/_Scripts/Blockchain/ActionRenderHandler.cs
+++ b/nekoyume/Assets/_Scripts/Blockchain/ActionRenderHandler.cs
@@ -1834,6 +1834,7 @@ namespace Nekoyume.Blockchain
             {
                 // 액션이 정상적으로 실행되면 최대치로 채워지리라 예상, 최적화를 위해 GetState를 하지 않고 Set합니다.
                 ReactiveAvatarState.UpdateActionPoint(Action.DailyReward.ActionPointMax);
+                ReactiveAvatarState.UpdateDailyRewardReceivedIndex(eval.BlockIndex);
                 LocalLayer.Instance.ClearAvatarModifiers<AvatarDailyRewardReceivedIndexModifier>(
                     eval.Action.avatarAddress);
 

--- a/nekoyume/Assets/_Scripts/Blockchain/BlockRenderHandler.cs
+++ b/nekoyume/Assets/_Scripts/Blockchain/BlockRenderHandler.cs
@@ -130,11 +130,12 @@ namespace Nekoyume.Blockchain
                                 $"Given address {currentAvatarState.address} is empty."));
                         }
 
-
-                        var ap = avatarState.actionPoint;
+                        var states = await Task.WhenAll(
+                            agent.GetStateAsync(Addresses.ActionPoint, avatarState.address),
+                            agent.GetStateAsync(Addresses.DailyReward, avatarState.address));
+                        var ap = states[0] is Integer apValue ? (long)apValue : avatarState.actionPoint;
                         ReactiveAvatarState.UpdateActionPoint(ap);
-
-                        var dri = avatarState.dailyRewardReceivedIndex;
+                        var dri = states[1] is Integer driValue ? (long)driValue :  avatarState.dailyRewardReceivedIndex;
                         ReactiveAvatarState.UpdateDailyRewardReceivedIndex(dri);
                         _avatarUpdateRequired = false;
                         return (false, null);

--- a/nekoyume/Assets/_Scripts/Blockchain/BlockRenderHandler.cs
+++ b/nekoyume/Assets/_Scripts/Blockchain/BlockRenderHandler.cs
@@ -135,7 +135,7 @@ namespace Nekoyume.Blockchain
                             agent.GetStateAsync(Addresses.DailyReward, avatarState.address));
                         var ap = states[0] is Integer apValue ? (long)apValue : avatarState.actionPoint;
                         ReactiveAvatarState.UpdateActionPoint(ap);
-                        var dri = states[1] is Integer driValue ? (long)driValue :  avatarState.dailyRewardReceivedIndex;
+                        var dri = states[1] is Integer driValue ? (long)driValue : avatarState.dailyRewardReceivedIndex;
                         ReactiveAvatarState.UpdateDailyRewardReceivedIndex(dri);
                         _avatarUpdateRequired = false;
                         return (false, null);

--- a/nekoyume/Assets/_Scripts/Game/Game.cs
+++ b/nekoyume/Assets/_Scripts/Game/Game.cs
@@ -1292,7 +1292,7 @@ namespace Nekoyume.Game
                     var sw = new Stopwatch();
                     sw.Reset();
                     sw.Start();
-                    await RxProps.SelectAvatarAsync(slotIndex);
+                    await RxProps.SelectAvatarAsync(slotIndex, true);
                     sw.Stop();
                     Debug.Log("[Game] EnterNext()... SelectAvatarAsync() finished in" +
                               $" {sw.ElapsedMilliseconds}ms.(elapsed)");
@@ -1324,7 +1324,7 @@ namespace Nekoyume.Game
                         var sw = new Stopwatch();
                         sw.Reset();
                         sw.Start();
-                        await RxProps.SelectAvatarAsync(slotIndex);
+                        await RxProps.SelectAvatarAsync(slotIndex, true);
                         sw.Stop();
                         Debug.Log("[Game] EnterNext()... SelectAvatarAsync() finished in" +
                                   $" {sw.ElapsedMilliseconds}ms.(elapsed)");

--- a/nekoyume/Assets/_Scripts/Game/Stage.cs
+++ b/nekoyume/Assets/_Scripts/Game/Stage.cs
@@ -556,7 +556,7 @@ namespace Nekoyume.Game
                 objectPool.ReleaseExcept(ReleaseWhiteList);
             }
 
-            _battleResultModel.ActionPoint = avatarState.actionPoint;
+            _battleResultModel.ActionPoint = ReactiveAvatarState.ActionPoint;
             _battleResultModel.State = log.result;
             switch (StageType)
             {
@@ -579,7 +579,7 @@ namespace Nekoyume.Game
                         .TryGetValue(stageId, out var stageRow))
                     {
                         _battleResultModel.ActionPointNotEnough =
-                            avatarState.actionPoint < stageRow.CostAP;
+                            ReactiveAvatarState.ActionPoint < stageRow.CostAP;
                     }
 
                     break;

--- a/nekoyume/Assets/_Scripts/State/LocalLayerModifier.cs
+++ b/nekoyume/Assets/_Scripts/State/LocalLayerModifier.cs
@@ -472,66 +472,6 @@ namespace Nekoyume.State
             ReactiveAvatarState.UpdateInventory(outAvatarState.inventory);
         }
 
-        /// <summary>
-        /// Change the daily reward acquisition block index of the avatar.
-        /// </summary>
-        /// <param name="avatarAddress"></param>
-        /// <param name="blockCount"></param>
-        public static void IncreaseAvatarDailyRewardReceivedIndex(Address avatarAddress, long blockCount)
-        {
-            var modifier = new AvatarDailyRewardReceivedIndexModifier(blockCount);
-            LocalLayer.Instance.Add(avatarAddress, modifier);
-
-            if (!TryGetLoadedAvatarState(
-                avatarAddress,
-                out var outAvatarState,
-                out _,
-                out var isCurrentAvatarState)
-            )
-            {
-                return;
-            }
-
-            if (!isCurrentAvatarState)
-            {
-                return;
-            }
-
-            outAvatarState = modifier.Modify(outAvatarState);
-            ReactiveAvatarState.UpdateDailyRewardReceivedIndex(
-                outAvatarState.dailyRewardReceivedIndex);
-        }
-
-        public static void ModifyAvatarItemRequiredIndex(
-            Address avatarAddress,
-            Guid tradableId,
-            long blockIndex
-        )
-        {
-            var modifier = new AvatarItemRequiredIndexModifier(blockIndex, tradableId);
-            LocalLayer.Instance.Add(avatarAddress, modifier);
-
-            if (!TryGetLoadedAvatarState(
-                avatarAddress,
-                out var outAvatarState,
-                out _,
-                out var isCurrentAvatarState)
-            )
-            {
-                return;
-            }
-
-            outAvatarState = modifier.Modify(outAvatarState);
-
-            if (!isCurrentAvatarState)
-            {
-                return;
-            }
-
-            ReactiveAvatarState.UpdateDailyRewardReceivedIndex(
-                outAvatarState.dailyRewardReceivedIndex);
-        }
-
         public static void AddWorld(Address avatarAddress, int worldId)
         {
             var modifier = new AvatarWorldInformationAddWorldModifier(worldId);

--- a/nekoyume/Assets/_Scripts/State/LocalLayerModifier.cs
+++ b/nekoyume/Assets/_Scripts/State/LocalLayerModifier.cs
@@ -79,40 +79,6 @@ namespace Nekoyume.State
             States.Instance.SetCrystalBalance(crystalBalance);
         }
 
-        /// <summary>
-        /// Modify the avatar's action point.
-        /// </summary>
-        /// <param name="avatarAddress"></param>
-        /// <param name="actionPoint"></param>
-        public static void ModifyAvatarActionPoint(Address avatarAddress, int actionPoint)
-        {
-            if (actionPoint is 0)
-            {
-                return;
-            }
-
-            var modifier = new AvatarActionPointModifier(actionPoint);
-            LocalLayer.Instance.Add(avatarAddress, modifier);
-
-            if (!TryGetLoadedAvatarState(
-                avatarAddress,
-                out var outAvatarState,
-                out _,
-                out var isCurrentAvatarState)
-            )
-            {
-                return;
-            }
-
-            if (!isCurrentAvatarState)
-            {
-                return;
-            }
-
-            outAvatarState = modifier.Modify(outAvatarState);
-            ReactiveAvatarState.UpdateActionPoint(outAvatarState.actionPoint);
-        }
-
         #endregion
 
         #region Avatar / AddItem

--- a/nekoyume/Assets/_Scripts/State/ReactiveAvatarState.cs
+++ b/nekoyume/Assets/_Scripts/State/ReactiveAvatarState.cs
@@ -65,7 +65,6 @@ namespace Nekoyume.State
             _inventory.SetValueAndForceNotify(state.inventory);
             _mailBox.SetValueAndForceNotify(state.mailBox);
             _worldInformation.SetValueAndForceNotify(state.worldInformation);
-            _dailyRewardReceivedIndex.SetValueAndForceNotify(state.dailyRewardReceivedIndex);
             _questList.SetValueAndForceNotify(state.questList);
         }
 

--- a/nekoyume/Assets/_Scripts/State/ReactiveAvatarState.cs
+++ b/nekoyume/Assets/_Scripts/State/ReactiveAvatarState.cs
@@ -36,15 +36,15 @@ namespace Nekoyume.State
         public static IObservable<WorldInformation> WorldInformation
             => _worldInformation.ObserveOnMainThread();
 
-        private static readonly ReactiveProperty<int> _actionPoint
-            = new ReactiveProperty<int>();
+        private static readonly ReactiveProperty<long> _actionPoint = new();
 
-        public static IObservable<int> ActionPoint => _actionPoint.ObserveOnMainThread();
+        public static long ActionPoint => _actionPoint.Value;
+        public static IObservable<long> ObservableActionPoint => _actionPoint.ObserveOnMainThread();
 
-        private static readonly ReactiveProperty<long> _dailyRewardReceivedIndex
-            = new ReactiveProperty<long>();
+        private static readonly ReactiveProperty<long> _dailyRewardReceivedIndex = new();
 
-        public static IObservable<long> DailyRewardReceivedIndex
+        public static long DailyRewardReceivedIndex => _dailyRewardReceivedIndex.Value;
+        public static IObservable<long> ObservableDailyRewardReceivedIndex
             => _dailyRewardReceivedIndex.ObserveOnMainThread();
 
         private static readonly ReactiveProperty<QuestList> _questList
@@ -65,12 +65,11 @@ namespace Nekoyume.State
             _inventory.SetValueAndForceNotify(state.inventory);
             _mailBox.SetValueAndForceNotify(state.mailBox);
             _worldInformation.SetValueAndForceNotify(state.worldInformation);
-            _actionPoint.SetValueAndForceNotify(state.actionPoint);
             _dailyRewardReceivedIndex.SetValueAndForceNotify(state.dailyRewardReceivedIndex);
             _questList.SetValueAndForceNotify(state.questList);
         }
 
-        public static void UpdateActionPoint(int actionPoint)
+        public static void UpdateActionPoint(long actionPoint)
         {
             _actionPoint.SetValueAndForceNotify(actionPoint);
         }

--- a/nekoyume/Assets/_Scripts/State/Subjects/HammerPointStatesSubject.cs
+++ b/nekoyume/Assets/_Scripts/State/Subjects/HammerPointStatesSubject.cs
@@ -8,7 +8,7 @@ namespace Nekoyume.State.Subjects
     {
         private static readonly Subject<(int, HammerPointState)> _hammerPointSubject;
 
-        public static IObservable<(int, HammerPointState)> HammerPointSubject;
+        public static readonly IObservable<(int, HammerPointState)> HammerPointSubject;
 
         static HammerPointStatesSubject()
         {

--- a/nekoyume/Assets/_Scripts/UI/Combination/SubRecipeView.cs
+++ b/nekoyume/Assets/_Scripts/UI/Combination/SubRecipeView.cs
@@ -768,7 +768,7 @@ namespace Nekoyume.UI
                 return false;
             }
 
-            if (States.Instance.CurrentAvatarState.actionPoint < _selectedRecipeInfo.CostAP)
+            if (ReactiveAvatarState.ActionPoint < _selectedRecipeInfo.CostAP)
             {
                 errorMessage = L10nManager.Localize("ERROR_ACTION_POINT");
                 return false;

--- a/nekoyume/Assets/_Scripts/UI/Module/AvatarInformation.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/AvatarInformation.cs
@@ -853,7 +853,7 @@ namespace Nekoyume.UI.Module
                         submitText = L10nManager.Localize("UI_CHARGE_AP");
                         interactable = ActionPoint.IsInteractableMaterial();
 
-                        if (States.Instance.CurrentAvatarState.actionPoint > 0)
+                        if (ReactiveAvatarState.ActionPoint > 0)
                         {
                             submit = () => ActionPoint.ShowRefillConfirmPopup(
                                 () => Game.Game.instance.ActionManager.ChargeActionPoint().Subscribe()

--- a/nekoyume/Assets/_Scripts/UI/Module/Button/ConditionalCostButton.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/Button/ConditionalCostButton.cs
@@ -165,7 +165,7 @@ namespace Nekoyume.UI.Module
                 case CostType.Crystal:
                     return States.Instance.CrystalBalance.MajorUnit >= cost;
                 case CostType.ActionPoint:
-                    return States.Instance.CurrentAvatarState.actionPoint >= cost;
+                    return ReactiveAvatarState.ActionPoint >= cost;
                 case CostType.Hourglass:
                     var inventory = States.Instance.CurrentAvatarState.inventory;
                     var count = Util.GetHourglassCount(inventory, Game.Game.instance.Agent.BlockIndex);

--- a/nekoyume/Assets/_Scripts/UI/Module/Button/SimpleCostButton.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/Button/SimpleCostButton.cs
@@ -96,7 +96,7 @@ namespace Nekoyume.UI.Module
                 case CostType.Crystal:
                     return States.Instance.CrystalBalance.MajorUnit >= cost;
                 case CostType.ActionPoint:
-                    return States.Instance.CurrentAvatarState.actionPoint >= cost;
+                    return ReactiveAvatarState.ActionPoint >= cost;
                 case CostType.Hourglass:
                     inventory = States.Instance.CurrentAvatarState.inventory;
                     var count = Util.GetHourglassCount(inventory, Game.Game.instance.Agent.BlockIndex);

--- a/nekoyume/Assets/_Scripts/UI/Module/Currency/ActionPoint.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/Currency/ActionPoint.cs
@@ -143,15 +143,9 @@ namespace Nekoyume.UI.Module
             else
             {
                 var address = States.Instance.CurrentAvatarState.address;
-                if (GameConfigStateSubject.ActionPointState.ContainsKey(address))
-                {
-                    var value = GameConfigStateSubject.ActionPointState[address];
-                    Charger(value);
-                }
-                else
-                {
-                    Charger(false);
-                }
+                Charger(
+                    GameConfigStateSubject.ActionPointState.TryGetValue(address, out var value) &&
+                    value);
             }
         }
 

--- a/nekoyume/Assets/_Scripts/UI/Module/Currency/ActionPoint.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/Currency/ActionPoint.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using Nekoyume.Action;
 using Nekoyume.L10n;
 using Nekoyume.Model.Item;
 using Nekoyume.Model.Mail;
@@ -117,9 +118,9 @@ namespace Nekoyume.UI.Module
             var avatarState = States.Instance.CurrentAvatarState;
             if (avatarState is not null)
             {
-                SetActionPoint(avatarState.actionPoint, false);
+                SetActionPoint(ReactiveAvatarState.ActionPoint, false);
                 SetBlockIndex(Game.Game.instance.Agent.BlockIndex, false);
-                SetRewardReceivedBlockIndex(avatarState.dailyRewardReceivedIndex, false);
+                SetRewardReceivedBlockIndex(ReactiveAvatarState.DailyRewardReceivedIndex, false);
             }
 
             ReactiveAvatarState.ObservableActionPoint
@@ -310,8 +311,8 @@ namespace Nekoyume.UI.Module
                 return false;
             }
 
-            if (States.Instance.CurrentAvatarState.actionPoint ==
-                States.Instance.GameConfigState.ActionPointMax) // full?
+            // if full?
+            if (ReactiveAvatarState.ActionPoint == DailyReward.ActionPointMax)
             {
                 return false;
             }

--- a/nekoyume/Assets/_Scripts/UI/Module/Currency/ActionPoint.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/Currency/ActionPoint.cs
@@ -78,16 +78,9 @@ namespace Nekoyume.UI.Module
                 .AddTo(gameObject);
 
             sliderAnimator.SetValue(0f, false);
+            sliderAnimator.SetMaxValue(DailyReward.ActionPointMax);
             dailyBonus.sliderAnimator.SetValue(0f, false);
-
-            GameConfigStateSubject.GameConfigState
-                .ObserveOnMainThread()
-                .Subscribe(state =>
-                {
-                    sliderAnimator.SetMaxValue(state.ActionPointMax);
-                    dailyBonus.sliderAnimator.SetMaxValue(state.DailyRewardInterval);
-                })
-                .AddTo(gameObject);
+            dailyBonus.sliderAnimator.SetMaxValue(DailyReward.DailyRewardInterval);
 
             GameConfigStateSubject.ActionPointState.ObserveAdd()
                 .Where(x => x.Key == States.Instance.CurrentAvatarState.address)
@@ -105,15 +98,8 @@ namespace Nekoyume.UI.Module
         {
             base.OnEnable();
 
-            if (!syncWithAvatarState)
-                return;
-
-            var gameConfig = States.Instance.GameConfigState;
-            if (gameConfig is not null)
-            {
-                sliderAnimator.SetMaxValue(gameConfig.ActionPointMax);
-                dailyBonus.sliderAnimator.SetMaxValue(gameConfig.DailyRewardInterval);
-            }
+            sliderAnimator.SetMaxValue(DailyReward.ActionPointMax);
+            dailyBonus.sliderAnimator.SetMaxValue(DailyReward.DailyRewardInterval);
 
             var avatarState = States.Instance.CurrentAvatarState;
             if (avatarState is not null)
@@ -194,10 +180,9 @@ namespace Nekoyume.UI.Module
 
         private void UpdateDailyBonusSlider(bool useAnimation)
         {
-            var gameConfigState = States.Instance.GameConfigState;
             var endValue = Math.Max(0, _currentBlockIndex - _rewardReceivedBlockIndex);
-            var value = Math.Min(gameConfigState.DailyRewardInterval, endValue);
-            var remainBlock = gameConfigState.DailyRewardInterval - value;
+            var value = Math.Min(DailyReward.DailyRewardInterval, endValue);
+            var remainBlock = DailyReward.DailyRewardInterval - value;
 
             dailyBonus.sliderAnimator.SetValue(value, useAnimation);
             var timeSpanString =
@@ -215,11 +200,6 @@ namespace Nekoyume.UI.Module
         private void OnDailyBonusSliderChange()
         {
             animator.SetBool(IsFull, dailyBonus.sliderAnimator.IsFull);
-        }
-
-        public void SetActionPoint(long actionPoint)
-        {
-            SetActionPoint(actionPoint, false);
         }
 
         public void SetEventTriggerEnabled(bool value)

--- a/nekoyume/Assets/_Scripts/UI/Module/Currency/ActionPoint.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/Currency/ActionPoint.cs
@@ -52,7 +52,7 @@ namespace Nekoyume.UI.Module
         private Button button;
 
         private readonly List<IDisposable> _disposables = new List<IDisposable>();
-        private int _currentActionPoint;
+        private long _currentActionPoint;
         private long _currentBlockIndex;
         private long _rewardReceivedBlockIndex;
 
@@ -122,13 +122,13 @@ namespace Nekoyume.UI.Module
                 SetRewardReceivedBlockIndex(avatarState.dailyRewardReceivedIndex, false);
             }
 
-            ReactiveAvatarState.ActionPoint
+            ReactiveAvatarState.ObservableActionPoint
                 .Subscribe(x => SetActionPoint(x, true))
                 .AddTo(_disposables);
             Game.Game.instance.Agent.BlockIndexSubject.ObserveOnMainThread()
                 .Subscribe(x => SetBlockIndex(x, true))
                 .AddTo(_disposables);
-            ReactiveAvatarState.DailyRewardReceivedIndex
+            ReactiveAvatarState.ObservableDailyRewardReceivedIndex
                 .Subscribe(x => SetRewardReceivedBlockIndex(x, true))
                 .AddTo(_disposables);
 
@@ -164,7 +164,7 @@ namespace Nekoyume.UI.Module
 
         #endregion
 
-        private void SetActionPoint(int actionPoint, bool useAnimation)
+        private void SetActionPoint(long actionPoint, bool useAnimation)
         {
             if (_currentActionPoint == actionPoint)
             {
@@ -222,7 +222,7 @@ namespace Nekoyume.UI.Module
             animator.SetBool(IsFull, dailyBonus.sliderAnimator.IsFull);
         }
 
-        public void SetActionPoint(int actionPoint)
+        public void SetActionPoint(long actionPoint)
         {
             SetActionPoint(actionPoint, false);
         }

--- a/nekoyume/Assets/_Scripts/UI/Module/Currency/DailyBonus.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/Currency/DailyBonus.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using JetBrains.Annotations;
+using Nekoyume.Action;
 using Nekoyume.Game.Controller;
 using Nekoyume.Game.VFX;
 using Nekoyume.L10n;
@@ -64,22 +65,18 @@ namespace Nekoyume.UI.Module
                 .Subscribe(_ => OnSliderChange())
                 .AddTo(gameObject);
             sliderAnimator.SetValue(0f, false);
-
-            GameConfigStateSubject.GameConfigState
-                .ObserveOnMainThread()
-                .Subscribe(state => sliderAnimator.SetMaxValue(state.DailyRewardInterval))
-                .AddTo(gameObject);
+            sliderAnimator.SetMaxValue(DailyReward.DailyRewardInterval);
         }
 
         protected override void OnEnable()
         {
             base.OnEnable();
 
-            sliderAnimator.SetMaxValue(States.Instance.GameConfigState?.DailyRewardInterval ?? 0f);
+            sliderAnimator.SetMaxValue(DailyReward.DailyRewardInterval);
             if (States.Instance.CurrentAvatarState is not null)
             {
                 SetBlockIndex(Game.Game.instance.Agent.BlockIndex, false);
-                SetRewardReceivedBlockIndex(States.Instance.CurrentAvatarState.dailyRewardReceivedIndex, false);
+                SetRewardReceivedBlockIndex(ReactiveAvatarState.DailyRewardReceivedIndex, false);
             }
 
             Game.Game.instance.Agent.BlockIndexSubject.ObserveOnMainThread()
@@ -125,10 +122,9 @@ namespace Nekoyume.UI.Module
 
         private void UpdateSlider(bool useAnimation)
         {
-            var gameConfigState = States.Instance.GameConfigState;
             var endValue = Math.Max(0, _currentBlockIndex - _rewardReceivedBlockIndex);
-            var value = Math.Min(gameConfigState.DailyRewardInterval, endValue);
-            var remainBlock = gameConfigState.DailyRewardInterval - value;
+            var value = Math.Min(DailyReward.DailyRewardInterval, endValue);
+            var remainBlock = DailyReward.DailyRewardInterval - value;
 
             sliderAnimator.SetValue(value, useAnimation);
             timeSpanText.text =

--- a/nekoyume/Assets/_Scripts/UI/Module/Currency/DailyBonus.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/Currency/DailyBonus.cs
@@ -85,7 +85,7 @@ namespace Nekoyume.UI.Module
             Game.Game.instance.Agent.BlockIndexSubject.ObserveOnMainThread()
                 .Subscribe(x => SetBlockIndex(x, true))
                 .AddTo(_disposables);
-            ReactiveAvatarState.DailyRewardReceivedIndex
+            ReactiveAvatarState.ObservableDailyRewardReceivedIndex
                 .Subscribe(x => SetRewardReceivedBlockIndex(x, true))
                 .AddTo(_disposables);
 

--- a/nekoyume/Assets/_Scripts/UI/Module/Currency/DailyBonus.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/Currency/DailyBonus.cs
@@ -147,7 +147,7 @@ namespace Nekoyume.UI.Module
                 additiveImage.enabled = _isFull;
             }
 
-            hasNotificationImage.enabled = _isFull && States.Instance.CurrentAvatarState?.actionPoint == 0;
+            hasNotificationImage.enabled = _isFull && ReactiveAvatarState.ActionPoint == 0;
 
             animator.SetBool(IsFull, _isFull);
         }
@@ -178,7 +178,7 @@ namespace Nekoyume.UI.Module
                     L10nManager.Localize("UI_CHARGING_AP"),
                     NotificationCell.NotificationType.Information);
             }
-            else if (States.Instance.CurrentAvatarState.actionPoint > 0)
+            else if (ReactiveAvatarState.ActionPoint > 0)
             {
                 var confirm = Widget.Find<ConfirmPopup>();
                 confirm.Show("UI_CONFIRM", "UI_AP_REFILL_CONFIRM_CONTENT");

--- a/nekoyume/Assets/_Scripts/UI/Module/GrindModule.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/GrindModule.cs
@@ -215,7 +215,7 @@ namespace Nekoyume.UI.Module
 
         private void Subscribe()
         {
-            ReactiveAvatarState.ActionPoint
+            ReactiveAvatarState.ObservableActionPoint
                 .Subscribe(_ => grindButton.Interactable = CanGrind)
                 .AddTo(_disposables);
 

--- a/nekoyume/Assets/_Scripts/UI/Widget/BattlePreparation.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/BattlePreparation.cs
@@ -119,7 +119,7 @@ namespace Nekoyume.UI
             StageType.EventDungeon =>
                 RxProps.EventDungeonTicketProgress.Value.currentTickets >= _requiredCost,
             _ =>
-                States.Instance.CurrentAvatarState.actionPoint >= _requiredCost,
+                ReactiveAvatarState.ActionPoint >= _requiredCost,
         };
 
         private bool IsFirstStage => _stageType switch

--- a/nekoyume/Assets/_Scripts/UI/Widget/BattlePreparation.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/BattlePreparation.cs
@@ -224,7 +224,7 @@ namespace Nekoyume.UI
             {
                 case StageType.HackAndSlash:
                 case StageType.Mimisbrunnr:
-                    ReactiveAvatarState.ActionPoint
+                    ReactiveAvatarState.ObservableActionPoint
                         .Subscribe(_ => UpdateStartButton())
                         .AddTo(_disposables);
                     break;

--- a/nekoyume/Assets/_Scripts/UI/Widget/Enhancement.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Enhancement.cs
@@ -303,7 +303,7 @@ namespace Nekoyume.UI
                 return false;
             }
 
-            if (States.Instance.CurrentAvatarState.actionPoint < GameConfig.EnhanceEquipmentCostAP)
+            if (ReactiveAvatarState.ActionPoint < GameConfig.EnhanceEquipmentCostAP)
             {
                 _errorMessage = L10nManager.Localize("NOTIFICATION_NOT_ENOUGH_ACTION_POWER");
                 return false;

--- a/nekoyume/Assets/_Scripts/UI/Widget/Menu.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Menu.cs
@@ -167,7 +167,7 @@ namespace Nekoyume.UI
             }
 
             var requiredCost = stageRow.CostAP;
-            if (States.Instance.CurrentAvatarState.actionPoint < requiredCost)
+            if (ReactiveAvatarState.ActionPoint < requiredCost)
             {
                 OneLineSystem.Push(
                     MailType.System,

--- a/nekoyume/Assets/_Scripts/UI/Widget/Popup/BattleResultPopup.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Popup/BattleResultPopup.cs
@@ -51,7 +51,7 @@ namespace Nekoyume.UI
             public int WorldID;
             public int StageID;
             public int ClearedWaveNumber;
-            public int ActionPoint;
+            public long ActionPoint;
             public int LastClearedStageId;
             public bool ActionPointNotEnough;
             public bool IsClear;

--- a/nekoyume/Assets/_Scripts/UI/Widget/Popup/BattleResultPopup.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Popup/BattleResultPopup.cs
@@ -438,7 +438,6 @@ namespace Nekoyume.UI
                 true);
             worldStageId.text = $"{SharedModel.WorldName}" +
                                 $" {stageText}";
-            actionPoint.SetActionPoint(model.ActionPoint);
             actionPoint.SetEventTriggerEnabled(true);
 
             base.Show();

--- a/nekoyume/Assets/_Scripts/UI/Widget/Popup/BoosterPopup.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Popup/BoosterPopup.cs
@@ -82,7 +82,7 @@ namespace Nekoyume.UI
             _worldId = worldId;
             _stageId = stageId;
 
-            ObservableExtensions.Subscribe(ReactiveAvatarState.ActionPoint, value =>
+            ObservableExtensions.Subscribe(ReactiveAvatarState.ObservableActionPoint, value =>
             {
                 var costOfStage = GetCostOfStage();
                 apSlider.maxValue = value / costOfStage >= maxCount ? maxCount : value / costOfStage;

--- a/nekoyume/Assets/_Scripts/UI/Widget/Popup/BoosterPopup.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Popup/BoosterPopup.cs
@@ -97,7 +97,7 @@ namespace Nekoyume.UI
             });
 
             var cost = GetCostOfStage();
-            var actionPoint = Game.Game.instance.States.CurrentAvatarState.actionPoint;
+            var actionPoint = ReactiveAvatarState.ActionPoint;
             ownAPText.text = actionPoint.ToString();
             // Call onValueChanged by Change value
             apSlider.value = 0;

--- a/nekoyume/Assets/_Scripts/UI/Widget/Popup/MaterialNavigationPopup.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Popup/MaterialNavigationPopup.cs
@@ -118,7 +118,7 @@ namespace Nekoyume.UI
 
         private static void InvokeAfterActionPointCheck(System.Action action)
         {
-            if (States.Instance.CurrentAvatarState.actionPoint > 0)
+            if (ReactiveAvatarState.ActionPoint > 0)
             {
                 ActionPoint.ShowRefillConfirmPopup(action);
             }

--- a/nekoyume/Assets/_Scripts/UI/Widget/Popup/SweepPopup.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Popup/SweepPopup.cs
@@ -157,7 +157,7 @@ namespace Nekoyume.UI
             _worldId = worldId;
             _stageRow = stageRow;
             _apStoneCount.SetValueAndForceNotify(0);
-            _ap.SetValueAndForceNotify(States.Instance.CurrentAvatarState.actionPoint);
+            _ap.SetValueAndForceNotify((int)ReactiveAvatarState.ActionPoint);
             _cp.SetValueAndForceNotify(Util.TotalCP(BattleType.Adventure));
             _repeatBattleAction = repeatBattleAction;
             var disableRepeat = States.Instance.CurrentAvatarState.worldInformation.IsStageCleared(stageId);
@@ -205,7 +205,7 @@ namespace Nekoyume.UI
                     materialSheet.Values.First(r => r.ItemSubType == ItemSubType.ApStone).Id,
                     Game.Game.instance.Agent?.BlockIndex ?? -1);
 
-                var haveApCount = States.Instance.CurrentAvatarState.actionPoint;
+                var haveApCount = ReactiveAvatarState.ActionPoint;
                 haveApText.text = haveApCount.ToString();
                 haveApStoneText.text = haveApStoneCount.ToString();
 
@@ -214,8 +214,8 @@ namespace Nekoyume.UI
                         _stageRow.CostAP, 1, States.Instance.StakingLevel)
                     : _stageRow.CostAP;
                 apSlider.Set(0,
-                    haveApCount / _costAp,
-                    haveApCount / _costAp,
+                    (int)(haveApCount / _costAp),
+                    (int)haveApCount / _costAp,
                     States.Instance.GameConfigState.ActionPointMax,
                     _costAp,
                     x => _ap.Value = x * _costAp);


### PR DESCRIPTION
### Description

1. resolve #4656 
2. https://github.com/planetarium/lib9c/pull/2502 의 내용을 클라이언트에 반영하는 PR입니다.
3. 하드포크로 인해 더 이상 `AvatarState.actionPoint`와 `AvatarState.dailyRewardReceivedIndex`를 사용하지 않습니다. 이를 클라이언트에서 반영하고, 액션 렌더에서 갱신할 수 있도록 수정했습니다.
4. 앞으로는 현재 아바타의 ActionPoint를 클라이언트에서 알고싶거나 관리하고 싶다면 `ReactiveAvatarState.ActionPoint`와 `ReactiveAvatarState.ObservableActionPoint`를 사용하면 됩니다. 기존에 `States.Instance.CurrentAvatarState.actionPoint` 를 통해 접근하던 코드는 모두 변경했습니다.
5. dailyRewardReceivedIndex 또한 `ReactiveAvatarState.DailyRewardReceivedBlockIndex`와 `ReactiveAvatarState.ObservableDailyRewardReceivedBlockIndex`을 통해 관리되도록 수정했습니다.
6. ChargeAp와 DailyReward는 예외 없이 실행될 경우 무조건 `DailyReward.ActionPointMax`로 값이 갱신되는 것을 알기에, GetState 없이 Update하도록 변경했습니다. 더 이상 DailyReward의 action render에서 AvatarState를 갱신하지 않습니다.
7. 기존에 AP를 사용하던 액션 렌더에서는 별개로 ActionPoint를 GetState로 갱신하도록 하였습니다.
8. States 코드가 너무 복잡해서 어디에 뭘 넣어야 상태가 갱신되는지 잘 모르겠어서 리팩토링을 조금 했습니다.

*동작 확인 후, lib9c의 작업 브랜치가 development에 머지된 뒤 범프하고나서 머지해야합니다.
**이번 변경이 기존 동작에 아무런 차이도 주지 않아야 합니다.

### How to test

- [x] Grinding 할때 AP가 잘 갱신되는지 확인한다
- [x] HAS를 돌리면 AP가 잘 갱신되는지 확인한다
- [x] Sweep을 돌리면 AP가 잘 갱신되는지 확인한다
- [x] AP포션을 사용하면 AP가 잘 갱신되는지 확인한다
- [x] DailyReward를 하면 AP와 ReceivedDailyRewardIndex가 잘 갱신되는지 확인한다
- [x] RegisterProduct를 할 때 AP가 잘 갱신되는지 확인한다
- [x] ReRegisterProduct를 할 때 AP가 잘 갱신되는지 확인한다
- [x] CancelProductRegistration을 할 때 AP가 잘 갱신되는지 확인한다
- [x] 다른 캐릭터로 바꾸면 해당 캐릭터의 AP와 ReceivedDailyRewardIndex로 잘 변경되는지 확인한다
- [ ] 마이그레이션이 안된 아바타가 정상적으로 액션 실행 후 새 상태로 마이그레이션되는지 확인한다
