### PR TITLE
change render texture depth stencil format for android

### DIFF
--- a/nekoyume/Assets/Resources/Video/21-9_render_texture.renderTexture
+++ b/nekoyume/Assets/Resources/Video/21-9_render_texture.renderTexture
@@ -18,7 +18,7 @@ RenderTexture:
   m_Height: 640
   m_AntiAliasing: 1
   m_MipCount: -1
-  m_DepthStencilFormat: 94
+  m_DepthStencilFormat: 92
   m_ColorFormat: 8
   m_MipMap: 0
   m_GenerateMips: 1

--- a/nekoyume/Assets/Resources/Video/intro_video.renderTexture
+++ b/nekoyume/Assets/Resources/Video/intro_video.renderTexture
@@ -18,7 +18,7 @@ RenderTexture:
   m_Height: 1080
   m_AntiAliasing: 1
   m_MipCount: -1
-  m_DepthStencilFormat: 94
+  m_DepthStencilFormat: 92
   m_ColorFormat: 8
   m_MipMap: 0
   m_GenerateMips: 1


### PR DESCRIPTION
### Description

안드로이드 특정 기기에서 사용할 수 없는 렌더텍스처 포멧을 사용하는 경우가 있어 수정하였습니다.

### How to test

이슈가 발생한 기기(HUAWEI Y7 Prime 2019)에서 룬 조각 소환 연출이 제대로 진행되는지 확인합니다.

### Related Links

https://github.com/planetarium/NineChronicles/issues/4811

