### PR TITLE
fix: shatter strike max damage of rendering `HackAndSlash` action

### DIFF
--- a/nekoyume/Assets/_Scripts/Extensions/ActionEvalToViewModelExtensions.cs
+++ b/nekoyume/Assets/_Scripts/Extensions/ActionEvalToViewModelExtensions.cs
@@ -7,6 +7,7 @@ using Nekoyume.Blockchain;
 using Nekoyume.Game;
 using Nekoyume.Model.Item;
 using Nekoyume.Model.State;
+using Nekoyume.State;
 using Nekoyume.UI;
 using Nekoyume.UI.Model;
 
@@ -63,7 +64,9 @@ namespace Nekoyume
                     sheets.CostumeStatSheet,
                     StageSimulator.GetWaveRewards(random, stageRow, sheets.MaterialItemSheet),
                     collectionState.GetEffects(sheets.CollectionSheet),
-                    sheets.DeBuffLimitSheet);
+                    sheets.DeBuffLimitSheet,
+                    logEvent: true,
+                    States.Instance.GameConfigState.ShatterStrikeMaxDamage);
                 simulator.Simulate();
                 if (simulator.Log.IsClear)
                 {


### PR DESCRIPTION
### Description

1. Apply `GameConfigState.ShatterStrikeMaxDamage` to `StageSimulator`.
