### PR TITLE
add task cancel log and retry when fail load

### DIFF
--- a/nekoyume/Assets/_Scripts/L10n/L10nManager.cs
+++ b/nekoyume/Assets/_Scripts/L10n/L10nManager.cs
@@ -575,7 +575,7 @@ namespace Nekoyume.L10n
             return false;
         }
 
-        public static async UniTask AdditionalL10nTableDownload(string url, bool forceDownload = false)
+        public static async UniTask AdditionalL10nTableDownload(string url, bool forceDownload = false, int retryCount = 3)
         {
             var client = new HttpClient();
             if (_initializedURLs.TryGetValue(url, out var initialized) && !forceDownload)
@@ -623,10 +623,35 @@ namespace Nekoyume.L10n
 
                 _initializedURLs.TryAdd(url, true);
             }
+            catch (TaskCanceledException e)
+            {
+                if (e.CancellationToken.IsCancellationRequested)
+                {
+                    NcDebug.LogError($"Task was canceled due to a cancellation request. Cancellation requested by: {e.CancellationToken}");
+                }
+                else
+                {
+                    NcDebug.LogError($"Task was canceled, but no cancellation was requested explicitly. Exception: {e}");
+                }
+                NcDebug.LogError($"{e.InnerException} \n\n {e.Source} \n\n{e.StackTrace}");
+                if (retryCount > 0)
+                {
+                    ReTryAdditionalTableDownload().Forget();
+                }
+                return;
+            }
             catch (Exception e)
             {
                 NcDebug.LogError(e);
+                if (retryCount > 0)
+                {
+                    ReTryAdditionalTableDownload().Forget();
+                }
                 return;
+            }
+            async UniTaskVoid ReTryAdditionalTableDownload()
+            {
+                await AdditionalL10nTableDownload(url, forceDownload,--retryCount);
             }
         }
 


### PR DESCRIPTION
모바일 환경에서 접속시 번역어테이블을 받는과정에서 간헐적으로 Task 가 깨지는 문제 로그추가 및 로드 재시도 추가.

관련에러로그 확인시 상세정보가 안나와서 추적불가.

```
[2024-4-24 08:59:08] System.Threading.Tasks.TaskCanceledException: A task was canceled.
  at System.Net.Http.MonoWebRequestHandler.SendAsync (System.Net.Http.HttpRequestMessage request, System.Threading.CancellationToken cancellationToken) [0x00000] in <00000000000000000000000000000000>:0 
  at System.Threading.ExecutionContext.RunInternal (System.Threading.ExecutionContext executionContext, System.Threading.ContextCallback callback, System.Object state, System.Boolean preserveSyncCtx) [0x00000] in <00000000000000000000000000000000>:0 
  at System.Runtime.CompilerServices.AsyncMethodBuilderCore+MoveNextRunner.Run () [0x00000] in <00000000000000000000000000000000>:0 
  at System.Threading.Tasks.AwaitTaskContinuation.RunOrScheduleAction (System.Action action, System.Boolean allowInlining, System.Threading.Tasks.Task& currentTask) [0x00000] in <00000000000000000000000000000000>:0 
  at System.Threading.Tasks.Task.FinishContinuations () [0x00000] in <00000000000000000000000000000000>:0 
  at System.Threading.Tasks.Task.Finish (System.Boolean bUserDelegateExecuted) [0x00000] in <00000000000000000000000000000000>:0 
  at System.Threading.Tasks.Task.TrySetException (System.Object exceptionObject) [0x00000] in <00000000000000000000000000000000>:0 
  at System.Threading.Tasks.UnwrapPromise`1[TResult].TrySetFromTask (System.Threading.Tasks.Task task, System.Boolean lookForOce) [0x00000] in <00000000000000000000000000000000>:0 
  at System.Threading.Tasks.UnwrapPromise`1[TResult].InvokeCore (System.Threading.Tasks.Task completingTask) [0x00000] in <00000000000000000000000000000000>:0 
  at System.Threading.Tasks.UnwrapPromise`1[TResult].Invoke (System.Threading.Tasks.Task completingTask) [0x00000] in <00000000000000000000000000000000>:0 
  at System.Threading.Tasks.Task.FinishContinuations () [0x00000] in <00000000000000000000000000000000>:0 
  at System.Threading.Tasks.Task.Finish (System.Boolean bUserDelegateExecuted) [0x00000] in <00000000000000000000000000000000>:0 
  at System.Threading.Tasks.Task.TrySetException (System.Object exceptionObject) [0x00000] in <00000000000000000000000000000000>:0 
  at System.Threading.Tasks.TaskFactory`1[TResult].FromAsyncCoreLogic (System.IAsyncResult iar, System.Func`2[T,TResult] endFunction, System.Action`1[T] endAction, System.Threading.Tasks.Task`1[TResult] promise, System.Boolean requiresSynchronization) [0x00000] in <00000000000000000000000000000000>:0 
  at System.Threading.Tasks.TaskFactory`1+<>c__DisplayClass35_0[TResult].<FromAsyncImpl>b__0 (System.IAsyncResult iar) [0x00000] in <00000000000000000000000000000000>:0 
  at System.Threading.Tasks.AwaitTaskContinuation.RunOrScheduleAction (System.Action action, System.Boolean allowInlining, System.Threading.Tasks.Task& currentTask) [0x00000] in <00000000000000000000000000000000>:0 
  at System.Threading.Tasks.Task.FinishContinuations () [0x00000] in <00000000000000000000000000000000>:0 
  at System.Threading.Tasks.Task.Finish (System.Boolean bUserDelegateExecuted) [0x00000] in <00000000000000000000000000000000>:0 
  at System.Threading.Tasks.Task.TrySetException (System.Object exceptionObject) [0x00000] in <00000000000000000000000000000000>:0 
  at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1[TResult].SetException (System.Exception exception) [0x00000] in <00000000000000000000000000000000>:0 
  at System.Net.HttpWebRequest.RunWithTimeoutWorker[T] (System.Threading.Tasks.Task`1[TResult] workerTask, System.Int32 timeout, System.Action abort, System.Func`1[TResult] aborted, System.Threading.CancellationTokenSource cts) [0x00000] in <00000000000000000000000000000000>:0 
  at System.Threading.ExecutionContext.RunInternal (System.Threading.ExecutionContext executionContext, System.Threading.ContextCallback callback, System.Object state, System.Boolean preserveSyncCtx) [0x00000] in <00000000000000000000000000000000>:0 
  at System.Runtime.CompilerServices.AsyncMethodBuilderCore+MoveNextRunner.Run () [0x00000] in <00000000000000000000000000000000>:0 
  at System.Threading.Tasks.AwaitTaskContinuation.RunOrScheduleAction (System.Action action, System.Boolean allowInlining, System.Threading.Tasks.Task& currentTask) [0x00000] in <00000000000000000000000000000000>:0 
  at System.Threading.Tasks.Task.FinishContinuations () [0x00000] in <00000000000000000000000000000000>:0 
  at System.Threading.Tasks.Task`1[TResult].TrySetResult (TResult result) [0x00000] in <00000000000000000000000000000000>:0 
  at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1[TResult].SetResult (TResult result) [0x00000] in <00000000000000000000000000000000>:0 
  at System.Net.ServicePointScheduler.WaitAsync (System.Threading.Tasks.Task workerTask, System.Int32 millisecondTimeout) [0x00000] in <00000000000000000000000000000000>:0 
  at System.Threading.ExecutionContext.RunInternal (System.Threading.ExecutionContext executionContext, System.Threading.ContextCallback callback, System.Object state, System.Boolean preserveSyncCtx) [0x00000] in <00000000000000000000000000000000>:0 
  at System.Runtime.CompilerServices.AsyncMethodBuilderCore+MoveNextRunner.Run () [0x00000] in <00000000000000000000000000000000>:0 
  at System.Threading.Tasks.AwaitTaskContinuation.RunOrScheduleAction (System.Action action, System.Boolean allowInlining, System.Threading.Tasks.Task& currentTask) [0x00000] in <00000000000000000000000000000000>:0 
  at System.Threading.Tasks.Task.FinishContinuations () [0x00000] in <00000000000000000000000000000000>:0 
  at System.Threading.Tasks.Task`1[TResult].TrySetResult (TResult result) [0x00000] in <00000000000000000000000000000000>:0 
  at System.Threading.Tasks.TaskFactory+CompleteOnInvokePromise.Invoke (System.Threading.Tasks.Task completingTask) [0x00000] in <00000000000000000000000000000000>:0 
  at System.Threading.Tasks.Task.FinishContinuations () [0x00000] in <00000000000000000000000000000000>:0 
  at System.Threading.Tasks.Task.Finish (System.Boolean bUserDelegateExecuted) [0x00000] in <00000000000000000000000000000000>:0 
  at System.Threading.Tasks.Task.TrySetException (System.Object exceptionObject) [0x00000] in <00000000000000000000000000000000>:0 
  at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1[TResult].SetException (System.Exception exception) [0x00000] in <00000000000000000000000000000000>:0 
  at System.Net.HttpWebRequest.MyGetResponseAsync (System.Threading.CancellationToken cancellationToken) [0x00000] in <00000000000000000000000000000000>:0 
  at System.Threading.ExecutionContext.RunInternal (System.Threading.ExecutionContext executionContext, System.Threading.ContextCallback callback, System.Object state, System.Boolean preserveSyncCtx) [0x00000] in <00000000000000000000000000000000>:0 
  at System.Runtime.CompilerServices.AsyncMethodBuilderCore+MoveNextRunner.Run () [0x00000] in <00000000000000000000000000000000>:0 
  at System.Threading.Tasks.AwaitTaskContinuation.RunOrScheduleAction (System.Action action, System.Boolean allowInlining, System.Threading.Tasks.Task& currentTask) [0x00000] in <00000000000000000000000000000000>:0 
  at System.Threading.Tasks.Task.FinishContinuations () [0x00000] in <00000000000000000000000000000000>:0 
  at System.Threading.Tasks.Task.TrySetCanceled (System.Threading.CancellationToken tokenToRecord, System.Object cancellationException) [0x00000] in <00000000000000000000000000000000>:0 
  at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1[TResult].SetException (System.Exception exception) [0x00000] in <00000000000000000000000000000000>:0 
  at System.Net.WebCompletionSource`1[T].WaitForCompletion () [0x00000] in <00000000000000000000000000000000>:0 
  at System.Threading.ExecutionContext.RunInternal (System.Threading.ExecutionContext executionContext, System.Threading.ContextCallback callback, System.Object state, System.Boolean preserveSyncCtx) [0x00000] in <00000000000000000000000000000000>:0 
  at System.Runtime.CompilerServices.AsyncMethodBuilderCore+MoveNextRunner.Run () [0x00000] in <00000000000000000000000000000000>:0 
  at System.Threading.ThreadPoolWorkQueue.Dispatch () [0x00000] in <00000000000000000000000000000000>:0 
--- End of stack trace from previous location where exception was thrown ---

  at System.Net.Http.HttpClient.SendAsyncWorker (System.Net.Http.HttpRequestMessage request, System.Net.Http.HttpCompletionOption completionOption, System.Threading.CancellationToken cancellationToken) [0x00000] in <00000000000000000000000000000000>:0 
  at System.Threading.ExecutionContext.RunInternal (System.Threading.ExecutionContext executionContext, System.Threading.ContextCallback callback, System.Object state, System.Boolean preserveSyncCtx) [0x00000] in <00000000000000000000000000000000>:0 
  at System.Runtime.CompilerServices.AsyncMethodBuilderCore+MoveNextRunner.Run () [0x00000] in <00000000000000000000000000000000>:0 
  at System.Threading.Tasks.AwaitTaskContinuation.RunOrScheduleAction (System.Action action, System.Boolean allowInlining, System.Threading.Tasks.Task& currentTask) [0x00000] in <00000000000000000000000000000000>:0 
  at System.Threading.Tasks.Task.FinishContinuations () [0x00000] in <00000000000000000000000000000000>:0 
  at System.Threading.Tasks.Task.TrySetCanceled (System.Threading.CancellationToken tokenToRecord, System.Object cancellationException) [0x00000] in <00000000000000000000000000000000>:0 
  at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1[TResult].SetException (System.Exception exception) [0x00000] in <00000000000000000000000000000000>:0 
  at System.Net.Http.MonoWebRequestHandler.SendAsync (System.Net.Http.HttpRequestMessage request, System.Threading.CancellationToken cancellationToken) [0x00000] in <00000000000000000000000000000000>:0 
  at System.Threading.ExecutionContext.RunInternal (System.Threading.ExecutionContext executionCont<truncated>
Nekoyume.L10n.<AdditionalL10nTableDownload>d__53:MoveNext()
Cysharp.Threading.Tasks.CompilerServices.AsyncUniTask`1:Run()
UnityEngine.UnitySynchronizationContext:Exec()
```