### PR TITLE
android CICD for 9cK

### DIFF
--- a/.github/workflows/android-build-and-release-for-9ck.yml
+++ b/.github/workflows/android-build-and-release-for-9ck.yml
@@ -1,0 +1,228 @@
+name: Android Build and Release
+
+on:
+  push:
+    branches:
+      - release/*
+      - fast-track/*
+    tags: ["*"]
+  workflow_dispatch:
+    inputs:
+      version-code:
+        description: "Google Play Console VersionCode"
+      app-version:
+        description: "Google Play Console VersionName ex(40.0.0)"
+      package-name:
+        description: "package name ex(com.planetariumlabs.ninechroniclesmobile)"
+        required: false
+        type: string
+        default: "com.planetariumlabs.ninechroniclesmobilek"
+      cloud-project-id:
+        description: "cloud project id ex(abcd-1234-xyz0)"
+        required: false
+        type: string
+        default: "fa57c419-1189-418d-951c-055e5f9738d0"
+      player-name:
+        description: "player name ex(Nine-Chronicles-M -> Nine Chronicles M)"
+        required: false
+        type: string
+        default: "Nine-Chronicles-K"
+      other-google-services:
+        description: "Please turn on the option when build other package"
+        required: false
+        type: boolean
+        default: false
+      manual_build_option:
+        description: "Please turn on the option when manually executing the action"
+        type: boolean
+        required: false
+        default: false
+
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.ref_name }}-K
+  cancel-in-progress: true
+
+env:
+  UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+  UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+  UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
+
+jobs:
+  build:
+    name: Build for ${{ matrix.targetPlatform }}
+    runs-on:
+      labels: ["linux", "8cores"]
+    defaults:
+        run:
+          shell: bash
+    strategy:
+      matrix:
+        projectPath:
+          - nekoyume
+        targetPlatform:
+          - Android
+    environment:
+      name: k
+    env:
+      GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
+
+    steps:
+      - name: Set CRLF
+        run: |
+          git config --global core.autocrlf true
+
+      - uses: actions/checkout@v3
+        with:
+          lfs: true
+          submodules: true
+
+      - uses: actions/cache@v3
+        with:
+          path: ${{ matrix.projectPath }}/Library
+          key: Library-${{ matrix.projectPath }}-ubuntu-${{ matrix.targetPlatform }}
+          restore-keys: |
+            Library-${{ matrix.projectPath }}-ubuntu-
+            Library-
+
+      - name: Decode google-services.json File
+        run: |
+          echo "$GOOGLE_SERVICES_JSON" | base64 -d > ${{ matrix.projectPath }}/Assets/NineChronicles/GoogleServices/google-services.json
+
+      - name: Resolve AAR files
+        run: |
+          sudo \cp -R ${{ matrix.projectPath }}/ResolvedAAR/. ${{ matrix.projectPath }}/Assets/Plugins/Android/
+
+      - name: Change cloudProjectId in ProjectSettings.asset
+        run: |
+          sed -i '/cloudProjectId/c\  cloudProjectId: fa57c419-1189-418d-951c-055e5f9738d0' ${{ matrix.projectPath }}/ProjectSettings/ProjectSettings.asset
+          cat ${{ matrix.projectPath }}/ProjectSettings/ProjectSettings.asset
+
+      - uses: game-ci/unity-builder@v4
+        with:
+          androidKeystoreName: 9c-aos-signing-keystore.keystore # This file won't exist, but this property needs to exist.
+          androidKeystoreBase64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+          androidKeystorePass: ${{ secrets.ANDROID_KEYSTORE_PASS }}
+          androidKeyaliasName: ${{ secrets.ANDROID_KEY_ALIAS_NAME }}
+          androidKeyaliasPass: ${{ secrets.ANDROID_KEY_ALIAS_PASS }}
+          androidExportType: 'androidAppBundle'
+          projectPath: ${{ matrix.projectPath }}
+          targetPlatform: ${{ matrix.targetPlatform }}
+          buildMethod: 'Editor.Builder.Build${{ matrix.targetPlatform }}'
+          buildName: ${{ matrix.targetPlatform }}
+          androidVersionCode: ${{ github.event.inputs.version-code }}
+          version: ${{ github.event.inputs.app-version }}
+          androidTargetSdkVersion: AndroidApiLevel33
+          customParameters: -identifier com.planetariumlabs.ninechroniclesmobilek -playerName Nine-Chronicles-K
+          allowDirtyBuild: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.11.0
+
+      - name: Install bundletool
+        run: |
+          tr -d "\r" < .github/bin/install-bundletool.sh > .github/bin/install-bundletool-trimed.sh
+          bash .github/bin/install-bundletool-trimed.sh /tmp
+
+      - name: Setup Keystore and Passwords
+        run: |
+          echo "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" | base64 -d > /tmp/9c-signing-keystore.keystore
+          echo "${{ secrets.ANDROID_KEYSTORE_PASS }}" > /tmp/keystore.pwd
+          echo "${{ secrets.ANDROID_KEY_ALIAS_NAME }}" > /tmp/keyalias.name
+          echo "${{ secrets.ANDROID_KEY_ALIAS_PASS }}" > /tmp/keyalias.pwd
+
+      - name: Set up Java
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+
+      - name: Print file content
+        run: ls -R $GITHUB_WORKSPACE/build
+
+      - name: Move Folder
+        run: |
+          sudo mv $GITHUB_WORKSPACE/build /tmp/player
+
+      - name: Convert AAB to APKS
+        run: |
+          sudo java -jar /tmp/bundletool-all-*.jar build-apks --bundle="/tmp/player/Android/android-build.aab" --output="/tmp/player/Android/result.apks" --ks="/tmp/9c-signing-keystore.keystore" --ks-pass=file:/tmp/keystore.pwd --ks-key-alias=$(cat /tmp/keyalias.name) --key-pass=file:/tmp/keyalias.pwd --mode=universal --local-testing
+
+      - name: Pack
+        run: |
+          targetPlatform=${{ matrix.targetPlatform }}
+
+          tr -d "\r" < .github/bin/pack.sh > .github/bin/pack_trimed.sh
+          rm .github/bin/pack.sh
+          mv .github/bin/pack_trimed.sh .github/bin/pack.sh
+
+          pip3 install wheel
+          sudo bash .github/bin/pack.sh \
+          /tmp/packages \
+          "${{ matrix.targetPlatform }}" \
+          "/tmp/player"
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: Build-${{ matrix.targetPlatform }}
+          path: /tmp/packages
+          retention-days: 7
+          if-no-files-found: error
+
+  extract:
+    if: startsWith(github.ref, 'refs/heads/release/') || startsWith(github.event.ref, 'refs/tags/') || github.event.inputs.manual_build_option
+    needs: build
+    runs-on: ubuntu-latest
+    outputs:
+      network: ${{ steps.extract.outputs.network }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: extract
+        id: extract
+        run: |
+          if [[ "${{ startsWith(github.ref, 'refs/heads/release/') }}" == "true" || "${{ github.event.inputs.manual_build_option }}" == "true" ]]; then
+              echo "::set-output name=network::internal"
+          elif [[ "${{ startsWith(github.event.ref, 'refs/tags/') }}" == "true" ]]; then
+              echo "::set-output name=network::main"
+          else
+            echo "::set-output name=network::null"
+          fi
+
+  release-to-google-play:
+    if: startsWith(github.ref, 'refs/heads/release/') || startsWith(github.event.ref, 'refs/tags/') || github.event.inputs.manual_build_option
+    name: Release to the Google Play Store
+    runs-on: ubuntu-latest
+    needs: ["extract"]
+    environment:
+      name: ${{ needs.extract.outputs.network }}
+    env:
+      GOOGLE_PLAY_KEY_FILE: ${{ secrets.GOOGLE_PLAY_KEY_FILE }}
+      GOOGLE_PLAY_KEY_FILE_PATH:
+        ${{ format('{0}/fastlane/google-fastlane.json', github.workspace) }}
+      ANDROID_BUILD_FILE_PATH: ${{ format('{0}/build/Android/android-build.aab', github.workspace) }}
+      ANDROID_PACKAGE_NAME: com.planetariumlabs.ninechroniclesmobilek
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+      - name: Download Android Artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: Build-Android
+          path: build
+      - name: unzip artifact for deployment
+        run: |
+          mkdir -p build/Android
+          unzip build/Android.zip -d build/Android
+      - name: Add Authentication
+        run: |
+          echo ${{secrets.GOOGLE_PLAY_KEY_FILE}} | base64 -d > ${{ env.GOOGLE_PLAY_KEY_FILE_PATH }}
+      - name: Set up Fastlane
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7.2
+          bundler-cache: true
+      - name: Upload to Google Play Internal
+        uses: maierj/fastlane-action@v3.0.0
+        with:
+          lane: 'android internal'

--- a/.github/workflows/ios-build-and-release-for-9ck.yml
+++ b/.github/workflows/ios-build-and-release-for-9ck.yml
@@ -5,10 +5,7 @@ on:
     branches:
       - main
       - release/*
-      - fast-track/*
     tags: ["*"]
-  pull_request:
-    types: [ready_for_review, opened, reopened, auto_merge_enabled]
   workflow_dispatch:
     inputs:
       clo:
@@ -63,7 +60,7 @@ jobs:
       MATCH_REPOSITORY_ACCOUNT: ${{ secrets.MATCH_REPOSITORY_ACCOUNT }}
       USYM_UPLOAD_AUTH_TOKEN: 'fake'
       GOOGLE_SERVICE_INFO: ${{ secrets.GOOGLE_SERVICE_INFO_K }}
-    
+
     steps:
       - name: Set CRLF
         run: |


### PR DESCRIPTION
### Description

1. release 브랜치에 커밋을 쌓거나 다른데서 태그를 달면 9cK 빌드 및 내부테스트 배포가 올라가도록 구축했습니다.

### How to test

1. check this https://github.com/planetarium/NineChronicles/actions/runs/9204570897/job/25319251866
![image](https://github.com/planetarium/NineChronicles/assets/48484989/6eab2077-8d41-41dd-935c-29238912a993)


### Related Links

resolve #4950 
