### PR TITLE
fix guest button refresh timing

### DIFF
--- a/nekoyume/Assets/_Scripts/Game/Game.cs
+++ b/nekoyume/Assets/_Scripts/Game/Game.cs
@@ -865,6 +865,12 @@ namespace Nekoyume.Game
                 }
             }
 
+            var introscreen = Widget.Find<IntroScreen>();
+            if(introscreen != null)
+            {
+                introscreen.GetGuestPrivateKey();
+            }
+
             NcDebug.Log("[Game] CommandLineOptions loaded");
             NcDebug.Log($"APV: {_commandLineOptions.AppProtocolVersion}");
             NcDebug.Log($"RPC: {_commandLineOptions.RpcServerHost}:{_commandLineOptions.RpcServerPort}");


### PR DESCRIPTION
언제부터인가 IntroScreen오브젝트의 초기화시점이 당겨지면서 게스트진입 버튼 초기화가 CommandLIneOption 이 세팅되기전에 실행되며 정상적으로 초기화되지않는문제로 확인되었습니다.

게스트진입 버튼 초기화 시점을 CommandLineOption 이후 시점으로 변경하고 추가 로그및 중복실행방지코드를 작성하였습니다.

OnLoadCommandlineOptions이 여러번불리는경우가 생기는것같은데 정리가 한번 필요해보입니다.