### PR TITLE
렌더 시점의 재화 잔고, 아이템 재료 수량이 맞지않는 버그 수정

### DIFF
--- a/nekoyume/Assets/_Scripts/Blockchain/ActionRenderHandler.cs
+++ b/nekoyume/Assets/_Scripts/Blockchain/ActionRenderHandler.cs
@@ -962,6 +962,12 @@ namespace Nekoyume.Blockchain
                    avatarAddress,
                    out var avatarState))
             {
+                // 액션을 스테이징한 시점에 미리 반영해둔 아이템의 레이어를 먼저 제거하고, 액션의 결과로 나온 실제 상태를 반영
+                foreach (var pair in result.materials)
+                {
+                    LocalLayerModifier.AddItem(avatarAddress, pair.Key.ItemId, pair.Value, false);
+                }
+
                 UpdateCombinationSlotState(avatarAddress, slotIndex, slot);
                 UpdateAgentStateAsync(eval).Forget();
                 UpdateCurrentAvatarStateAsync(eval).Forget();
@@ -1004,10 +1010,6 @@ namespace Nekoyume.Blockchain
                 LocalLayerModifier.ModifyAgentGold(renderArgs.Evaluation, agentAddress,
                     result.gold);
             });
-            foreach (var pair in result.materials)
-            {
-                LocalLayerModifier.AddItem(avatarAddress, pair.Key.ItemId, pair.Value, false);
-            }
 
             LocalLayerModifier.RemoveItem(
                 avatarAddress,

--- a/nekoyume/Assets/_Scripts/Blockchain/ActionRenderHandler.cs
+++ b/nekoyume/Assets/_Scripts/Blockchain/ActionRenderHandler.cs
@@ -2104,6 +2104,13 @@ namespace Nekoyume.Blockchain
         {
             var avatarAddress = States.Instance.CurrentAvatarState.address;
             var avatarState = StateGetter.GetAvatarState(eval.OutputState, avatarAddress);
+            if (eval.Action.apStoneCount > 0)
+            {
+                var row = TableSheets.Instance.MaterialItemSheet.Values.First(r =>
+                    r.ItemSubType == ItemSubType.ApStone);
+                // 액션을 스테이징한 시점에 미리 반영해둔 아이템의 레이어를 먼저 제거하고, 액션의 결과로 나온 실제 상태를 반영
+                LocalLayerModifier.AddItem(avatarAddress, row.ItemId, eval.Action.apStoneCount, false);
+            }
             UpdateCurrentAvatarStateAsync(avatarState).Forget();
             UpdateCurrentAvatarItemSlotState(eval, BattleType.Adventure);
             UpdateCurrentAvatarRuneSlotState(eval, BattleType.Adventure);
@@ -2116,14 +2123,6 @@ namespace Nekoyume.Blockchain
             ActionEvaluation<HackAndSlashSweep> eval)
         {
             Widget.Find<SweepResultPopup>().OnActionRender(new LocalRandom(eval.RandomSeed));
-            if (eval.Action.apStoneCount > 0)
-            {
-                var avatarAddress = eval.Action.avatarAddress;
-                var row = TableSheets.Instance.MaterialItemSheet.Values.First(r =>
-                    r.ItemSubType == ItemSubType.ApStone);
-                LocalLayerModifier.AddItem(avatarAddress, row.ItemId, eval.Action.apStoneCount);
-            }
-
             Widget.Find<BattlePreparation>().UpdateInventoryView();
         }
 

--- a/nekoyume/Assets/_Scripts/Blockchain/ActionRenderHandler.cs
+++ b/nekoyume/Assets/_Scripts/Blockchain/ActionRenderHandler.cs
@@ -825,7 +825,7 @@ namespace Nekoyume.Blockchain
             var result = (RapidCombination5.ResultModel)renderArgs.CombinationSlotState.Result;
             foreach (var pair in result.cost)
             {
-                LocalLayerModifier.AddItem(avatarAddress, pair.Key.ItemId, pair.Value);
+                LocalLayerModifier.AddItem(avatarAddress, pair.Key.ItemId, pair.Value, false);
             }
 
             string formatKey;
@@ -1006,7 +1006,7 @@ namespace Nekoyume.Blockchain
             });
             foreach (var pair in result.materials)
             {
-                LocalLayerModifier.AddItem(avatarAddress, pair.Key.ItemId, pair.Value);
+                LocalLayerModifier.AddItem(avatarAddress, pair.Key.ItemId, pair.Value, false);
             }
 
             LocalLayerModifier.RemoveItem(
@@ -1178,7 +1178,7 @@ namespace Nekoyume.Blockchain
             });
             foreach (var pair in result.materials)
             {
-                LocalLayerModifier.AddItem(avatarAddress, pair.Key.ItemId, pair.Value);
+                LocalLayerModifier.AddItem(avatarAddress, pair.Key.ItemId, pair.Value, false);
             }
 
             LocalLayerModifier.RemoveItem(
@@ -1342,7 +1342,7 @@ namespace Nekoyume.Blockchain
             if (itemUsable.ItemSubType == ItemSubType.Aura)
             {
                 //Because aura is a tradable item, local removal or add fails and an exception is handled.
-                LocalLayerModifier.AddNonFungibleItem(avatarAddress, itemUsable.ItemId);
+                LocalLayerModifier.AddNonFungibleItem(avatarAddress, itemUsable.ItemId, false);
             }
             else
             {
@@ -1350,7 +1350,8 @@ namespace Nekoyume.Blockchain
                     avatarAddress,
                     itemUsable.ItemId,
                     itemUsable.RequiredBlockIndex,
-                    1);
+                    1,
+                    false);
             }
 
             foreach (var tradableId in result.materialItemIdList)
@@ -1362,7 +1363,7 @@ namespace Nekoyume.Blockchain
                     if(itemUsable.ItemSubType == ItemSubType.Aura)
                     {
                         //Because aura is a tradable item, local removal or add fails and an exception is handled.
-                        LocalLayerModifier.AddNonFungibleItem(avatarAddress, tradableId);
+                        LocalLayerModifier.AddNonFungibleItem(avatarAddress, tradableId, false);
                     }
                     else
                     {
@@ -1370,7 +1371,8 @@ namespace Nekoyume.Blockchain
                             avatarAddress,
                             tradableId,
                             materialItem.RequiredBlockIndex,
-                            1);
+                            1,
+                            false);
                     }
                 }
             }
@@ -2422,7 +2424,7 @@ namespace Nekoyume.Blockchain
             {
                 var row = TableSheets.Instance.MaterialItemSheet.Values.First(r =>
                     r.ItemSubType == ItemSubType.ApStone);
-                LocalLayerModifier.AddItem(avatarAddress, row.ItemId);
+                LocalLayerModifier.AddItem(avatarAddress, row.ItemId, 1, false);
 
                 if (GameConfigStateSubject.ActionPointState.ContainsKey(eval.Action.AvatarAddress))
                 {
@@ -3485,7 +3487,7 @@ namespace Nekoyume.Blockchain
                     }
                 }
             }
-            
+
             UpdateCurrentAvatarStateAsync(StateGetter.GetAvatarState(states, avatarAddr)).Forget();
             return eval;
         }

--- a/nekoyume/Assets/_Scripts/Blockchain/ActionRenderHandler.cs
+++ b/nekoyume/Assets/_Scripts/Blockchain/ActionRenderHandler.cs
@@ -1113,6 +1113,7 @@ namespace Nekoyume.Blockchain
             var avatarAddress = eval.Action.avatarAddress;
             var slotIndex = eval.Action.slotIndex;
             var slot = StateGetter.GetCombinationSlotState(eval.OutputState, avatarAddress, slotIndex);
+            var result = (CombinationConsumable5.ResultModel)slot.Result;
 
             if(StateGetter.TryGetAvatarState(
                    eval.OutputState,
@@ -1120,6 +1121,12 @@ namespace Nekoyume.Blockchain
                    avatarAddress,
                    out var avatarState))
             {
+                // 액션을 스테이징한 시점에 미리 반영해둔 아이템의 레이어를 먼저 제거하고, 액션의 결과로 나온 실제 상태를 반영
+                foreach (var pair in result.materials)
+                {
+                    LocalLayerModifier.AddItem(avatarAddress, pair.Key.ItemId, pair.Value, false);
+                }
+
                 UpdateCombinationSlotState(avatarAddress, slotIndex, slot);
                 UpdateAgentStateAsync(eval).Forget();
                 UpdateCurrentAvatarStateAsync(eval).Forget();
@@ -1178,10 +1185,6 @@ namespace Nekoyume.Blockchain
                 LocalLayerModifier.ModifyAgentGold(renderArgs.Evaluation, agentAddress,
                     result.gold);
             });
-            foreach (var pair in result.materials)
-            {
-                LocalLayerModifier.AddItem(avatarAddress, pair.Key.ItemId, pair.Value, false);
-            }
 
             LocalLayerModifier.RemoveItem(
                 avatarAddress,


### PR DESCRIPTION
- resolve #5124 #5140, etc
- 렌더시점에 FAV를 가져오는 부분을 액션의 실행결과가 반영된 OutputState를 쓰도록 수정
- AP포션, 모래시계, 조합 재료와 같은 액션 스테이징 시점에 미리 차감시켜두고 렌더 시점에 수량을 복구시킬때 상태 정리가 안되는 문제를 해결하기 위해 OutputState에서 꺼내온 아바타를 반영하기전에 레이어를 미리 제거하도록 처리