### PR TITLE
improve Builder and android build CI

### DIFF
--- a/.github/workflows/android-build-and-release.yml
+++ b/.github/workflows/android-build-and-release.yml
@@ -25,17 +25,17 @@ on:
         description: "package name ex(com.planetariumlabs.ninechroniclesmobile)"
         required: false
         type: string
-        default: ""
+        default: "com.planetariumlabs.ninechroniclesmobile"
       cloud-project-id:
         description: "cloud project id ex(abcd-1234-xyz0)"
         required: false
         type: string
         default: ""
       player-name:
-        description: "player name ex(Nine Chronicles M)"
+        description: "player name ex(Nine-Chronicles-M -> Nine Chronicles M)"
         required: false
         type: string
-        default: ""
+        default: "Nine-Chronicles-M"
       other-google-services:
         description: "Please turn on the option when build other package"
         required: false
@@ -48,7 +48,7 @@ on:
         default: false
 
 concurrency: 
-  group: ${{ github.workflow }}-${{ github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.inputs.player-name }}
   cancel-in-progress: true
 
 env:
@@ -70,7 +70,11 @@ jobs:
           - nekoyume
         targetPlatform:
           - Android
-    environment: ${{ github.event.inputs.other-google-services && 'k' || 'main' }}
+    environment: |-
+      ${{ github.event.inputs.other-google-services == 'true' && 'k'
+      || github.ref_name == 'main' && 'main'
+      || startsWith(github.ref_name, 'release/') == 'true' && 'internal'
+      || '' }}
     env:
       GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
 
@@ -101,6 +105,12 @@ jobs:
       - name: Decode google-services.json File
         run: |
           echo "$GOOGLE_SERVICES_JSON" | base64 -d > ${{ matrix.projectPath }}/Assets/NineChronicles/GoogleServices/google-services.json
+
+      - name: Resolve AAR files
+        run: |
+          if [ '${{ github.event.inputs.other-google-services }}' == 'true' ]; then
+            sudo \cp -R ${{ matrix.projectPath }}/ResolvedAAR/. ${{ matrix.projectPath }}/Assets/Plugins/Android/
+          fi
 
       - name: Change cloudProjectId in ProjectSettings.asset
         run: |
@@ -155,10 +165,10 @@ jobs:
       - name: Move Folder
         run: |
           sudo mv $GITHUB_WORKSPACE/build /tmp/player
-          
+
       - name: Convert AAB to APKS
         run: |
-          sudo java -jar /tmp/bundletool-all-*.jar build-apks --bundle="/tmp/player/Android/Nine Chronicles M.aab" --output="/tmp/player/Android/result.apks" --ks="/tmp/9c-signing-keystore.keystore" --ks-pass=file:/tmp/keystore.pwd --ks-key-alias=$(cat /tmp/keyalias.name) --key-pass=file:/tmp/keyalias.pwd --mode=universal --local-testing
+          sudo java -jar /tmp/bundletool-all-*.jar build-apks --bundle="/tmp/player/Android/android-build.aab" --output="/tmp/player/Android/result.apks" --ks="/tmp/9c-signing-keystore.keystore" --ks-pass=file:/tmp/keystore.pwd --ks-key-alias=$(cat /tmp/keyalias.name) --key-pass=file:/tmp/keyalias.pwd --mode=universal --local-testing
 
       - name: Pack
         run: |
@@ -182,7 +192,7 @@ jobs:
           if-no-files-found: error
 
   extract:
-    if: startsWith(github.ref, 'refs/heads/release/') || startsWith(github.event.ref, 'refs/tags/') || github.event.inputs.manual_build_option
+    if: startsWith(github.ref, 'refs/heads/release/') || startsWith(github.event.ref, 'refs/tags/')
     needs: build
     runs-on: ubuntu-latest
     outputs:
@@ -201,7 +211,7 @@ jobs:
           fi
 
   release-to-google-play:
-    if: startsWith(github.ref, 'refs/heads/release/') || startsWith(github.event.ref, 'refs/tags/')|| github.event.inputs.manual_build_option
+    if: startsWith(github.ref, 'refs/heads/release/') || startsWith(github.event.ref, 'refs/tags/')
     name: Release to the Google Play Store
     runs-on: ubuntu-latest
     needs: ["extract"]
@@ -211,7 +221,7 @@ jobs:
       GOOGLE_PLAY_KEY_FILE: ${{ secrets.GOOGLE_PLAY_KEY_FILE }}
       GOOGLE_PLAY_KEY_FILE_PATH:
         ${{ format('{0}/fastlane/google-fastlane.json', github.workspace) }}
-      ANDROID_BUILD_FILE_PATH: ${{ format('{0}/build/Android/Nine Chronicles M.aab', github.workspace) }}
+      ANDROID_BUILD_FILE_PATH: ${{ format('{0}/build/Android/android-build.aab', github.workspace) }}
       ANDROID_PACKAGE_NAME: ${{ secrets.ANDROID_PACKAGE_NAME }}
     steps:
       - name: Checkout Repository

--- a/nekoyume/Assets/Editor/Builder.cs
+++ b/nekoyume/Assets/Editor/Builder.cs
@@ -258,7 +258,7 @@ namespace Editor
                     BuildTarget.StandaloneWindows or BuildTarget.StandaloneWindows64 =>
                         $"{PlayerName}.exe",
                     BuildTarget.Android =>
-                        $"{PlayerName}.{(EditorUserBuildSettings.buildAppBundle ? "aab" : "apk")}",
+                        $"android-build.{(EditorUserBuildSettings.buildAppBundle ? "aab" : "apk")}",
                     _ => PlayerName,
                 }
             );
@@ -544,9 +544,9 @@ namespace Editor
                 }
 
                 if (cliOptions.TryGetValue("playerName", out var outPlayerName) &&
-                    !string.IsNullOrEmpty(outPath))
+                    !string.IsNullOrEmpty(outPlayerName))
                 {
-                    PlayerName = outPlayerName;
+                    PlayerName = outPlayerName.Replace("-", " ");
                 }
             }
         }

--- a/tools/pack/pack.py
+++ b/tools/pack/pack.py
@@ -83,7 +83,7 @@ ZIP = {
 
 
 def cleanup_debug_dir(build_result_dir: str, isMobile: bool):
-    build_name = "Nine Chronicles M" if isMobile else "NineChronicles" 
+    build_name = "android-build" if isMobile else "NineChronicles" 
     shutil.rmtree(os.path.join(build_result_dir,
                   f"{build_name}_BurstDebugInformation_DoNotShip"))
 


### PR DESCRIPTION
add ci trigger, reflect pack.py about changed binary name

### Description

1. change android build binary name(`Nine Chronicles M` -> `android-build`)
2. add ci trigger and field for another build

### How to test

1. check this [9cM build action](https://github.com/planetarium/NineChronicles/actions/runs/9107181220)
2. check this [9cK build action](https://github.com/planetarium/NineChronicles/actions/runs/9107236177)

### Related Links

resolve #4913 

### Screenshot
![image](https://github.com/planetarium/NineChronicles/assets/48484989/021d9689-2a3e-4e17-8f7f-d0ecda107547)
