### PR TITLE
fix get item from mail on service

### DIFF
--- a/nekoyume/Assets/_Scripts/Blockchain/ActionRenderHandler.cs
+++ b/nekoyume/Assets/_Scripts/Blockchain/ActionRenderHandler.cs
@@ -3455,7 +3455,6 @@ namespace Nekoyume.Blockchain
                 }
             }
             
-            var avatarState = StateGetter.GetAvatarState(states, avatarAddr);
             UpdateCurrentAvatarStateAsync(StateGetter.GetAvatarState(states, avatarAddr)).Forget();
             return eval;
         }

--- a/nekoyume/Assets/_Scripts/Blockchain/ActionRenderHandler.cs
+++ b/nekoyume/Assets/_Scripts/Blockchain/ActionRenderHandler.cs
@@ -3378,7 +3378,11 @@ namespace Nekoyume.Blockchain
 
                 if (mail is not null)
                 {
-                    LocalLayerModifier.AddNewMail(avatarAddr, mail.id);
+                    UniTask.RunOnThreadPool(() =>
+                    {
+                        var avatarState = StateGetter.GetAvatarState(states, avatarAddr);
+                        LocalLayerModifier.AddNewMail(avatarState, mail.id);
+                    }).Forget();
                     if (mail.Memo != null && mail.Memo.Contains("season_pass"))
                     {
                         OneLineSystem.Push(MailType.System,
@@ -3450,7 +3454,8 @@ namespace Nekoyume.Blockchain
                     }
                 }
             }
-
+            
+            var avatarState = StateGetter.GetAvatarState(states, avatarAddr);
             UpdateCurrentAvatarStateAsync(StateGetter.GetAvatarState(states, avatarAddr)).Forget();
             return eval;
         }
@@ -3515,7 +3520,11 @@ namespace Nekoyume.Blockchain
                 }
                 if (mail is not null)
                 {
-                    LocalLayerModifier.AddNewMail(avatarAddr, mail.id);
+                    UniTask.RunOnThreadPool(() =>
+                    {
+                        var avatarState = StateGetter.GetAvatarState(states, avatarAddr);
+                        LocalLayerModifier.AddNewMail(avatarState, mail.id);
+                    }).Forget();
                     if (mail.Memo != null && mail.Memo.Contains("season_pass"))
                     {
                         OneLineSystem.Push(MailType.System,
@@ -3619,7 +3628,13 @@ namespace Nekoyume.Blockchain
 
             if (mail is not null)
             {
-                LocalLayerModifier.AddNewMail(avatar.address, mail.id);
+                UniTask.RunOnThreadPool(() =>
+                {
+                    var avatarAddr  = gameStates.CurrentAvatarState.address;
+                    var states      = eval.OutputState;
+                    var avatarState = StateGetter.GetAvatarState(states, avatarAddr);
+                    LocalLayerModifier.AddNewMail(avatarState, mail.id);
+                }).Forget();
             }
             if (Widget.TryFind<MobileShop>(out var mobileShop) && mobileShop.IsActive())
             {

--- a/nekoyume/Assets/_Scripts/State/LocalLayerModifier.cs
+++ b/nekoyume/Assets/_Scripts/State/LocalLayerModifier.cs
@@ -228,9 +228,15 @@ namespace Nekoyume.State
             ReactiveAvatarState.UpdateMailBox(outAvatarState.mailBox);
         }
 
+        public static void AddNewMail(AvatarState avatarState, Guid mailId)
+        {
+            UnityEngine.Debug.Log($"[AddNewMail] AddNewMail mailid : {mailId}");
+            ReactiveAvatarState.UpdateMailBox(avatarState.mailBox);
+        }
+
         public static void AddNewMail(Address avatarAddress, Guid mailId)
         {
-            UnityEngine.Debug.Log($"[MailRead] AddNewMail mailid : {mailId}");
+            UnityEngine.Debug.Log($"[AddNewMail] AddNewMail mailid : {mailId}");
             var modifier = new AvatarMailNewSetter(mailId);
             LocalLayer.Instance.Add(avatarAddress, modifier);
 
@@ -241,7 +247,7 @@ namespace Nekoyume.State
                 out var isCurrentAvatarState)
             )
             {
-                UnityEngine.Debug.LogError($"[MailRead] AddNewMail TryGetLoadedAvatarState fail mailid : {mailId}");
+                UnityEngine.Debug.LogError($"[AddNewMail] AddNewMail TryGetLoadedAvatarState fail mailid : {mailId}");
                 return;
             }
 
@@ -249,7 +255,7 @@ namespace Nekoyume.State
 
             if (!isCurrentAvatarState)
             {
-                UnityEngine.Debug.LogError($"[MailRead] AddNewMail isCurrentAvatarState fail mailid : {mailId}");
+                UnityEngine.Debug.LogError($"[AddNewMail] AddNewMail isCurrentAvatarState fail mailid : {mailId}");
                 return;
             }
 


### PR DESCRIPTION
### Description

ResponseUnloadFromMyGarages, ResponseClaimItems, ResponseMintAssets
세가지 액션을 통해 데이터를 받아오는 경우, 최신 상태의 아바타 값으로 데이터를 셋팅하는 것이 아닌 액션의 결과로 데이터를 셋팅하는 것으로 변경하였습니다. 다만 현재 구현상 메일함을 통해 새로운 메일이 왔다는 레드닷이 뜨고 메일을 수령하여 어떤 아이템을 획득했는지에 대해 확인할 수 없고, 클라이언트가 체인과 연결이 일시적으로 끊긴 경우 보상이 수령 안되는 이슈가 또 발생할 가능성이 남아있습니다.

연결 끊김 관련 이슈는 아래 이슈에서 별도 처리 예정입니다
https://github.com/planetarium/NineChronicles/issues/5117

### Related Links

https://github.com/planetarium/NineChronicles/issues/5135
https://github.com/planetarium/NineChronicles/issues/5129