### PR TITLE
Feature/battle freeze

### DIFF
--- a/nekoyume/Assets/_Scripts/Game/Battle/Stage.cs
+++ b/nekoyume/Assets/_Scripts/Game/Battle/Stage.cs
@@ -28,7 +28,6 @@ using Nekoyume.Game.VFX.Skill;
 using Nekoyume.Helper;
 using Nekoyume.Model;
 using Nekoyume.Model.BattleStatus;
-using Nekoyume.Model.Buff;
 using Nekoyume.Model.Item;
 using Nekoyume.Model.Skill;
 using Nekoyume.Model.State;
@@ -1013,6 +1012,10 @@ namespace Nekoyume.Game.Battle
             if (infosFirstWaveTurn > 0)
             {
                 yield return new WaitUntil(() => Time.time - time > 5f || waveTurn == infosFirstWaveTurn);
+                if (Time.time - time > 5f)
+                {
+                    NcDebug.LogWarning($"Time out. waveTurn: {waveTurn}, infosFirstWaveTurn: {infosFirstWaveTurn}");
+                }
             }
 
             yield return StartCoroutine(CoBeforeSkill(character));
@@ -1062,6 +1065,11 @@ namespace Nekoyume.Game.Battle
             var time = Time.time;
             yield return new WaitUntil(() =>
                 Time.time - time > 2f || character.TargetInAttackRange(enemy));
+            
+            if (Time.time - time > 2f)
+            {
+                NcDebug.LogWarning($"Time out. character: {character.Id}, enemy: {enemy.Id}");
+            }
         }
 
         private IEnumerator CoAfterSkill(Actor character, IEnumerable<Skill.SkillInfo> buffInfos)

--- a/nekoyume/Assets/_Scripts/Game/Character/Actor.cs
+++ b/nekoyume/Assets/_Scripts/Game/Character/Actor.cs
@@ -1141,7 +1141,7 @@ namespace Nekoyume.Game.Character
             foreach (var info in _action.skillInfos)
             {
                 var target = info.Target;
-                if (target == null || target.IsDead)
+                if (target == null || !target.IsDead)
                 {
                     continue;
                 }

--- a/nekoyume/Assets/_Scripts/Game/Character/Actor.cs
+++ b/nekoyume/Assets/_Scripts/Game/Character/Actor.cs
@@ -1153,6 +1153,11 @@ namespace Nekoyume.Game.Character
 
                 var time = Time.time;
                 yield return new WaitUntil(() => Time.time - time > 10f || !targetActor.HasAction());
+                if (Time.time - time > 10f)
+                {
+                    NcDebug.LogError($"[{nameof(Actor)}] CoExecuteAction Timeout. {gameObject.name}");
+                    break;
+                }
             }
 
             yield return new WaitForSeconds(StageConfig.instance.actionDelay);

--- a/nekoyume/ProjectSettings/ProjectSettings.asset
+++ b/nekoyume/ProjectSettings/ProjectSettings.asset
@@ -168,7 +168,7 @@ PlayerSettings:
     iPhone: 0
     tvOS: 0
   overrideDefaultApplicationIdentifier: 1
-  AndroidBundleVersionCode: 206
+  AndroidBundleVersionCode: 207
   AndroidMinSdkVersion: 22
   AndroidTargetSdkVersion: 33
   AndroidPreferredInstallLocation: 2


### PR DESCRIPTION
### Description

지금 전투중 멈추는거는 죽은 몬스터의 연출을 기달리던것을 제가 상대 몬스터의 연출을 기다리는것으로 확장해서 해석해서 적용해버려 생긴 일인데, 플레이어와 몬스터가 동시에 스킬을 사용하는 케이스들이 있어 해당 케이스에서 발생하는것같네요. 이를 죽은 몬스터 연출 기다리는것으로 되돌려놓으니 멈추는 현상 발생하지 않는것같아 이대로 돌려놓겠습니다.

https://github.com/planetarium/NineChronicles/issues/4963