### PR TITLE
Bugfix/set fungibleasset tradabletext

### DIFF
--- a/nekoyume/Assets/_Scripts/Extensions/FungibleAssetValueExtensions.cs
+++ b/nekoyume/Assets/_Scripts/Extensions/FungibleAssetValueExtensions.cs
@@ -1,4 +1,6 @@
+using System.Linq;
 using Libplanet.Types.Assets;
+using Nekoyume.Action;
 using Nekoyume.Helper;
 using UnityEngine;
 
@@ -11,5 +13,8 @@ namespace Nekoyume
 
         public static Sprite GetIconSprite(this FungibleAssetValue value) =>
             SpriteHelper.GetFavIcon(value.Currency.Ticker);
+
+        public static bool IsTradable(this FungibleAssetValue value) =>
+            !RegisterProduct.NonTradableTickerCurrencies.Contains(value.Currency);
     }
 }

--- a/nekoyume/Assets/_Scripts/UI/Model/InventoryItem.cs
+++ b/nekoyume/Assets/_Scripts/UI/Model/InventoryItem.cs
@@ -18,7 +18,6 @@ namespace Nekoyume.UI.Model
         public readonly ReactiveProperty<int> Count;
         public readonly ReactiveProperty<bool> LevelLimited;
         public readonly ReactiveProperty<bool> Equipped = new();
-        // TODO: 룬조각을 제외하고는 소유하지 않은 장비가 Tradable = true로 설정되어 있음. 네이밍이 꼬인것으로 추정되며 아이템 상태 개선이 필요해보임
         public readonly ReactiveProperty<bool> Tradable;
         public readonly ReactiveProperty<bool> DimObjectEnabled;
         public readonly ReactiveProperty<bool> Selected;

--- a/nekoyume/Assets/_Scripts/UI/Module/Item/BaseItemView.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/Item/BaseItemView.cs
@@ -136,6 +136,7 @@ namespace Nekoyume
         public GameObject MinusObject => minusObject;
         public GameObject FocusObject => focusObject;
         public GameObject ExpiredObject => expiredObject;
+        // TODO: 소유하지 않은 장비가 Tradable = true로 설정되어 있음. 네이밍이 꼬인것으로 추정되며 아이템 상태 개선이 필요해보임
         public GameObject TradableObject => tradableObject;
         public GameObject DimObject => dimObject;
         public GameObject LevelLimitObject => levelLimitObject;

--- a/nekoyume/Assets/_Scripts/UI/Widget/Tooltip/FungibleAssetTooltip.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Tooltip/FungibleAssetTooltip.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Numerics;
 using Coffee.UIEffects;
+using Lib9c;
 using Libplanet.Types.Assets;
 using Nekoyume.Action;
 using Nekoyume.EnumType;
@@ -234,8 +235,9 @@ namespace Nekoyume.UI
 
         private void UpdateInformation(string ticker, string amount, System.Action onClose)
         {
-            var grade = 1;
-            var id = 0;
+            var tradable = true;
+            var grade    = 1;
+            var id       = 0;
             if (RuneFrontHelper.TryGetRuneData(ticker, out var runeData))
             {
                 var sheet = Game.Game.instance.TableSheets.RuneListSheet;
@@ -244,6 +246,9 @@ namespace Nekoyume.UI
                     grade = row.Grade;
                     id = runeData.id;
                 }
+
+                var rune = Currencies.GetRune(ticker);
+                tradable = !RegisterProduct.NonTradableTickerCurrencies.Contains(rune);
             }
 
             var petSheet = Game.Game.instance.TableSheets.PetSheet;
@@ -275,7 +280,7 @@ namespace Nekoyume.UI
             _onClose = onClose;
             scrollbar.value = 1f;
 
-            SetTradableState(false, true);
+            SetTradableState(false, tradable);
         }
 
         private void UpdateGrade(int grade)

--- a/nekoyume/Assets/_Scripts/UI/Widget/Tooltip/FungibleAssetTooltip.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Tooltip/FungibleAssetTooltip.cs
@@ -130,7 +130,7 @@ namespace Nekoyume.UI
             sell.gameObject.SetActive(false);
             buy.gameObject.SetActive(false);
 
-            UpdateInformation(item.FungibleAssetValue, onClose, item.Tradable.Value);
+            UpdateInformation(item.FungibleAssetValue, onClose);
             base.Show();
             StartCoroutine(CoUpdate(panel.gameObject));
         }
@@ -189,13 +189,14 @@ namespace Nekoyume.UI
             buy.gameObject.SetActive(false);
             sell.gameObject.SetActive(false);
             _onRegister = onRegister;
-            UpdateInformation(item.FungibleAssetValue, onClose, item.Tradable.Value, true);
+            UpdateInformation(item.FungibleAssetValue, onClose, true);
             base.Show();
             StartCoroutine(CoUpdate(registerButton.gameObject));
         }
 
-        private void UpdateInformation(FungibleAssetValue fav, System.Action onClose, bool isTradeAble = false, bool isAvailableSell = false)
+        private void UpdateInformation(FungibleAssetValue fav, System.Action onClose, bool isAvailableSell = false)
         {
+            var isTradeAble = fav.IsTradable();
             var grade = 1;
             var id = 0;
             var ticker = fav.Currency.Ticker;
@@ -228,8 +229,7 @@ namespace Nekoyume.UI
             _onClose = onClose;
             scrollbar.value = 1f;
 
-            isTradeAble = isTradeAble && fav.MajorUnit > 0;
-            SetTradableState(isAvailableSell, isTradeAble);
+            SetTradableState(isAvailableSell, isTradeAble, fav.MajorUnit > 0);
         }
 
         private void UpdateInformation(string ticker, string amount, System.Action onClose)
@@ -275,7 +275,7 @@ namespace Nekoyume.UI
             _onClose = onClose;
             scrollbar.value = 1f;
 
-            SetTradableState(false);
+            SetTradableState(false, true);
         }
 
         private void UpdateGrade(int grade)
@@ -354,11 +354,11 @@ namespace Nekoyume.UI
             _isPointerOnScrollArea = value;
         }
 
-        private void SetTradableState(bool isAvailableSell, bool isTradable = false)
+        private void SetTradableState(bool isAvailableSell, bool isTradable = false, bool hasItem = false)
         {
             registerButton.gameObject.SetActive(isAvailableSell);
 
-            registerButton.Interactable = isTradable && isAvailableSell;
+            registerButton.Interactable = isTradable && isAvailableSell && hasItem;
             detail.UpdateTradableText(isTradable);
         }
     }


### PR DESCRIPTION
### Description

- fungibleasset 툴팁에서 RegisterProduct.NonTradableTickerCurrencies 컬랙션에 속하지 않은 에셋들의 경우 tradeable 텍스트가 출력되도록 수정합니다.

### How to test

각 fungibleasset 툴팁에서 NonTradableTickerCurrencies에 속하지 않은 아이템들에 tradeable 텍스트가 정상적으로 표시되는지 확인합니다. 현재 가장 확인하기 쉬운 에셋들은 shop-sell, inventory-rune에서 확인할 수 있는 신성 등급 룬들 입니다.

### Related Links

https://github.com/planetarium/NineChronicles/issues/4820

