### PR TITLE
retry initializing when fail to connect to services

### DIFF
--- a/nekoyume/Assets/_Scripts/Helper/Util.cs
+++ b/nekoyume/Assets/_Scripts/Helper/Util.cs
@@ -581,8 +581,13 @@ namespace Nekoyume.Helper
 
                 try
                 {
-                    var rawdata = await DownloadTextureRaw(url);
-                    var result = CreateSprite(rawdata);
+                    var rawData = await DownloadTextureRaw(url);
+                    if (rawData == null)
+                    {
+                        throw new Exception($"DownloadTextureRaw({url}) is null.");
+                    }
+
+                    var result = CreateSprite(rawData);
                     CachedDownloadTextures.Add(url, result);
                     return result;
                 }

--- a/nekoyume/Assets/_Scripts/Helper/Util.cs
+++ b/nekoyume/Assets/_Scripts/Helper/Util.cs
@@ -583,7 +583,8 @@ namespace Nekoyume.Helper
                 var rawData = await DownloadTextureRaw(url);
                 if (rawData == null)
                 {
-                    throw new Exception($"DownloadTextureRaw({url}) is null.");
+                    NcDebug.LogError($"[DownloadTexture] DownloadTextureRaw({url}) is null.");
+                    return null;
                 }
 
                 var result = CreateSprite(rawData);
@@ -592,11 +593,6 @@ namespace Nekoyume.Helper
             }
             catch (Exception e)
             {
-                if (CachedDownloadTextures.TryGetValue(url, out cachedTexture))
-                {
-                    return cachedTexture;
-                }
-
                 NcDebug.LogError($"[DownloadTexture] {url}\n{e}");
                 return null;
             }

--- a/nekoyume/Assets/_Scripts/Helper/Util.cs
+++ b/nekoyume/Assets/_Scripts/Helper/Util.cs
@@ -572,34 +572,33 @@ namespace Nekoyume.Helper
                 CachedDownloadTextures.Add(url, result);
                 return result;
             }
-            else
+
+            if (CachedDownloadTextures.TryGetValue(url, out cachedTexture))
+            {
+                return cachedTexture;
+            }
+
+            try
+            {
+                var rawData = await DownloadTextureRaw(url);
+                if (rawData == null)
+                {
+                    throw new Exception($"DownloadTextureRaw({url}) is null.");
+                }
+
+                var result = CreateSprite(rawData);
+                CachedDownloadTextures.Add(url, result);
+                return result;
+            }
+            catch (Exception e)
             {
                 if (CachedDownloadTextures.TryGetValue(url, out cachedTexture))
                 {
                     return cachedTexture;
                 }
 
-                try
-                {
-                    var rawData = await DownloadTextureRaw(url);
-                    if (rawData == null)
-                    {
-                        throw new Exception($"DownloadTextureRaw({url}) is null.");
-                    }
-
-                    var result = CreateSprite(rawData);
-                    CachedDownloadTextures.Add(url, result);
-                    return result;
-                }
-                catch
-                {
-                    if (CachedDownloadTextures.TryGetValue(url, out cachedTexture))
-                    {
-                        return cachedTexture;
-                    }
-                    NcDebug.LogError($"[DownloadTexture] {url}");
-                    return null;
-                }
+                NcDebug.LogError($"[DownloadTexture] {url}\n{e}");
+                return null;
             }
         }
 

--- a/nekoyume/Assets/_Scripts/UI/Widget/EventBanner.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/EventBanner.cs
@@ -64,7 +64,10 @@ namespace Nekoyume.UI.Module
         public override void Show(bool ignoreShowAnimation = false)
         {
             base.Show(ignoreShowAnimation);
-
+            if (!LiveAssetManager.instance.IsInitialized)
+            {
+                LiveAssetManager.instance.InitializeEvent();
+            }
 #if UNITY_ANDROID || UNITY_IOS
             this.transform.SetSiblingIndex(Widget.Find<Menu>().transform.GetSiblingIndex()+1);
 #endif

--- a/nekoyume/Assets/_Scripts/UI/Widget/Popup/EventReleaseNotePopup.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Popup/EventReleaseNotePopup.cs
@@ -55,12 +55,12 @@ namespace Nekoyume.UI
         private EventBannerItem _selectedEventBannerItem;
         private NoticeItem _selectedNoticeItem;
         private readonly ToggleGroup _tabGroup = new();
+        private bool _isInitialized;
 
         private System.Action _onClose;
 
         private const string LastReadingDayKey = "LAST_READING_DAY";
         private const string DateTimeFormat = "yyyy-MM-ddTHH:mm:ss";
-
         public bool HasUnread
         {
             get
@@ -81,6 +81,12 @@ namespace Nekoyume.UI
         public override void Initialize()
         {
             base.Initialize();
+            var liveAssetManager = LiveAssetManager.instance;
+            if (!liveAssetManager.IsInitialized || _isInitialized)
+            {
+                return;
+            }
+
             try
             {
                 _tabGroup.RegisterToggleable(eventTabButton);
@@ -103,7 +109,6 @@ namespace Nekoyume.UI
                 _tabGroup.SetToggledOn(eventTabButton);
                 closeButton.onClick.AddListener(() => Close());
 
-                var liveAssetManager = LiveAssetManager.instance;
                 eventTabButton.HasNotification.SetValueAndForceNotify(liveAssetManager.HasUnreadEvent);
                 noticeTabButton.HasNotification.SetValueAndForceNotify(liveAssetManager.HasUnreadNotice);
                 liveAssetManager.ObservableHasUnreadEvent
@@ -158,6 +163,14 @@ namespace Nekoyume.UI
             {
                 NcDebug.LogError(e);
             }
+
+            _isInitialized = true;
+        }
+
+        protected override void OnEnable()
+        {
+            base.OnEnable();
+            Initialize();
         }
 
         public override void Close(bool ignoreCloseAnimation = false)

--- a/nekoyume/Assets/_Scripts/UI/Widget/Popup/PatrolRewardPopup.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Popup/PatrolRewardPopup.cs
@@ -66,12 +66,6 @@ namespace Nekoyume.UI
 
         public override void Show(bool ignoreShowAnimation = false)
         {
-            if (!PatrolReward.Initialized)
-            {
-                NcDebug.LogError("PatrolReward is not initialized.");
-                return;
-            }
-
             if (Claiming.Value)
             {
                 return;
@@ -94,6 +88,19 @@ namespace Nekoyume.UI
 
         private async void ShowAsync(bool ignoreShowAnimation = false)
         {
+            var clientInitialized = Game.Game.instance.PatrolRewardServiceClient.IsInitialized;
+            if (!clientInitialized)
+            {
+                NcDebug.Log(
+                    $"[{nameof(PatrolRewardPopup)}]PatrolRewardServiceClient is not initialized.");
+                return;
+            }
+
+            if (!PatrolReward.Initialized)
+            {
+                await InitializePatrolReward();
+            }
+
             Analyzer.Instance.Track("Unity/PatrolReward/Show Popup", new Dictionary<string, Value>
             {
                 ["PatrolTime"] = PatrolReward.PatrolTime.Value


### PR DESCRIPTION
### Description

1. LiveAssetManager가 리소스를 다운로드하는데 실패했을 경우, 추후 재시도 할 수 있게 코드를 변경했습니다.
2. `Util.DownloadTexture` 메소드가 null로 텍스쳐를 만들어 캐싱하는 경우가 없도록 코드를 수정했습니다.
3. PatrolReward가 쿼리 실패로 초기화되지 않았을때, 필요한 경우 다시 쿼리를 이용해 초기화를 할 수 있도록 변경했습니다.

### Related Links

resolve #4753 
