### PR TITLE
reset time scale on clear battle

### DIFF
--- a/nekoyume/Assets/_Scripts/Game/Battle/RaidStage.cs
+++ b/nekoyume/Assets/_Scripts/Game/Battle/RaidStage.cs
@@ -612,7 +612,7 @@ namespace Nekoyume.Game.Battle
             _currentPlayData = null;
             _isPlaying = false;
 
-            Time.timeScale = 1;
+            Time.timeScale = Game.DefaultTimeScale;
         }
     }
 }

--- a/nekoyume/Assets/_Scripts/Game/Battle/RaidStage.cs
+++ b/nekoyume/Assets/_Scripts/Game/Battle/RaidStage.cs
@@ -264,12 +264,8 @@ namespace Nekoyume.Game.Battle
                 yield return new WaitUntil(() => IsAvatarStateUpdatedAfterBattle);
             }
 
-            if (_battleCoroutine is not null)
-            {
-                StopCoroutine(_battleCoroutine);
-                _battleCoroutine = null;
-            }
-            _isPlaying = false;
+            ClearBattle();
+
             ActionRenderHandler.Instance.Pending = false;
             BattleRenderer.Instance.IsOnBattle = false;
             Widget.Find<WorldBossBattle>().Close();
@@ -607,14 +603,16 @@ namespace Nekoyume.Game.Battle
 
         private void ClearBattle()
         {
-            if (_battleCoroutine is not null)
+            if (_battleCoroutine != null)
             {
                 StopCoroutine(_battleCoroutine);
                 _battleCoroutine = null;
                 objectPool.ReleaseAll();
             }
             _currentPlayData = null;
-        }
+            _isPlaying = false;
 
+            Time.timeScale = 1;
+        }
     }
 }

--- a/nekoyume/Assets/_Scripts/Game/Game.cs
+++ b/nekoyume/Assets/_Scripts/Game/Game.cs
@@ -77,6 +77,8 @@ namespace Nekoyume.Game
     [RequireComponent(typeof(Agent), typeof(RPCAgent))]
     public class Game : MonoSingleton<Game>
     {
+        public const float DefaultTimeScale = 1.25f;
+
         [SerializeField]
         private Stage stage;
 

--- a/nekoyume/Assets/_Scripts/Game/Prologue.cs
+++ b/nekoyume/Assets/_Scripts/Game/Prologue.cs
@@ -32,8 +32,6 @@ namespace Nekoyume.Game
         private int _weaponId = 10151000;
         private int _characterId = 205007;
 
-        public const float DefaultTimeScale = 1.25f;
-
         public void StartPrologue()
         {
             StartCoroutine(CoStartPrologue());
@@ -271,7 +269,7 @@ namespace Nekoyume.Game
             yield return new WaitWhile(() => Widget.Find<PrologueDialogPopup>().isActiveAndEnabled);
             yield return StartCoroutine(_fenrir.CoFinisher(new[] {580214, 999999}, new[] {true, true}));
             yield return new WaitForSeconds(1f);
-            Time.timeScale = DefaultTimeScale;
+            Time.timeScale = Game.DefaultTimeScale;
             _fenrir.Animator.Idle();
         }
     }

--- a/nekoyume/Assets/_Scripts/Timeline/TimeScale/TimeScaleBehaviour.cs
+++ b/nekoyume/Assets/_Scripts/Timeline/TimeScale/TimeScaleBehaviour.cs
@@ -22,7 +22,7 @@ namespace Nekoyume
                 var inputWeight = playable.GetInputWeight(i);
                 if (!(inputWeight > 0f))
                 {
-                    Time.timeScale = Game.Prologue.DefaultTimeScale;
+                    Time.timeScale = Game.Game.DefaultTimeScale;
                     continue;
                 }
 

--- a/nekoyume/Assets/_Scripts/Timeline/TimeScale/TimeScaleTrack.cs
+++ b/nekoyume/Assets/_Scripts/Timeline/TimeScale/TimeScaleTrack.cs
@@ -11,7 +11,7 @@ namespace Nekoyume
         {
             var scriptPlayable = ScriptPlayable<TimeScaleBehaviour>.Create(graph, inputCount);
             var behaviour = scriptPlayable.GetBehaviour();
-            behaviour.timeScale = Game.Prologue.DefaultTimeScale;
+            behaviour.timeScale = Game.Game.DefaultTimeScale;
             return scriptPlayable;
         }
     }

--- a/nekoyume/Assets/_Scripts/UI/Widget/Menu.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Menu.cs
@@ -673,7 +673,7 @@ namespace Nekoyume.UI
             AirbridgeUnity.TrackEvent(evt);
 
             SubscribeAtShow();
-            Time.timeScale = Prologue.DefaultTimeScale;
+            Time.timeScale = Game.Game.DefaultTimeScale;
 
             if (!(_coLazyClose is null))
             {


### PR DESCRIPTION
### Description

월드보스 전투가 끝나고 타임스케일을 1로 리셋합니다

### How to test

월드보스 연출에서 속도가 느려지는 부분(에디터의 경우 RaidStage 오브젝트의 하위 오브젝트로 생성된 연출 오브젝트를 클릭한 후 타임스케일이 변경되는 타이밍을 확인가능)에 스킵을 하여 속도가 느려지지 않는지 확인합니다.

### Related Links

https://github.com/planetarium/NineChronicles/issues/4892
https://github.com/planetarium/NineChronicles/issues/4470

