### PR TITLE
fix bug about HAS simulate and CrystalRandomSkill

### DIFF
--- a/nekoyume/Assets/_Scripts/Blockchain/ActionHandler.cs
+++ b/nekoyume/Assets/_Scripts/Blockchain/ActionHandler.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Security.Cryptography;
 using Cysharp.Threading.Tasks;
 using Lib9c.Renderers;
 using Libplanet.Action.State;
+using Libplanet.Common;
 using Libplanet.Crypto;
 using Libplanet.Types.Assets;
 using LruCacheNet;
@@ -141,13 +143,13 @@ namespace Nekoyume.Blockchain
             }
         }
 
-        protected static CrystalRandomSkillState GetCrystalRandomSkillState<T>(
-            ActionEvaluation<T> evaluation) where T : ActionBase
+        protected static CrystalRandomSkillState GetCrystalRandomSkillState(
+            HashDigest<SHA256> states)
         {
             var avatarAddress = States.Instance.CurrentAvatarState.address;
             var buffStateAddress = Addresses.GetSkillStateAddressFromAvatarAddress(avatarAddress);
             if (StateGetter.GetState(
-                    evaluation.OutputState,
+                    states,
                     ReservedAddresses.LegacyAccount,
                     buffStateAddress) is Bencodex.Types.List serialized)
             {
@@ -297,7 +299,7 @@ namespace Nekoyume.Blockchain
         protected static void UpdateCrystalRandomSkillState<T>(
             ActionEvaluation<T> evaluation) where T : ActionBase
         {
-            var state = GetCrystalRandomSkillState(evaluation);
+            var state = GetCrystalRandomSkillState(evaluation.OutputState);
 
             if (state is { })
             {

--- a/nekoyume/Assets/_Scripts/UI/Module/Button/BonusBuffButton.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/Button/BonusBuffButton.cs
@@ -68,7 +68,12 @@ namespace Nekoyume.UI.Module
                 return;
             }
 
-            var starCount = skillState?.StarCount ?? 0;
+            var starCount = 0;
+            if (skillState != null && skillState.StageId == _stageId)
+            {
+                starCount = skillState.StarCount;
+            }
+
             _hasEnoughStars = starCount >= row.MaxStar;
             if (_hasEnoughStars)
             {
@@ -87,7 +92,7 @@ namespace Nekoyume.UI.Module
             var isBuffAvailable = skillState != null && _hasEnoughStars;
 
             var avatarAddress = States.Instance.CurrentAvatarState.address;
-            var key = string.Format("HackAndSlash.SelectedBonusSkillId.{0}", avatarAddress);
+            var key = $"HackAndSlash.SelectedBonusSkillId.{avatarAddress}";
             var selectedId = PlayerPrefs.GetInt(key, 0);
 
             var tableSheets = Game.Game.instance.TableSheets;


### PR DESCRIPTION
### Description

1. 조사 결과, HAS 렌더에서 1회성 버프를 적용하는 로직이 전혀 클리어하지 못한 HAS 액션을 클리어한것처럼 보여주는 버그를 유발하고 있었습니다.
2. 이에, HAS 렌더를 할 때는 1회성 버프가 정상적으로 적용될 수 있는 케이스에만 올바른 버프를 적용하도록 고쳤습니다.
3. 추가로, 클라이언트에서 선택한 1회성 버프를 캐싱하고 가져오는 로직이 있어서 이때 stage id에 대해서도 검증을 하도록 수정했습니다.

### Related Links

resolve #4355
