### PR TITLE
only flip ice shield vfx

### DIFF
--- a/nekoyume/Assets/_Scripts/Game/VFX/Skill/BuffController.cs
+++ b/nekoyume/Assets/_Scripts/Game/VFX/Skill/BuffController.cs
@@ -4,6 +4,7 @@ using Nekoyume.Game.Util;
 using Nekoyume.Helper;
 using Nekoyume.Model.Buff;
 using System.Collections;
+using Nekoyume.Model.Skill;
 using UnityEngine;
 
 namespace Nekoyume.Game.VFX.Skill
@@ -80,7 +81,15 @@ namespace Nekoyume.Game.VFX.Skill
             while (g.activeSelf && target)
             {
                 t.position = target.transform.position + BuffHelper.GetBuffPosition(buffModel.BuffInfo.Id);
-                vfx.transform.FlipX(target.IsFlipped);
+
+                if (buffModel is ActionBuff actionBuff)
+                {
+                    if (actionBuff.RowData.ActionBuffType == ActionBuffType.IceShield)
+                    {
+                        vfx.transform.FlipX(target.IsFlipped);
+                    }
+                }
+
                 yield return null;
             }
         }


### PR DESCRIPTION
### Description

아이스 실드 타입의 스킬만 아레나에서 캐릭터 반전시 좌우반전 되도록 설정합니다.

### How to test

아레나에서 Bleed와 같은 액션 캐스트 이펙트가 좌우반전되는지 확인

### Related Links

https://github.com/planetarium/NineChronicles/issues/5101

