### PR TITLE
move SetWorldInformation invoking at HAS rendering

### DIFF
--- a/nekoyume/Assets/_Scripts/Blockchain/ActionRenderHandler.cs
+++ b/nekoyume/Assets/_Scripts/Blockchain/ActionRenderHandler.cs
@@ -1919,7 +1919,6 @@ namespace Nekoyume.Blockchain
                                     newAvatarState.questList.completedQuestIds);
                                 _disposableForBattleEnd = null;
                                 Game.Game.instance.Stage.IsAvatarStateUpdatedAfterBattle = true;
-                                Widget.Find<WorldMap>().SetWorldInformation(newAvatarState.worldInformation);
                             }
                             catch (Exception e)
                             {
@@ -1928,6 +1927,7 @@ namespace Nekoyume.Blockchain
                         });
                     });
 
+            Widget.Find<WorldMap>().SetWorldInformation(newAvatarState.worldInformation);
             var tableSheets = TableSheets.Instance;
             var skillsOnWaveStart = new List<Skill>();
             if (prevSkillState != null && prevSkillState.StageId == eval.Action.StageId && prevSkillState.SkillIds.Any())


### PR DESCRIPTION
### Description

1. move SetWorldInformation invoking at HAS rendering for avoid exception.
2. onEnterToStageEnd의 콜백이 UniTask.Void 안에서 실행되고 있어서 WorldMap.SetWorldInformation을 실행할때 예외를 발생시키고 있었습니다.

### How to test

1. try to render HAS action

