### PR TITLE
add keystore backup to many case

### DIFF
--- a/nekoyume/Assets/Resources/UI/Prefabs/UI_IntroScreen.prefab
+++ b/nekoyume/Assets/Resources/UI/Prefabs/UI_IntroScreen.prefab
@@ -5804,6 +5804,7 @@ MonoBehaviour:
   startButtonContainer: {fileID: 3860952466932365792}
   signinButton: {fileID: 636972386927832638}
   guestButton: {fileID: 1379309947048601246}
+  backupButton: {fileID: 1081669423292407343}
   yourPlanetText: {fileID: 4350155878917045938}
   yourPlanetButton: {fileID: 231605217515246203}
   yourPlanetButtonText: {fileID: 1224978541094035838}
@@ -7707,7 +7708,7 @@ MonoBehaviour:
   fixedSpacingOption: 0
   fixedMarginOption: 0
   fontMaterialType: 1
-  l10nKey: UI_SIGNIN_BUTTON
+  l10nKey: 
   fontMaterialIndexInitialized: 0
   fontMaterialIndex: 0
   defaultFontStylesInitialized: 0

--- a/nekoyume/Assets/StreamingAssets/Localization/common.csv
+++ b/nekoyume/Assets/StreamingAssets/Localization/common.csv
@@ -1996,3 +1996,4 @@ UI_ENTER_NCG_TO_STAKE,Enter the amount of NCG to receive rewards.,보상을 받�
 UI_LEVEL_TITLE,MonsterCollection Level,몬스터 컬렉션 레벨,Nível de Coleção de Monstros,モンスターコレクションレベル,Nivel de Colección de Monstruos,ระดับการสะสมมอนสเตอร์,Tingkat Koleksi Monster,Уровень Коллекции Монстров,怪物收集等级,怪物收集等級,Antas ng Koleksyon ng Halimaw,Cấp Độ Bộ Sưu Tập Quái Vật
 UI_SHOP_PC,Shop (PC),마켓 (PC),Comprar (PC),マーケット(PC),Tienda (PC),ร้านค้า (PC),Toko (PC),Магазин (ПК),店铺 (PC),店鋪 (PC),Tindahan (PC),Cửa hàng (PC)
 UI_SHOP_MOBILE,Shop (Mobile),마켓 (모바일),Comprar (Móvel),マーケット(モバイル),Tienda (Móvil),ร้านค้า (Mobai),Toko (Seluler),Магазин (Мобильный ),店铺 (移动 ),店鋪 (移動 ),Tindahan (Mobile),Cửa hàng (Di động)
+UI_KEY_BACKUP,Key backup,키 백업,,,,,,,,,,

--- a/nekoyume/Assets/_Scripts/Blockchain/Agent.cs
+++ b/nekoyume/Assets/_Scripts/Blockchain/Agent.cs
@@ -196,6 +196,7 @@ namespace Nekoyume.Blockchain
                 var popup = Widget.Find<IconAndButtonSystem>();
                 popup.Show("UI_RESET_STORE", "UI_RESET_STORE_CONTENT");
                 popup.SetConfirmCallbackToExit();
+                popup.SetCancelCallbackToBackup();
             }
 
 #if BLOCK_LOG_USE

--- a/nekoyume/Assets/_Scripts/Blockchain/Agent.cs
+++ b/nekoyume/Assets/_Scripts/Blockchain/Agent.cs
@@ -194,9 +194,22 @@ namespace Nekoyume.Blockchain
             catch (InvalidGenesisBlockException)
             {
                 var popup = Widget.Find<IconAndButtonSystem>();
-                popup.Show("UI_RESET_STORE", "UI_RESET_STORE_CONTENT");
-                popup.SetConfirmCallbackToExit();
-                popup.SetCancelCallbackToBackup();
+                if (Util.GetKeystoreJson() != string.Empty)
+                {
+                    popup.ShowWithTwoButton(
+                        "UI_RESET_STORE",
+                        "UI_RESET_STORE_CONTENT",
+                        "UI_OK",
+                        "UI_KEY_BACKUP",
+                        true,
+                        IconAndButtonSystem.SystemType.Information);
+                    popup.SetCancelCallbackToBackup();
+                }
+                else
+                {
+                    popup.Show("UI_RESET_STORE", "UI_RESET_STORE_CONTENT");
+                    popup.SetConfirmCallbackToExit();
+                }
             }
 
 #if BLOCK_LOG_USE

--- a/nekoyume/Assets/_Scripts/Game/Game.cs
+++ b/nekoyume/Assets/_Scripts/Game/Game.cs
@@ -399,10 +399,11 @@ namespace Nekoyume.Game
             if (_commandLineOptions.RequiredUpdate)
             {
                 var popup = Widget.Find<IconAndButtonSystem>();
-                popup.Show(
+                popup.ShowWithTwoButton(
                         "UI_REQUIRED_UPDATE_TITLE",
                         "UI_REQUIRED_UPDATE_CONTENT",
                         "UI_OK",
+                        "UI_SHARE_QR_TITLE",
                         true,
                         IconAndButtonSystem.SystemType.Information);
                 popup.ConfirmCallback = popup.CancelCallback = () =>
@@ -413,6 +414,7 @@ namespace Nekoyume.Game
                     Application.OpenURL(_commandLineOptions.AppleMarketUrl);
 #endif
                 };
+                popup.SetCancelCallbackToBackup();
                 yield break;
             }
 
@@ -1036,6 +1038,7 @@ namespace Nekoyume.Game
             popup = Widget.Find<IconAndButtonSystem>();
             popup.Show("UI_ERROR", "UI_ERROR_RPC_CONNECTION", "UI_QUIT");
             popup.SetConfirmCallbackToExit();
+            popup.SetCancelCallbackToBackup();
         }
 
         /// <summary>
@@ -1473,6 +1476,7 @@ namespace Nekoyume.Game
                 L10nManager.Localize("UI_OK"),
                 false);
             popup.SetConfirmCallbackToExit();
+            popup.SetCancelCallbackToBackup();
         }
 
         public static void Quit()
@@ -1500,19 +1504,13 @@ namespace Nekoyume.Game
             if (_commandLineOptions.Maintenance)
             {
                 var w = Widget.Create<IconAndButtonSystem>();
-                w.CancelCallback = () =>
-                {
-                    Application.OpenURL(LiveAsset.GameConfig.DiscordLink);
-#if UNITY_EDITOR
-                    UnityEditor.EditorApplication.ExitPlaymode();
-#else
-                    Application.Quit();
-#endif
-                };
-                w.Show(
+                w.ConfirmCallback = () => Application.OpenURL(LiveAsset.GameConfig.DiscordLink);
+                w.SetCancelCallbackToBackup();
+                w.ShowWithTwoButton(
                     "UI_MAINTENANCE",
                     "UI_MAINTENANCE_CONTENT",
                     "UI_OK",
+                    "UI_SHARE_QR_TITLE",
                     true,
                     IconAndButtonSystem.SystemType.Information
                 );

--- a/nekoyume/Assets/_Scripts/Game/Game.cs
+++ b/nekoyume/Assets/_Scripts/Game/Game.cs
@@ -399,13 +399,27 @@ namespace Nekoyume.Game
             if (_commandLineOptions.RequiredUpdate)
             {
                 var popup = Widget.Find<IconAndButtonSystem>();
-                popup.ShowWithTwoButton(
+                if (Nekoyume.Helper.Util.GetKeystoreJson() != string.Empty)
+                {
+                    popup.ShowWithTwoButton(
                         "UI_REQUIRED_UPDATE_TITLE",
                         "UI_REQUIRED_UPDATE_CONTENT",
                         "UI_OK",
-                        "UI_SHARE_QR_TITLE",
+                        "UI_KEY_BACKUP",
                         true,
                         IconAndButtonSystem.SystemType.Information);
+                    popup.SetCancelCallbackToBackup();
+                }
+                else
+                {
+                    popup.Show(
+                        "UI_REQUIRED_UPDATE_TITLE",
+                        "UI_REQUIRED_UPDATE_CONTENT",
+                        "UI_OK",
+                        true,
+                        IconAndButtonSystem.SystemType.Information);
+                }
+
                 popup.ConfirmCallback = popup.CancelCallback = () =>
                 {
 #if UNITY_ANDROID
@@ -414,7 +428,6 @@ namespace Nekoyume.Game
                     Application.OpenURL(_commandLineOptions.AppleMarketUrl);
 #endif
                 };
-                popup.SetCancelCallbackToBackup();
                 yield break;
             }
 
@@ -1038,7 +1051,6 @@ namespace Nekoyume.Game
             popup = Widget.Find<IconAndButtonSystem>();
             popup.Show("UI_ERROR", "UI_ERROR_RPC_CONNECTION", "UI_QUIT");
             popup.SetConfirmCallbackToExit();
-            popup.SetCancelCallbackToBackup();
         }
 
         /// <summary>
@@ -1476,7 +1488,6 @@ namespace Nekoyume.Game
                 L10nManager.Localize("UI_OK"),
                 false);
             popup.SetConfirmCallbackToExit();
-            popup.SetCancelCallbackToBackup();
         }
 
         public static void Quit()
@@ -1505,15 +1516,28 @@ namespace Nekoyume.Game
             {
                 var w = Widget.Create<IconAndButtonSystem>();
                 w.ConfirmCallback = () => Application.OpenURL(LiveAsset.GameConfig.DiscordLink);
-                w.SetCancelCallbackToBackup();
-                w.ShowWithTwoButton(
-                    "UI_MAINTENANCE",
-                    "UI_MAINTENANCE_CONTENT",
-                    "UI_OK",
-                    "UI_SHARE_QR_TITLE",
-                    true,
-                    IconAndButtonSystem.SystemType.Information
-                );
+                if (Nekoyume.Helper.Util.GetKeystoreJson() != string.Empty)
+                {
+                    w.SetCancelCallbackToBackup();
+                    w.ShowWithTwoButton(
+                        "UI_MAINTENANCE",
+                        "UI_MAINTENANCE_CONTENT",
+                        "UI_OK",
+                        "UI_KEY_BACKUP",
+                        true,
+                        IconAndButtonSystem.SystemType.Information
+                    );
+                }
+                else
+                {
+                    w.Show(
+                        "UI_MAINTENANCE",
+                        "UI_MAINTENANCE_CONTENT",
+                        "UI_OK",
+                        true,
+                        IconAndButtonSystem.SystemType.Information);
+                }
+
                 yield break;
             }
 

--- a/nekoyume/Assets/_Scripts/UI/Widget/Screen/IntroScreen.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Screen/IntroScreen.cs
@@ -395,7 +395,7 @@ namespace Nekoyume.UI
                         // ignored
                     }
 
-                    Find<LoginSystem>().Show(privateKeyString: pk?.ToString() ?? string.Empty);
+                    Find<LoginSystem>().Show(privateKeyString: pk?.ToHexWithZeroPaddings() ?? string.Empty);
                     Analyzer.Instance.Track("Unity/Intro/QRCodeImported");
 
                     var evt = new AirbridgeEvent("Intro_QRCodeImported");

--- a/nekoyume/Assets/_Scripts/UI/Widget/System/IconAndButtonSystem.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/System/IconAndButtonSystem.cs
@@ -150,6 +150,24 @@ namespace Nekoyume.UI
             };
         }
 
+        public void SetCancelCallbackToBackup()
+        {
+            CancelCallback = () =>
+            {
+                new NativeShare().AddFile(Util.GetQrCodePngFromKeystore(), "shareQRImg.png")
+                    .SetSubject(L10nManager.Localize("UI_SHARE_QR_TITLE"))
+                    .SetText(L10nManager.Localize("UI_SHARE_QR_CONTENT"))
+                    .SetCallback((_, _) =>
+                    {
+#if UNITY_EDITOR
+                        UnityEditor.EditorApplication.ExitPlaymode();
+#else
+                UnityEngine.Application.Quit();
+#endif
+                    })
+                    .Share();
+            };
+        }
         private IEnumerator CoCheckBlockIndex(long blockIndex)
         {
             yield return new WaitWhile(() => Game.Game.instance.Agent.BlockIndex == blockIndex);

--- a/nekoyume/Assets/_Scripts/UI/Widget/System/IconAndButtonSystem.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/System/IconAndButtonSystem.cs
@@ -168,6 +168,7 @@ namespace Nekoyume.UI
                     .Share();
             };
         }
+
         private IEnumerator CoCheckBlockIndex(long blockIndex)
         {
             yield return new WaitWhile(() => Game.Game.instance.Agent.BlockIndex == blockIndex);

--- a/nekoyume/ProjectSettings/ProjectSettings.asset
+++ b/nekoyume/ProjectSettings/ProjectSettings.asset
@@ -167,7 +167,7 @@ PlayerSettings:
     iPhone: 0
     tvOS: 0
   overrideDefaultApplicationIdentifier: 1
-  AndroidBundleVersionCode: 178
+  AndroidBundleVersionCode: 179
   AndroidMinSdkVersion: 22
   AndroidTargetSdkVersion: 33
   AndroidPreferredInstallLocation: 2

--- a/nekoyume/ProjectSettings/ProjectSettings.asset
+++ b/nekoyume/ProjectSettings/ProjectSettings.asset
@@ -138,7 +138,7 @@ PlayerSettings:
     16:10: 0
     16:9: 1
     Others: 0
-  bundleVersion: 160.1.1
+  bundleVersion: 160.1.2
   preloadedAssets: []
   metroInputSource: 0
   wsaTransparentSwapchain: 0
@@ -167,7 +167,7 @@ PlayerSettings:
     iPhone: 0
     tvOS: 0
   overrideDefaultApplicationIdentifier: 1
-  AndroidBundleVersionCode: 177
+  AndroidBundleVersionCode: 178
   AndroidMinSdkVersion: 22
   AndroidTargetSdkVersion: 33
   AndroidPreferredInstallLocation: 2


### PR DESCRIPTION
### Description

1. 게임 접속 전 타이틀 화면에서 키를 백업할 수 있도록 했습니다.
2. 게임에 정상적으로 접속하지 못하는 상황(점검, 업데이트 필요 등)에서 키를 백업할 수 있도록 했습니다.
3. 비밀번호가 설정되지 않은 QR코드를 임포트하면 자동으로 로그인되도록 수정했습니다.

### Related Links

resolve #4770 

### Required Reviewers

### Screenshot
![Screenshot_20240419_115323_Nine Chronicles M](https://github.com/planetarium/NineChronicles/assets/48484989/2b3973c6-d30b-41b5-80df-dfc01980f820)
![Screenshot_20240419_140801_Nine Chronicles M](https://github.com/planetarium/NineChronicles/assets/48484989/86f79d8b-3f2d-4e49-921d-99f7d175be07)
![Screenshot_20240419_114703_Nine Chronicles M](https://github.com/planetarium/NineChronicles/assets/48484989/10691265-959a-4d60-97a7-93a00de3d3e6)
![Screenshot_20240419_114716_Nine Chronicles M](https://github.com/planetarium/NineChronicles/assets/48484989/60b5e999-72fc-4f9c-8e31-172f78d2b7db)
