### PR TITLE
add updating player arena score and rank when render BattleArena

### DIFF
--- a/nekoyume/Assets/_Scripts/Blockchain/ActionRenderHandler.cs
+++ b/nekoyume/Assets/_Scripts/Blockchain/ActionRenderHandler.cs
@@ -2627,8 +2627,8 @@ namespace Nekoyume.Blockchain
             }
 
             // NOTE: Start cache some arena info which will be used after battle ends.
-            RxProps.ArenaInfoTuple.UpdateAsync().Forget();
-            RxProps.ArenaInformationOrderedWithScore.UpdateAsync().Forget();
+            await UniTask.WhenAll(RxProps.ArenaInfoTuple.UpdateAsync(),
+                RxProps.ArenaInformationOrderedWithScore.UpdateAsync());
 
             _disposableForBattleEnd?.Dispose();
             _disposableForBattleEnd = Game.Game.instance.Arena.OnArenaEnd

--- a/nekoyume/Assets/_Scripts/State/RxProps.Arena.cs
+++ b/nekoyume/Assets/_Scripts/State/RxProps.Arena.cs
@@ -331,7 +331,8 @@ namespace Nekoyume.State
             _lastArenaBattleBlockIndex.SetValueAndForceNotify(lastBattleBlockIndex);
 
             // Calculate and Reset Rank.
-            var arenaInfoList = arenaInfo.OrderByDescending(participant => participant.Score)
+            var arenaInfoList = arenaInfo
+                .OrderByDescending(participant => participant.Score)
                 .ThenByDescending(participant => participant.AvatarAddr == currentAvatarAddr)
                 .ToList();
             var playerIndex =

--- a/nekoyume/Assets/_Scripts/State/RxProps.Arena.cs
+++ b/nekoyume/Assets/_Scripts/State/RxProps.Arena.cs
@@ -341,8 +341,10 @@ namespace Nekoyume.State
             {
                 playerArenaInfo.Rank = 1;
             }
-            else if (playerIndex < avatarCount)
+            else if (playerIndex < avatarCount - 1) // avoid out of range exception
             {
+                // 다음 순서에 위치한 유저가 같은 점수일 경우, 같은 등수로 표기한다.
+                // 같지 않을 경우, 앞 순서에 있는 유저의 등수 - 1로 표기한다.
                 playerArenaInfo.Rank =
                     arenaInfoList[playerIndex + 1].Score == playerArenaInfo.Score
                         ? arenaInfoList[playerIndex + 1].Rank

--- a/nekoyume/Assets/_Scripts/UI/Widget/ArenaBoard.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/ArenaBoard.cs
@@ -64,7 +64,8 @@ namespace Nekoyume.UI
             loading.Show(LoadingScreen.LoadingType.Arena);
             var sw = new Stopwatch();
             sw.Start();
-            await RxProps.ArenaInformationOrderedWithScore.UpdateAsync();
+            await UniTask.WhenAll(RxProps.ArenaInformationOrderedWithScore.UpdateAsync(),
+                RxProps.ArenaInfoTuple.UpdateAsync());
             loading.Close();
             Show(RxProps.ArenaInformationOrderedWithScore.Value,
                 ignoreShowAnimation);


### PR DESCRIPTION
### Description

1. 현재 클라이언트의 아레나 리스트는 헤드리스에서 arenaParticipants 쿼리를 통해 가져온 모델을 토대로 렌더하고 있습니다.
2. 그런데 이 리스트는 액션을 즉시 반영하진 않아, 전투 후에 갱신하려고 해도 갱신되지 않은 점수를 보여주는 현상이 있었습니다.
3. 그래서 RxProps.Arena.UpdateArenaInformationOrderedWithScoreAsync()에서 점수를 다시 GetState하고 등수를 재계산하는 로직을 추가했습니다
4. 추가로 BattleArena 액션 렌더시 각 상태를 업데이트하는 로직이 Forget으로 비동기 처리되고 있었는데, await으로 기다리고 렌더하도록 변경했습니다.

### Related Links

resolve #4584
