### PR TITLE
add invoking SetWorldInformation at HAS rendering

### DIFF
--- a/nekoyume/Assets/_Scripts/Blockchain/ActionRenderHandler.cs
+++ b/nekoyume/Assets/_Scripts/Blockchain/ActionRenderHandler.cs
@@ -1919,6 +1919,7 @@ namespace Nekoyume.Blockchain
                                     newAvatarState.questList.completedQuestIds);
                                 _disposableForBattleEnd = null;
                                 Game.Game.instance.Stage.IsAvatarStateUpdatedAfterBattle = true;
+                                Widget.Find<WorldMap>().SetWorldInformation(newAvatarState.worldInformation);
                             }
                             catch (Exception e)
                             {


### PR DESCRIPTION
### Description

1. 스테이지 클리어 후 결과 화면에서 스테이지-이후 뒤로가기를 통해 월드맵에 가면 월드맵 UI의 정보가 업데이트 안되는 문제가 있었습니다.
2. WorldMap의 ViewModel이 업데이트 안되는 문제라서 액션 렌더에서 뷰모델 업데이트를 하도록 수정했습니다

### Related Links

resolve #4396 
