### PR TITLE
bug fix about cached state

### DIFF
--- a/nekoyume/Assets/_Scripts/Blockchain/ActionHandler.cs
+++ b/nekoyume/Assets/_Scripts/Blockchain/ActionHandler.cs
@@ -429,15 +429,15 @@ namespace Nekoyume.Blockchain
                 return;
             }
 
-            if (Game.Game.instance.CachedStates.ContainsKey((accountAddress,state.address)))
+            if (Game.Game.instance.CachedStates.ContainsKey(accountAddress.Derive(state.address.ToByteArray())))
             {
                 try
                 {
-                    Game.Game.instance.CachedStates[(accountAddress,state.address)] = state.Serialize();
+                    Game.Game.instance.CachedStates[accountAddress.Derive(state.address.ToByteArray())] = state.Serialize();
                 }
                 catch (NotSupportedException)
                 {
-                    Game.Game.instance.CachedStates[(accountAddress,state.address)] = state.SerializeList();
+                    Game.Game.instance.CachedStates[accountAddress.Derive(state.address.ToByteArray())] = state.SerializeList();
                 }
             }
         }

--- a/nekoyume/Assets/_Scripts/Blockchain/ActionHandler.cs
+++ b/nekoyume/Assets/_Scripts/Blockchain/ActionHandler.cs
@@ -309,7 +309,7 @@ namespace Nekoyume.Blockchain
 
         private static UniTask UpdateAgentStateAsync(AgentState state)
         {
-            UpdateCache(state);
+            UpdateCache(Addresses.Agent, state);
             return States.Instance.SetAgentStateAsync(state);
         }
 
@@ -402,7 +402,7 @@ namespace Nekoyume.Blockchain
                 }
             }
 
-            UpdateCache(avatarState);
+            UpdateCache(Addresses.Avatar, avatarState);
             await UpdateAvatarState(avatarState, States.Instance.CurrentAvatarKey);
         }
 
@@ -419,25 +419,25 @@ namespace Nekoyume.Blockchain
             CombinationSlotState state)
         {
             States.Instance.UpdateCombinationSlotState(avatarAddress, slotIndex, state);
-            UpdateCache(state);
+            UpdateCache(ReservedAddresses.LegacyAccount, state);
         }
 
-        private static void UpdateCache(Model.State.State state)
+        private static void UpdateCache(Address accountAddress, Model.State.State state)
         {
             if (state is null)
             {
                 return;
             }
 
-            if (Game.Game.instance.CachedStates.ContainsKey(state.address))
+            if (Game.Game.instance.CachedStates.ContainsKey((accountAddress,state.address)))
             {
                 try
                 {
-                    Game.Game.instance.CachedStates[state.address] = state.Serialize();
+                    Game.Game.instance.CachedStates[(accountAddress,state.address)] = state.Serialize();
                 }
                 catch (NotSupportedException)
                 {
-                    Game.Game.instance.CachedStates[state.address] = state.SerializeList();
+                    Game.Game.instance.CachedStates[(accountAddress,state.address)] = state.SerializeList();
                 }
             }
         }

--- a/nekoyume/Assets/_Scripts/Game/Game.cs
+++ b/nekoyume/Assets/_Scripts/Game/Game.cs
@@ -162,9 +162,9 @@ namespace Nekoyume.Game
 
         public Url URL { get; private set; }
 
-        public readonly LruCache<Address, IValue> CachedStates = new();
+        public readonly LruCache<(Address,Address), IValue> CachedStates = new();
 
-        public readonly Dictionary<Address, bool> CachedStateAddresses = new();
+        public readonly Dictionary<(Address,Address), bool> CachedStateAddresses = new();
 
         public readonly Dictionary<Currency, LruCache<Address, FungibleAssetValue>>
             CachedBalance = new();

--- a/nekoyume/Assets/_Scripts/Game/Game.cs
+++ b/nekoyume/Assets/_Scripts/Game/Game.cs
@@ -162,9 +162,9 @@ namespace Nekoyume.Game
 
         public Url URL { get; private set; }
 
-        public readonly LruCache<(Address,Address), IValue> CachedStates = new();
+        public readonly LruCache<Address, IValue> CachedStates = new();
 
-        public readonly Dictionary<(Address,Address), bool> CachedStateAddresses = new();
+        public readonly Dictionary<Address, bool> CachedStateAddresses = new();
 
         public readonly Dictionary<Currency, LruCache<Address, FungibleAssetValue>>
             CachedBalance = new();


### PR DESCRIPTION
### Description

1. State 캐싱에 버그가 있었습니다. 캐싱할때 AccountAddress를 무시하고 그냥 address만 캐싱하다보니, 다른 account에 같은 address로 상태를 캐싱하는 경우 잘못된 값을 캐시에서 가져오는 문제가 있었습니다.
2. 그래서 Dictionary의 키가 AccountAddress와 Address를 같이 저장하도록 수정했습니다.
3. 수정 이후 링크된 이슈와 관련된 버그는 재발하지 않았습니다.

### Related Links

resolve #4871 
