### PR TITLE
unused override for ios

### DIFF
--- a/nekoyume/Assets/Resources/UI/Icons/Item/100000.png.meta
+++ b/nekoyume/Assets/Resources/UI/Icons/Item/100000.png.meta
@@ -98,7 +98,7 @@ TextureImporter:
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0
-    overridden: 1
+    overridden: 0
     androidETC2FallbackOverride: 0
     forceMaximumCompressionQuality_BC6H_BC7: 0
   - serializedVersion: 3

--- a/nekoyume/Assets/Resources/UI/Icons/Item/200000.png.meta
+++ b/nekoyume/Assets/Resources/UI/Icons/Item/200000.png.meta
@@ -98,7 +98,7 @@ TextureImporter:
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0
-    overridden: 1
+    overridden: 0
     androidETC2FallbackOverride: 0
     forceMaximumCompressionQuality_BC6H_BC7: 0
   - serializedVersion: 3

--- a/nekoyume/Assets/Resources/UI/Icons/Item/201000.png.meta
+++ b/nekoyume/Assets/Resources/UI/Icons/Item/201000.png.meta
@@ -98,7 +98,7 @@ TextureImporter:
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0
-    overridden: 1
+    overridden: 0
     androidETC2FallbackOverride: 0
     forceMaximumCompressionQuality_BC6H_BC7: 0
   - serializedVersion: 3

--- a/nekoyume/Assets/Resources/UI/Icons/Item/201001.png.meta
+++ b/nekoyume/Assets/Resources/UI/Icons/Item/201001.png.meta
@@ -98,7 +98,7 @@ TextureImporter:
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0
-    overridden: 1
+    overridden: 0
     androidETC2FallbackOverride: 0
     forceMaximumCompressionQuality_BC6H_BC7: 0
   - serializedVersion: 3

--- a/nekoyume/Assets/Resources/UI/Icons/Item/201002.png.meta
+++ b/nekoyume/Assets/Resources/UI/Icons/Item/201002.png.meta
@@ -98,7 +98,7 @@ TextureImporter:
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0
-    overridden: 1
+    overridden: 0
     androidETC2FallbackOverride: 0
     forceMaximumCompressionQuality_BC6H_BC7: 0
   - serializedVersion: 3

--- a/nekoyume/Assets/Resources/UI/Icons/Item/201003.png.meta
+++ b/nekoyume/Assets/Resources/UI/Icons/Item/201003.png.meta
@@ -98,7 +98,7 @@ TextureImporter:
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0
-    overridden: 1
+    overridden: 0
     androidETC2FallbackOverride: 0
     forceMaximumCompressionQuality_BC6H_BC7: 0
   - serializedVersion: 3

--- a/nekoyume/Assets/Resources/UI/Icons/Item/201004.png.meta
+++ b/nekoyume/Assets/Resources/UI/Icons/Item/201004.png.meta
@@ -98,7 +98,7 @@ TextureImporter:
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0
-    overridden: 1
+    overridden: 0
     androidETC2FallbackOverride: 0
     forceMaximumCompressionQuality_BC6H_BC7: 0
   - serializedVersion: 3

--- a/nekoyume/Assets/Resources/UI/Icons/Item/201005.png.meta
+++ b/nekoyume/Assets/Resources/UI/Icons/Item/201005.png.meta
@@ -98,7 +98,7 @@ TextureImporter:
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0
-    overridden: 1
+    overridden: 0
     androidETC2FallbackOverride: 0
     forceMaximumCompressionQuality_BC6H_BC7: 0
   - serializedVersion: 3

--- a/nekoyume/Assets/Resources/UI/Icons/Item/201006.png.meta
+++ b/nekoyume/Assets/Resources/UI/Icons/Item/201006.png.meta
@@ -98,7 +98,7 @@ TextureImporter:
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0
-    overridden: 1
+    overridden: 0
     androidETC2FallbackOverride: 0
     forceMaximumCompressionQuality_BC6H_BC7: 0
   - serializedVersion: 3

--- a/nekoyume/Assets/Resources/UI/Icons/Item/201007.png.meta
+++ b/nekoyume/Assets/Resources/UI/Icons/Item/201007.png.meta
@@ -98,7 +98,7 @@ TextureImporter:
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0
-    overridden: 1
+    overridden: 0
     androidETC2FallbackOverride: 0
     forceMaximumCompressionQuality_BC6H_BC7: 0
   - serializedVersion: 3

--- a/nekoyume/Assets/Resources/UI/Icons/Item/201008.png.meta
+++ b/nekoyume/Assets/Resources/UI/Icons/Item/201008.png.meta
@@ -98,7 +98,7 @@ TextureImporter:
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0
-    overridden: 1
+    overridden: 0
     androidETC2FallbackOverride: 0
     forceMaximumCompressionQuality_BC6H_BC7: 0
   - serializedVersion: 3

--- a/nekoyume/Assets/Resources/UI/Icons/Item/201009.png.meta
+++ b/nekoyume/Assets/Resources/UI/Icons/Item/201009.png.meta
@@ -98,7 +98,7 @@ TextureImporter:
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0
-    overridden: 1
+    overridden: 0
     androidETC2FallbackOverride: 0
     forceMaximumCompressionQuality_BC6H_BC7: 0
   - serializedVersion: 3

--- a/nekoyume/Assets/Resources/UI/Icons/Item/201010.png.meta
+++ b/nekoyume/Assets/Resources/UI/Icons/Item/201010.png.meta
@@ -98,7 +98,7 @@ TextureImporter:
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0
-    overridden: 1
+    overridden: 0
     androidETC2FallbackOverride: 0
     forceMaximumCompressionQuality_BC6H_BC7: 0
   - serializedVersion: 3

--- a/nekoyume/Assets/Resources/UI/Icons/Item/201011.png.meta
+++ b/nekoyume/Assets/Resources/UI/Icons/Item/201011.png.meta
@@ -98,7 +98,7 @@ TextureImporter:
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0
-    overridden: 1
+    overridden: 0
     androidETC2FallbackOverride: 0
     forceMaximumCompressionQuality_BC6H_BC7: 0
   - serializedVersion: 3

--- a/nekoyume/Assets/Resources/UI/Icons/Item/201012.png.meta
+++ b/nekoyume/Assets/Resources/UI/Icons/Item/201012.png.meta
@@ -98,7 +98,7 @@ TextureImporter:
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0
-    overridden: 1
+    overridden: 0
     androidETC2FallbackOverride: 0
     forceMaximumCompressionQuality_BC6H_BC7: 0
   - serializedVersion: 3

--- a/nekoyume/Assets/Resources/UI/Icons/Item/201013.png.meta
+++ b/nekoyume/Assets/Resources/UI/Icons/Item/201013.png.meta
@@ -98,7 +98,7 @@ TextureImporter:
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0
-    overridden: 1
+    overridden: 0
     androidETC2FallbackOverride: 0
     forceMaximumCompressionQuality_BC6H_BC7: 0
   - serializedVersion: 3

--- a/nekoyume/Assets/Resources/UI/Icons/Item/202001.png.meta
+++ b/nekoyume/Assets/Resources/UI/Icons/Item/202001.png.meta
@@ -98,7 +98,7 @@ TextureImporter:
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0
-    overridden: 1
+    overridden: 0
     androidETC2FallbackOverride: 0
     forceMaximumCompressionQuality_BC6H_BC7: 0
   - serializedVersion: 3

--- a/nekoyume/Assets/Resources/UI/Materials/Distortion_Stencil.shader
+++ b/nekoyume/Assets/Resources/UI/Materials/Distortion_Stencil.shader
@@ -1,5 +1,10 @@
 ﻿Shader "Custom/Distortion_Stencil"
 {
+    Properties
+    {
+        // Unused _MainTex property, added to prevent runtime exceptions for elements whose parent is a ScrollRect
+        [HideInInspector] _MainTex("Main Texture - unused", 2D) = "white" {}
+    }
     SubShader
     {
         Tags

--- a/nekoyume/Assets/Sprites/Background/Combination/Combination_Upgrade/bg_combination_Upgrade.png.meta
+++ b/nekoyume/Assets/Sprites/Background/Combination/Combination_Upgrade/bg_combination_Upgrade.png.meta
@@ -98,7 +98,7 @@ TextureImporter:
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0
-    overridden: 1
+    overridden: 0
     androidETC2FallbackOverride: 0
     forceMaximumCompressionQuality_BC6H_BC7: 0
   - serializedVersion: 3

--- a/nekoyume/Assets/Sprites/Background/MainMenu/Event/Valentine/bg_valentine_bg_00.png.meta
+++ b/nekoyume/Assets/Sprites/Background/MainMenu/Event/Valentine/bg_valentine_bg_00.png.meta
@@ -98,7 +98,7 @@ TextureImporter:
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0
-    overridden: 1
+    overridden: 0
     androidETC2FallbackOverride: 0
     forceMaximumCompressionQuality_BC6H_BC7: 0
   - serializedVersion: 3

--- a/nekoyume/Assets/Sprites/Background/MainMenu/Event/Valentine/bg_valentine_bg_01.png.meta
+++ b/nekoyume/Assets/Sprites/Background/MainMenu/Event/Valentine/bg_valentine_bg_01.png.meta
@@ -98,7 +98,7 @@ TextureImporter:
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0
-    overridden: 1
+    overridden: 0
     androidETC2FallbackOverride: 0
     forceMaximumCompressionQuality_BC6H_BC7: 0
   - serializedVersion: 3

--- a/nekoyume/Assets/Sprites/Background/MainMenu/Event/Valentine/bg_valentine_bg_02.png.meta
+++ b/nekoyume/Assets/Sprites/Background/MainMenu/Event/Valentine/bg_valentine_bg_02.png.meta
@@ -98,7 +98,7 @@ TextureImporter:
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0
-    overridden: 1
+    overridden: 0
     androidETC2FallbackOverride: 0
     forceMaximumCompressionQuality_BC6H_BC7: 0
   - serializedVersion: 3

--- a/nekoyume/Assets/Sprites/Background/MainMenu/Event/Valentine/bg_valentine_bg_08.png.meta
+++ b/nekoyume/Assets/Sprites/Background/MainMenu/Event/Valentine/bg_valentine_bg_08.png.meta
@@ -98,7 +98,7 @@ TextureImporter:
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0
-    overridden: 1
+    overridden: 0
     androidETC2FallbackOverride: 0
     forceMaximumCompressionQuality_BC6H_BC7: 0
   - serializedVersion: 3

--- a/nekoyume/Assets/Sprites/Background/MainMenu/Event/Valentine/bg_valentine_bg_12.png.meta
+++ b/nekoyume/Assets/Sprites/Background/MainMenu/Event/Valentine/bg_valentine_bg_12.png.meta
@@ -98,7 +98,7 @@ TextureImporter:
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0
-    overridden: 1
+    overridden: 0
     androidETC2FallbackOverride: 0
     forceMaximumCompressionQuality_BC6H_BC7: 0
   - serializedVersion: 3

--- a/nekoyume/Assets/Sprites/Background/MainMenu/Event/Valentine/bg_valentine_bg_13.png.meta
+++ b/nekoyume/Assets/Sprites/Background/MainMenu/Event/Valentine/bg_valentine_bg_13.png.meta
@@ -98,7 +98,7 @@ TextureImporter:
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0
-    overridden: 1
+    overridden: 0
     androidETC2FallbackOverride: 0
     forceMaximumCompressionQuality_BC6H_BC7: 0
   - serializedVersion: 3

--- a/nekoyume/Assets/Sprites/Background/MainMenu/Event/Valentine/bg_valentine_bg_14.png.meta
+++ b/nekoyume/Assets/Sprites/Background/MainMenu/Event/Valentine/bg_valentine_bg_14.png.meta
@@ -98,7 +98,7 @@ TextureImporter:
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0
-    overridden: 1
+    overridden: 0
     androidETC2FallbackOverride: 0
     forceMaximumCompressionQuality_BC6H_BC7: 0
   - serializedVersion: 3

--- a/nekoyume/Assets/Sprites/Background/MainMenu/Event/Valentine/bg_valentine_monster_01.png.meta
+++ b/nekoyume/Assets/Sprites/Background/MainMenu/Event/Valentine/bg_valentine_monster_01.png.meta
@@ -98,7 +98,7 @@ TextureImporter:
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0
-    overridden: 1
+    overridden: 0
     androidETC2FallbackOverride: 0
     forceMaximumCompressionQuality_BC6H_BC7: 0
   - serializedVersion: 3

--- a/nekoyume/Assets/UIResources/Content/Effect/Common/Fx_Helix_01.png.meta
+++ b/nekoyume/Assets/UIResources/Content/Effect/Common/Fx_Helix_01.png.meta
@@ -98,7 +98,7 @@ TextureImporter:
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0
-    overridden: 1
+    overridden: 0
     androidETC2FallbackOverride: 0
     forceMaximumCompressionQuality_BC6H_BC7: 0
   - serializedVersion: 3


### PR DESCRIPTION
문제가 발생한 이미지의 IOS 포맷설정이 따로 오버라이드되어있어 제거해주었습니다.
빌드에 포함해서 테스트진행해봐야합니다.