### PR TITLE
fix crossfade-background on enter stage

### DIFF
--- a/nekoyume/Assets/_Scripts/Game/Battle/Stage.cs
+++ b/nekoyume/Assets/_Scripts/Game/Battle/Stage.cs
@@ -315,10 +315,17 @@ namespace Nekoyume.Game.Battle
                 }
             }
 
-            if (hasPrevBackground && _background.TryGetComponent<BackgroundGroup>(out var backgroundGroup))
+            if (_background.TryGetComponent<BackgroundGroup>(out var backgroundGroup))
             {
-                backgroundGroup.SetBackgroundAlpha(0);
-                backgroundGroup.FadeIn(fadeTime);
+                if (hasPrevBackground)
+                {
+                    backgroundGroup.SetBackgroundAlpha(0);
+                    backgroundGroup.FadeIn(fadeTime);
+                }
+                else
+                {
+                    backgroundGroup.SetBackgroundAlpha(1);
+                }
             }
         }
 


### PR DESCRIPTION
### Description

처음 stage에 입장하는 경우, 이전에 출력되었던 위젯이 잠깐 보이는 현상이 있어 stage입장시 던전의 background의 alpha값을 1로 고정하도록 수정하였습니다.

### How to test

던전 입장시 배경이 크로스페이드되지 않고 alpha값이 1로 바로 적용되는지 확인합니다 

### Related Links

https://github.com/planetarium/NineChronicles/issues/4650

