### PR TITLE
Feature/refactor vfx

### DIFF
--- a/nekoyume/Assets/Resources/ScriptableObject/BuffVFXData.asset
+++ b/nekoyume/Assets/Resources/ScriptableObject/BuffVFXData.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 510b4ed31bf193f4595806794f747a2b, type: 3}
   m_Name: BuffVFXData
   m_EditorClassIdentifier: 
-  DataList:
+  <DataList>k__BackingField:
   - StatType: 1
     PlusIcon: {fileID: 21300000, guid: c4377040b973b41eb82d99b5e2022d75, type: 3}
     MinusIcon: {fileID: 21300000, guid: 0e3b4f674f3b24e9a82bca31a8e7a4ca, type: 3}
@@ -134,7 +134,7 @@ MonoBehaviour:
       type: 3}
     MinusVFX: {fileID: 7837708294353371776, guid: c0b45884b3a1a8447b760337c0618eaa,
       type: 3}
-  OverrideDataList:
+  <OverrideDataList>k__BackingField:
   - Id: 500001
     Icon: {fileID: 21300000, guid: a3c38c985c66a42b1b20aaaba99934b1, type: 3}
     CastingVFX: {fileID: 5166876917278104467, guid: 5b2f8b6efafe66b4b864000303377aab,
@@ -249,7 +249,7 @@ MonoBehaviour:
       type: 3}
     BuffVFX: {fileID: 1597932600176430146, guid: a812dcf0b3bedf84dbcd7d96f139d3c4,
       type: 3}
-  BuffPosOverrideDataList:
+  <BuffPosOverrideDataList>k__BackingField:
   - Id: 708000
     IsCasting: 0
     Position: {x: 0, y: 0, z: 0}
@@ -265,21 +265,15 @@ MonoBehaviour:
   - Id: 709000
     IsCasting: 1
     Position: {x: 0, y: 1.1, z: 0}
-  - Id: 709001
-    IsCasting: 0
-    Position: {x: 0, y: 1.1, z: 0}
-  - Id: 709001
-    IsCasting: 1
-    Position: {x: 0, y: 1.1, z: 0}
-  - Id: 709002
-    IsCasting: 0
-    Position: {x: 0, y: 1.1, z: 0}
-  - Id: 709002
-    IsCasting: 1
-    Position: {x: 0, y: 1.1, z: 0}
-  FallbackIcon: {fileID: 21300000, guid: 39d46914ec312d8469b6bb4740099db4, type: 3}
-  FallbackCastingVFX: {fileID: 2327172370517842916, guid: 8e07f2c1b187b68428f03f03327fa497,
+   <FallbackIcon>k__BackingField: {fileID: 21300000, guid: 39d46914ec312d8469b6bb4740099db4,
     type: 3}
-  FallbackBuffVFX: {fileID: 7756120939619406518, guid: 18a90bf73ccf9834db3f450f3e3b3278,
+  <FallbackCastingVFX>k__BackingField: {fileID: 2327172370517842916, guid: 8e07f2c1b187b68428f03f03327fa497,
     type: 3}
-  FallbackPosition: {x: 0, y: 0.55, z: 0}
+  <FallbackBuffVFX>k__BackingField: {fileID: 7756120939619406518, guid: 18a90bf73ccf9834db3f450f3e3b3278,
+    type: 3}
+  <FallbackPosition>k__BackingField: {x: 0, y: 0.55, z: 1}
+X>k__BackingField: {fileID: 2327172370517842916, guid: 8e07f2c1b187b68428f03f03327fa497,
+    type: 3}
+  <FallbackBuffVFX>k__BackingField: {fileID: 7756120939619406518, guid: 18a90bf73ccf9834db3f450f3e3b3278,
+    type: 3}
+  <FallbackPosition>k__BackingField: {x: 0, y: 0.55, z: 0}

--- a/nekoyume/Assets/Resources/ScriptableObject/BuffVFXData.asset
+++ b/nekoyume/Assets/Resources/ScriptableObject/BuffVFXData.asset
@@ -135,30 +135,6 @@ MonoBehaviour:
     MinusVFX: {fileID: 7837708294353371776, guid: c0b45884b3a1a8447b760337c0618eaa,
       type: 3}
   <OverrideDataList>k__BackingField:
-  - Id: 500001
-    Icon: {fileID: 21300000, guid: a3c38c985c66a42b1b20aaaba99934b1, type: 3}
-    CastingVFX: {fileID: 5166876917278104467, guid: 5b2f8b6efafe66b4b864000303377aab,
-      type: 3}
-    BuffVFX: {fileID: 7171611368931243746, guid: 717216517b03d4c57bae5a9a59286335,
-      type: 3}
-  - Id: 500002
-    Icon: {fileID: 21300000, guid: a3c38c985c66a42b1b20aaaba99934b1, type: 3}
-    CastingVFX: {fileID: 5166876917278104467, guid: 5b2f8b6efafe66b4b864000303377aab,
-      type: 3}
-    BuffVFX: {fileID: 7171611368931243746, guid: 717216517b03d4c57bae5a9a59286335,
-      type: 3}
-  - Id: 500003
-    Icon: {fileID: 21300000, guid: a3c38c985c66a42b1b20aaaba99934b1, type: 3}
-    CastingVFX: {fileID: 5166876917278104467, guid: 5b2f8b6efafe66b4b864000303377aab,
-      type: 3}
-    BuffVFX: {fileID: 7171611368931243746, guid: 717216517b03d4c57bae5a9a59286335,
-      type: 3}
-  - Id: 600001
-    Icon: {fileID: 21300000, guid: a3c38c985c66a42b1b20aaaba99934b1, type: 3}
-    CastingVFX: {fileID: 5166876917278104467, guid: 5b2f8b6efafe66b4b864000303377aab,
-      type: 3}
-    BuffVFX: {fileID: 7171611368931243746, guid: 717216517b03d4c57bae5a9a59286335,
-      type: 3}
   - Id: 701000
     Icon: {fileID: 21300000, guid: b44fd3fdbb6304b45aa8a18aad5db6d5, type: 3}
     CastingVFX: {fileID: 5166876917278104467, guid: 5e3a035730f654cc5a4edd3cee17a180,
@@ -176,60 +152,6 @@ MonoBehaviour:
     CastingVFX: {fileID: 5166876917278104467, guid: 5b2f8b6efafe66b4b864000303377aab,
       type: 3}
     BuffVFX: {fileID: 1391978601354276969, guid: bcbcfa4b5d2e148ed94d37debecd2d34,
-      type: 3}
-  - Id: 704000
-    Icon: {fileID: 21300000, guid: 84b2b543cf286054a8c1ca1f7d651c85, type: 3}
-    CastingVFX: {fileID: 5166876917278104467, guid: 96b1b4bff4a56f249a2c0b5bd7b05bba,
-      type: 3}
-    BuffVFX: {fileID: 5359811590792080300, guid: 22f1ce67a3f7c5c4e80923d30d7507bf,
-      type: 3}
-  - Id: 704001
-    Icon: {fileID: 21300000, guid: 84b2b543cf286054a8c1ca1f7d651c85, type: 3}
-    CastingVFX: {fileID: 5166876917278104467, guid: 96b1b4bff4a56f249a2c0b5bd7b05bba,
-      type: 3}
-    BuffVFX: {fileID: 5359811590792080300, guid: 22f1ce67a3f7c5c4e80923d30d7507bf,
-      type: 3}
-  - Id: 705000
-    Icon: {fileID: 21300000, guid: 57a7c7f4be51432478858aafb6f53b71, type: 3}
-    CastingVFX: {fileID: 2280207480576973039, guid: 6b823acc2182e4f45ab6ee216761e7c8,
-      type: 3}
-    BuffVFX: {fileID: 6607344730775082401, guid: c0623a33e4f1fd94cace5dd3cfd158a4,
-      type: 3}
-  - Id: 706000
-    Icon: {fileID: 21300000, guid: 987237b059aecf8479124be78b862e09, type: 3}
-    CastingVFX: {fileID: 567492925472903853, guid: d7a82287ca7c1cb429791e364b7831a7,
-      type: 3}
-    BuffVFX: {fileID: 6480292753974600568, guid: 837736bf1d83a0545b2e6dd3548f0ed1,
-      type: 3}
-  - Id: 707000
-    Icon: {fileID: 21300000, guid: b2c3ad93baec3614baf400a8ac26c2e9, type: 3}
-    CastingVFX: {fileID: 517495102393359299, guid: 271ea9a1d7475434393c24f4739ef06e,
-      type: 3}
-    BuffVFX: {fileID: 5068662467704735941, guid: 36d05c79df5e4a847934261885229a83,
-      type: 3}
-  - Id: 707001
-    Icon: {fileID: 21300000, guid: b2c3ad93baec3614baf400a8ac26c2e9, type: 3}
-    CastingVFX: {fileID: 517495102393359299, guid: 271ea9a1d7475434393c24f4739ef06e,
-      type: 3}
-    BuffVFX: {fileID: 5068662467704735941, guid: 36d05c79df5e4a847934261885229a83,
-      type: 3}
-  - Id: 708000
-    Icon: {fileID: 21300000, guid: 7eddbb706b01b0048bf1e2958013ba31, type: 3}
-    CastingVFX: {fileID: 5986082888471747642, guid: d2dbf19aefdb0fd42b42c65c4d46301c,
-      type: 3}
-    BuffVFX: {fileID: 8503561367185379965, guid: 756b29425ce20a848ba8a8686b086942,
-      type: 3}
-  - Id: 708001
-    Icon: {fileID: 21300000, guid: 7eddbb706b01b0048bf1e2958013ba31, type: 3}
-    CastingVFX: {fileID: 5986082888471747642, guid: d2dbf19aefdb0fd42b42c65c4d46301c,
-      type: 3}
-    BuffVFX: {fileID: 8503561367185379965, guid: 756b29425ce20a848ba8a8686b086942,
-      type: 3}
-  - Id: 708002
-    Icon: {fileID: 21300000, guid: 7eddbb706b01b0048bf1e2958013ba31, type: 3}
-    CastingVFX: {fileID: 5986082888471747642, guid: d2dbf19aefdb0fd42b42c65c4d46301c,
-      type: 3}
-    BuffVFX: {fileID: 8503561367185379965, guid: 756b29425ce20a848ba8a8686b086942,
       type: 3}
   - Id: 709000
     Icon: {fileID: 21300000, guid: 8bc7f399af0f54c4a83c9f407283e061, type: 3}
@@ -249,6 +171,43 @@ MonoBehaviour:
       type: 3}
     BuffVFX: {fileID: 1597932600176430146, guid: a812dcf0b3bedf84dbcd7d96f139d3c4,
       type: 3}
+  <ActionBuffVFXOverrideDataList>k__BackingField:
+  - Type: 0
+    Icon: {fileID: 21300000, guid: a3c38c985c66a42b1b20aaaba99934b1, type: 3}
+    CastingVFX: {fileID: 5166876917278104467, guid: 5b2f8b6efafe66b4b864000303377aab,
+      type: 3}
+    BuffVFX: {fileID: 7171611368931243746, guid: 717216517b03d4c57bae5a9a59286335,
+      type: 3}
+  - Type: 1
+    Icon: {fileID: 21300000, guid: 84b2b543cf286054a8c1ca1f7d651c85, type: 3}
+    CastingVFX: {fileID: 5166876917278104467, guid: 96b1b4bff4a56f249a2c0b5bd7b05bba,
+      type: 3}
+    BuffVFX: {fileID: 5359811590792080300, guid: 22f1ce67a3f7c5c4e80923d30d7507bf,
+      type: 3}
+  - Type: 2
+    Icon: {fileID: 21300000, guid: 57a7c7f4be51432478858aafb6f53b71, type: 3}
+    CastingVFX: {fileID: 2280207480576973039, guid: 6b823acc2182e4f45ab6ee216761e7c8,
+      type: 3}
+    BuffVFX: {fileID: 6607344730775082401, guid: c0623a33e4f1fd94cace5dd3cfd158a4,
+      type: 3}
+  - Type: 3
+    Icon: {fileID: 21300000, guid: 987237b059aecf8479124be78b862e09, type: 3}
+    CastingVFX: {fileID: 567492925472903853, guid: d7a82287ca7c1cb429791e364b7831a7,
+      type: 3}
+    BuffVFX: {fileID: 6480292753974600568, guid: 837736bf1d83a0545b2e6dd3548f0ed1,
+      type: 3}
+  - Type: 4
+    Icon: {fileID: 21300000, guid: 7eddbb706b01b0048bf1e2958013ba31, type: 3}
+    CastingVFX: {fileID: 517495102393359299, guid: 271ea9a1d7475434393c24f4739ef06e,
+      type: 3}
+    BuffVFX: {fileID: 5068662467704735941, guid: 36d05c79df5e4a847934261885229a83,
+      type: 3}
+  - Type: 5
+    Icon: {fileID: 21300000, guid: 7eddbb706b01b0048bf1e2958013ba31, type: 3}
+    CastingVFX: {fileID: 5986082888471747642, guid: d2dbf19aefdb0fd42b42c65c4d46301c,
+      type: 3}
+    BuffVFX: {fileID: 8503561367185379965, guid: 756b29425ce20a848ba8a8686b086942,
+      type: 3}
   <BuffPosOverrideDataList>k__BackingField:
   - Id: 708000
     IsCasting: 0
@@ -265,15 +224,10 @@ MonoBehaviour:
   - Id: 709000
     IsCasting: 1
     Position: {x: 0, y: 1.1, z: 0}
-   <FallbackIcon>k__BackingField: {fileID: 21300000, guid: 39d46914ec312d8469b6bb4740099db4,
+  <FallbackIcon>k__BackingField: {fileID: 21300000, guid: 39d46914ec312d8469b6bb4740099db4,
     type: 3}
   <FallbackCastingVFX>k__BackingField: {fileID: 2327172370517842916, guid: 8e07f2c1b187b68428f03f03327fa497,
     type: 3}
   <FallbackBuffVFX>k__BackingField: {fileID: 7756120939619406518, guid: 18a90bf73ccf9834db3f450f3e3b3278,
     type: 3}
   <FallbackPosition>k__BackingField: {x: 0, y: 0.55, z: 1}
-X>k__BackingField: {fileID: 2327172370517842916, guid: 8e07f2c1b187b68428f03f03327fa497,
-    type: 3}
-  <FallbackBuffVFX>k__BackingField: {fileID: 7756120939619406518, guid: 18a90bf73ccf9834db3f450f3e3b3278,
-    type: 3}
-  <FallbackPosition>k__BackingField: {x: 0, y: 0.55, z: 0}

--- a/nekoyume/Assets/Resources/ScriptableObject/BuffVFXData.asset
+++ b/nekoyume/Assets/Resources/ScriptableObject/BuffVFXData.asset
@@ -209,21 +209,16 @@ MonoBehaviour:
     BuffVFX: {fileID: 8503561367185379965, guid: 756b29425ce20a848ba8a8686b086942,
       type: 3}
   <BuffPosOverrideDataList>k__BackingField:
-  - Id: 708000
-    IsCasting: 0
-    Position: {x: 0, y: 0, z: 0}
-  - Id: 708001
-    IsCasting: 0
-    Position: {x: 0, y: 0, z: 0}
-  - Id: 708002
-    IsCasting: 0
-    Position: {x: 0, y: 0, z: 0}
   - Id: 709000
     IsCasting: 0
     Position: {x: 0, y: 1.1, z: 0}
   - Id: 709000
     IsCasting: 1
     Position: {x: 0, y: 1.1, z: 0}
+  <ActionBuffPosOverrideDataList>k__BackingField:
+  - Type: 5
+    IsCasting: 0
+    Position: {x: 0, y: 0, z: 0}
   <FallbackIcon>k__BackingField: {fileID: 21300000, guid: 39d46914ec312d8469b6bb4740099db4,
     type: 3}
   <FallbackCastingVFX>k__BackingField: {fileID: 2327172370517842916, guid: 8e07f2c1b187b68428f03f03327fa497,

--- a/nekoyume/Assets/Resources/ScriptableObject/BuffVFXData.asset
+++ b/nekoyume/Assets/Resources/ScriptableObject/BuffVFXData.asset
@@ -215,6 +215,18 @@ MonoBehaviour:
   - Id: 709000
     IsCasting: 1
     Position: {x: 0, y: 1.1, z: 0}
+  - Id: 709001
+    IsCasting: 0
+    Position: {x: 0, y: 1.1, z: 0}
+  - Id: 709001
+    IsCasting: 1
+    Position: {x: 0, y: 1.1, z: 0}
+  - Id: 709002
+    IsCasting: 0
+    Position: {x: 0, y: 1.1, z: 0}
+  - Id: 709002
+    IsCasting: 1
+    Position: {x: 0, y: 1.1, z: 0}
   <ActionBuffPosOverrideDataList>k__BackingField:
   - Type: 5
     IsCasting: 0

--- a/nekoyume/Assets/_Scripts/Game/ScriptableObject/BuffVFXScriptableObject.cs
+++ b/nekoyume/Assets/_Scripts/Game/ScriptableObject/BuffVFXScriptableObject.cs
@@ -5,18 +5,17 @@ using UnityEngine;
 
 namespace Nekoyume
 {
-    [CreateAssetMenu(fileName = "BuffVFXData",
-        menuName = "Scriptable Object/Buff VFX Data",
-        order = int.MaxValue)]
+    [CreateAssetMenu(fileName = "BuffVFXData", menuName = "Scriptable Object/Buff VFX Data", order = int.MaxValue)]
     public class BuffVFXScriptableObject : ScriptableObject
     {
-        public List<BuffVFXData> DataList;
-        public List<BuffVFXOverrideData> OverrideDataList;
-        public List<BuffPosOverrideData> BuffPosOverrideDataList;
-        public Sprite FallbackIcon;
-        public GameObject FallbackCastingVFX;
-        public GameObject FallbackBuffVFX;
-        public Vector3 FallbackPosition;
+        [field:SerializeField] public List<BuffVFXData> DataList { get; set; }
+        [field:SerializeField] public List<BuffVFXOverrideData> OverrideDataList { get; set; }
+        [field:SerializeField] public List<BuffPosOverrideData> BuffPosOverrideDataList { get;  set; }
+        
+        [field:SerializeField] public Sprite     FallbackIcon       { get; set; }
+        [field:SerializeField] public GameObject FallbackCastingVFX { get; set; }
+        [field:SerializeField] public GameObject FallbackBuffVFX    { get; set; }
+        [field:SerializeField] public Vector3    FallbackPosition   { get; set; }
 
         [Serializable]
         public class BuffVFXData

--- a/nekoyume/Assets/_Scripts/Game/ScriptableObject/BuffVFXScriptableObject.cs
+++ b/nekoyume/Assets/_Scripts/Game/ScriptableObject/BuffVFXScriptableObject.cs
@@ -12,7 +12,9 @@ namespace Nekoyume
         [field:SerializeField] public List<BuffVFXData> DataList { get; set; }
         [field:SerializeField] public List<BuffVFXOverrideData> OverrideDataList { get; set; }
         [field:SerializeField] public List<ActionBuffVFXOverrideData> ActionBuffVFXOverrideDataList { get; set; }
-        [field:SerializeField] public List<BuffPosOverrideData> BuffPosOverrideDataList { get;  set; }
+        
+        [field:SerializeField] public List<BuffPosOverrideData>       BuffPosOverrideDataList       { get; set; }
+        [field:SerializeField] public List<ActionBuffPosOverrideData> ActionBuffPosOverrideDataList { get; set; }
         
         [field:SerializeField] public Sprite     FallbackIcon       { get; set; }
         [field:SerializeField] public GameObject FallbackCastingVFX { get; set; }
@@ -53,6 +55,14 @@ namespace Nekoyume
         public class BuffPosOverrideData
         {
             public int Id;
+            public bool IsCasting;
+            public Vector3 Position;
+        }
+        
+        [Serializable]
+        public class ActionBuffPosOverrideData
+        {
+            public ActionBuffType Type;
             public bool IsCasting;
             public Vector3 Position;
         }

--- a/nekoyume/Assets/_Scripts/Game/ScriptableObject/BuffVFXScriptableObject.cs
+++ b/nekoyume/Assets/_Scripts/Game/ScriptableObject/BuffVFXScriptableObject.cs
@@ -1,6 +1,7 @@
 using Nekoyume.Model.Stat;
 using System;
 using System.Collections.Generic;
+using Nekoyume.Model.Skill;
 using UnityEngine;
 
 namespace Nekoyume
@@ -10,6 +11,7 @@ namespace Nekoyume
     {
         [field:SerializeField] public List<BuffVFXData> DataList { get; set; }
         [field:SerializeField] public List<BuffVFXOverrideData> OverrideDataList { get; set; }
+        [field:SerializeField] public List<ActionBuffVFXOverrideData> ActionBuffVFXOverrideDataList { get; set; }
         [field:SerializeField] public List<BuffPosOverrideData> BuffPosOverrideDataList { get;  set; }
         
         [field:SerializeField] public Sprite     FallbackIcon       { get; set; }
@@ -33,6 +35,15 @@ namespace Nekoyume
         public class BuffVFXOverrideData
         {
             public int Id;
+            public Sprite Icon;
+            public GameObject CastingVFX;
+            public GameObject BuffVFX;
+        }
+        
+        [Serializable]
+        public class ActionBuffVFXOverrideData
+        {
+            public ActionBuffType Type;
             public Sprite Icon;
             public GameObject CastingVFX;
             public GameObject BuffVFX;

--- a/nekoyume/Assets/_Scripts/Helper/BuffHelper.cs
+++ b/nekoyume/Assets/_Scripts/Helper/BuffHelper.cs
@@ -1,6 +1,9 @@
 using Nekoyume.Model.Buff;
 using Nekoyume.Model.Stat;
 using System.Linq;
+using JetBrains.Annotations;
+using Nekoyume.Game;
+using Nekoyume.TableData;
 using UnityEngine;
 
 namespace Nekoyume.Helper
@@ -15,8 +18,7 @@ namespace Nekoyume.Helper
             {
                 if (_vfxData == null)
                 {
-                    _vfxData = Resources.Load<BuffVFXScriptableObject>(
-                        "ScriptableObject/BuffVFXData");
+                    _vfxData = Resources.Load<BuffVFXScriptableObject>("ScriptableObject/BuffVFXData");
                 }
 
                 return _vfxData;
@@ -25,101 +27,185 @@ namespace Nekoyume.Helper
 
         public static GameObject GetCastingVFXPrefab(Buff buff)
         {
+            var id               = buff.BuffInfo.Id;
+            var actionBuffCastingPrefab = GetActionBuffCastingPrefab(id);
+            if (actionBuffCastingPrefab != null)
+            {
+                return actionBuffCastingPrefab;
+            }
+            
             var overrideData = VFXData.OverrideDataList
                 .FirstOrDefault(x => x.Id == buff.BuffInfo.Id);
-            if (overrideData == null)
-            {
-                if (buff is StatBuff statBuff)
-                {
-                    var modifier   = statBuff.GetModifier();
-                    var isPositive = modifier.Value >= 0;
-                    var data = VFXData.DataList
-                        .FirstOrDefault(x => x.StatType == modifier.StatType);
-                    return data == null ? VFXData.FallbackCastingVFX :
-                        isPositive      ? data.PlusCastingVFX : data.MinusCastingVFX;
-                }
 
+            if (overrideData != null)
+            {
+                return overrideData.CastingVFX;
+            }
+
+            if (buff is not StatBuff statBuff)
+            {
                 return VFXData.FallbackCastingVFX;
             }
-            return overrideData.CastingVFX;
+            
+            var modifier   = statBuff.GetModifier();
+            var isPositive = modifier.Value >= 0;
+            var data = VFXData.DataList
+                .FirstOrDefault(x => x.StatType == modifier.StatType);
+            return data == null ? VFXData.FallbackCastingVFX :
+                isPositive      ? data.PlusCastingVFX : data.MinusCastingVFX;
         }
 
         public static GameObject GetCastingVFXPrefab(int buffId)
         {
+            var actionBuffCastingPrefab = GetActionBuffCastingPrefab(buffId);
+            if (actionBuffCastingPrefab != null)
+            {
+                return actionBuffCastingPrefab;
+            }
+            
             var overrideData = VFXData.OverrideDataList
                 .FirstOrDefault(x => x.Id == buffId);
 
             return overrideData == null ? VFXData.FallbackCastingVFX : overrideData.CastingVFX;
         }
+        
+        [CanBeNull]
+        private static GameObject GetActionBuffCastingPrefab(int id)
+        {
+            var actionSheet   = GetActionBuffSheet();
+            var hasActionBuff = actionSheet.TryGetValue(id, out var actionBuffRow);
+            if (!hasActionBuff)
+            {
+                return null;
+            }
+            
+            var actionBuffType     = actionBuffRow.ActionBuffType;
+            var actionBuffDataList = VFXData.ActionBuffVFXOverrideDataList;
+            var actionOverrideData = actionBuffDataList
+                .FirstOrDefault(x => x.Type == actionBuffType);
+            return actionOverrideData?.CastingVFX;
+        }
 
         public static GameObject GetBuffVFXPrefab(Buff buff)
         {
-            var overrideData = VFXData.OverrideDataList
-                .FirstOrDefault(x => x.Id == buff.BuffInfo.Id);
-            if (overrideData == null)
+            var id = buff.BuffInfo.Id;
+            var actionBuffPrefab = GetActionBuffPrefab(id);
+            if (actionBuffPrefab != null)
             {
-                if (buff is StatBuff statBuff)
-                {
-                    var modifier   = statBuff.GetModifier();
-                    var isPositive = modifier.Value >= 0;
-                    var data = VFXData.DataList
-                        .FirstOrDefault(x => x.StatType == modifier.StatType);
-                    return data == null ? VFXData.FallbackBuffVFX :
-                        isPositive      ? data.PlusVFX : data.MinusVFX;
-                }
-
+                return actionBuffPrefab;
+            }
+            
+            var overrideData = VFXData.OverrideDataList
+                .FirstOrDefault(x => x.Id == id);
+            if (overrideData != null)
+            {
+                return overrideData.BuffVFX;
+            }
+            
+            if (buff is not StatBuff statBuff)
+            {
                 return VFXData.FallbackBuffVFX;
             }
-            return overrideData.BuffVFX;
+            var modifier   = statBuff.GetModifier();
+            var isPositive = modifier.Value >= 0;
+            var data = VFXData.DataList
+                .FirstOrDefault(x => x.StatType == modifier.StatType);
+            return data == null ? VFXData.FallbackBuffVFX :
+                isPositive      ? data.PlusVFX : data.MinusVFX;
         }
 
         public static GameObject GetBuffVFXPrefab(int buffId)
         {
+            var actionBuffPrefab = GetActionBuffPrefab(buffId);
+            if (actionBuffPrefab != null)
+            {
+                return actionBuffPrefab;
+            }
+            
             var overrideData = VFXData.OverrideDataList
                 .FirstOrDefault(x => x.Id == buffId);
             return overrideData == null ? VFXData.FallbackBuffVFX : overrideData.BuffVFX;
         }
+        
+        [CanBeNull]
+        private static GameObject GetActionBuffPrefab(int id)
+        {
+            var actionSheet   = GetActionBuffSheet();
+            var hasActionBuff = actionSheet.TryGetValue(id, out var actionBuffRow);
+            if (!hasActionBuff)
+            {
+                return null;
+            }
+            
+            var actionBuffType     = actionBuffRow.ActionBuffType;
+            var actionBuffDataList = VFXData.ActionBuffVFXOverrideDataList;
+            var actionOverrideData = actionBuffDataList
+                .FirstOrDefault(x => x.Type == actionBuffType);
+            return actionOverrideData?.BuffVFX;
+        }
 
         public static Sprite GetBuffIcon(Buff buff)
         {
-            var overrideData = VFXData.OverrideDataList
-                .FirstOrDefault(x => x.Id == buff.BuffInfo.Id);
-            if (overrideData == null)
+            var id = buff.BuffInfo.Id;
+            var actionBuffIcon = GetActionBuffIcon(id);
+            if (actionBuffIcon != null)
             {
-                if (buff is StatBuff statBuff)
-                {
-                    var modifier = statBuff.GetModifier();
-                    var isPositive = modifier.Value >= 0;
-                    var data = VFXData.DataList
-                        .FirstOrDefault(x => x.StatType == modifier.StatType);
-                    return data == null ? VFXData.FallbackIcon :
-                        isPositive ? data.PlusIcon : data.MinusIcon;
-                }
-
-                return VFXData.FallbackIcon;
+                return actionBuffIcon;
             }
-            else
+            
+            var overrideData = VFXData.OverrideDataList
+                .FirstOrDefault(x => x.Id == id);
+            if (overrideData != null)
             {
                 return overrideData.Icon;
             }
+            
+            if (buff is not StatBuff statBuff)
+            {
+                return VFXData.FallbackIcon;
+            }
+                
+            var modifier   = statBuff.GetModifier();
+            var isPositive = modifier.Value >= 0;
+            var data = VFXData.DataList
+                .FirstOrDefault(x => x.StatType == modifier.StatType);
+            return data == null ? VFXData.FallbackIcon :
+                isPositive      ? data.PlusIcon : data.MinusIcon;
         }
 
         public static Sprite GetBuffOverrideIcon(int id)
         {
-            var overrideData = VFXData.OverrideDataList
-                    .FirstOrDefault(x => x.Id == id);
-            if(overrideData == null)
+            var actionBuffIcon = GetActionBuffIcon(id);
+            if (actionBuffIcon != null)
             {
-                return VFXData.FallbackIcon;
+                return actionBuffIcon;
             }
-            return overrideData.Icon;
+            
+            var overrideData = VFXData.OverrideDataList.FirstOrDefault(x => x.Id == id);
+            return overrideData == null ? VFXData.FallbackIcon : overrideData.Icon;
+        }
+
+        [CanBeNull]
+        private static Sprite GetActionBuffIcon(int id)
+        {
+            var actionSheet   = GetActionBuffSheet();
+            var hasActionBuff = actionSheet.TryGetValue(id, out var actionBuffRow);
+            if (!hasActionBuff)
+            {
+                return null;
+            }
+            
+            var actionBuffType     = actionBuffRow.ActionBuffType;
+            var actionBuffDataList = VFXData.ActionBuffVFXOverrideDataList;
+            var actionOverrideData = actionBuffDataList
+                .FirstOrDefault(x => x.Type == actionBuffType);
+            return actionOverrideData?.Icon;
         }
 
         public static Sprite GetStatBuffIcon(StatType statType, bool isDebuff)
         {
             var data = VFXData.DataList.FirstOrDefault(x => x.StatType == statType);
-            return data == null ? VFXData.FallbackIcon :
-                isDebuff ? data.MinusIcon : data.PlusIcon;
+            return data == null ? VFXData.FallbackIcon : isDebuff ? data.MinusIcon : data.PlusIcon;
         }
 
         public static Vector3 GetDefaultBuffPosition()
@@ -129,9 +215,28 @@ namespace Nekoyume.Helper
 
         public static Vector3 GetBuffPosition(int id, bool isCasting = false)
         {
+            var actionSheet = GetActionBuffSheet();
+            var hasActionBuff = actionSheet.TryGetValue(id, out var actionBuffRow);
+            if (hasActionBuff)
+            {
+                var actionBuffType = actionBuffRow.ActionBuffType;
+                var actionBuffDataList = VFXData.ActionBuffPosOverrideDataList;
+                var actionOverrideData = actionBuffDataList
+                    .FirstOrDefault(x => x.Type == actionBuffType && x.IsCasting == isCasting);
+                if (actionOverrideData != null)
+                {
+                    return actionOverrideData.Position;
+                }
+            }
+            
             var overrideData = VFXData.BuffPosOverrideDataList
                 .FirstOrDefault(x => x.Id == id && x.IsCasting == isCasting);
             return overrideData?.Position ?? VFXData.FallbackPosition;
+        }
+        
+        private static ActionBuffSheet GetActionBuffSheet()
+        {
+            return TableSheets.Instance.ActionBuffSheet;
         }
     }
 }


### PR DESCRIPTION
### Description

action buff sheet에 등록된 버프들을 action buff type기반으로 관리하도록 변경합니다.

![image](https://github.com/planetarium/NineChronicles/assets/58686228/91b0148e-346e-4423-a3cb-733a72d130cd)

상 -> 기존 버프데이터들: 같은 타입의 데이터라도 여러개의 id를 가지기 때문에 각 id별로 같은 값을 넣어서 데이터를 채워줘야함, 새로운 데이터 추가시 버그 생성 확률 높음
하 ->새로운 버프데이터들: 같은 타입의 데이터는 일관된 동작을 보임. 데이터 추가시에도 버그 생성 확률 낮음

https://github.com/planetarium/NineChronicles/issues/5028