### PR TITLE
add ruby dust material control

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Module/Button/SimpleCostButton.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/Button/SimpleCostButton.cs
@@ -108,6 +108,7 @@ namespace Nekoyume.UI.Module
                 // For material costs
                 case CostType.SilverDust:
                 case CostType.GoldDust:
+                case CostType.RubyDust:
                     inventory = States.Instance.CurrentAvatarState.inventory;
                     var materialCount = inventory.GetMaterialCount((int)type);
                     return materialCount >= cost;

--- a/nekoyume/Assets/_Scripts/UI/Widget/Popup/MaterialNavigationPopup.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Popup/MaterialNavigationPopup.cs
@@ -274,6 +274,7 @@ namespace Nekoyume.UI
                     break;
                 case CostType.SilverDust:
                 case CostType.GoldDust:
+                case CostType.RubyDust:
                     itemId = (int)costType;
                     var materialCount =
                         States.Instance.CurrentAvatarState.inventory.GetMaterialCount(itemId);


### PR DESCRIPTION
### Description

루비 더스트 재화 관련 팝업 / 코스트 제한 체크 로직을 추가합니다.

### How to test

1. 루비더스트가 부족한 경우 루비더스트를 재화로 사용하는 재화에 재화가 부족하다는 표시가 뜨는지 확인합니다.
2. 상단 메터리얼 UI에서 루비더스트 재화 클릭시 정보가 표시되도록 변경합니다.
3. 루비더스트 구매 관련 정보는 골드더스트와 같이 Shop으로 표시되도록 설정하였습니다.

https://github.com/planetarium/NineChronicles/issues/4841
