### PR TITLE
로컬레이어의 상태 초기화처리 수정

### DIFF
--- a/nekoyume/Assets/_Scripts/Blockchain/ActionRenderHandler.cs
+++ b/nekoyume/Assets/_Scripts/Blockchain/ActionRenderHandler.cs
@@ -1014,11 +1014,6 @@ namespace Nekoyume.Blockchain
                     result.gold);
             });
 
-            LocalLayerModifier.RemoveItem(
-                avatarAddress,
-                result.itemUsable.ItemId,
-                result.itemUsable.RequiredBlockIndex,
-                1);
             LocalLayerModifier.AddNewAttachmentMail(avatarAddress, result.id);
 
             var tableSheets = Game.Game.instance.TableSheets;
@@ -1189,11 +1184,6 @@ namespace Nekoyume.Blockchain
                     result.gold);
             });
 
-            LocalLayerModifier.RemoveItem(
-                avatarAddress,
-                result.itemUsable.ItemId,
-                result.itemUsable.RequiredBlockIndex,
-                1);
             LocalLayerModifier.AddNewAttachmentMail(avatarAddress, result.id);
 
             RenderQuest(avatarAddress, renderArgs.AvatarState.questList.completedQuestIds);
@@ -1246,11 +1236,6 @@ namespace Nekoyume.Blockchain
                     result.gold);
             });
 
-            LocalLayerModifier.RemoveItem(
-                avatarAddress,
-                itemUsable.ItemId,
-                itemUsable.RequiredBlockIndex,
-                1);
             LocalLayerModifier.AddNewAttachmentMail(avatarAddress, result.id);
 
             // Notify
@@ -1387,20 +1372,6 @@ namespace Nekoyume.Blockchain
                             false);
                     }
                 }
-            }
-
-            if (itemUsable.ItemSubType == ItemSubType.Aura)
-            {
-                //Because aura is a tradable item, local removal or add fails and an exception is handled.
-                LocalLayerModifier.RemoveNonFungibleItem(avatarAddress, itemUsable.ItemId);
-            }
-            else
-            {
-                LocalLayerModifier.RemoveItem(
-                    avatarAddress,
-                    itemUsable.ItemId,
-                    itemUsable.RequiredBlockIndex,
-                    1);
             }
 
             LocalLayerModifier.AddNewAttachmentMail(avatarAddress, result.id);

--- a/nekoyume/Assets/_Scripts/Blockchain/ActionRenderHandler.cs
+++ b/nekoyume/Assets/_Scripts/Blockchain/ActionRenderHandler.cs
@@ -1640,7 +1640,8 @@ namespace Nekoyume.Blockchain
             {
                 var row = Game.Game.instance.TableSheets.MaterialItemSheet.Values
                     .First(r => r.ItemSubType == ItemSubType.ApStone);
-                LocalLayerModifier.AddItem(eval.Action.AvatarAddress, row.ItemId);
+                // 액션을 스테이징한 시점에 미리 반영해둔 아이템의 레이어를 먼저 제거하고, 액션의 결과로 나온 실제 상태를 반영
+                LocalLayerModifier.AddItem(eval.Action.AvatarAddress, row.ItemId, 1, false);
             }
 
             if (GameConfigStateSubject.ActionPointState.ContainsKey(eval.Action.AvatarAddress))
@@ -1716,7 +1717,8 @@ namespace Nekoyume.Blockchain
             {
                 var row = Game.Game.instance.TableSheets.MaterialItemSheet.Values
                     .First(r => r.ItemSubType == ItemSubType.ApStone);
-                LocalLayerModifier.AddItem(eval.Action.AvatarAddress, row.ItemId);
+                // 액션을 스테이징한 시점에 미리 반영해둔 아이템의 레이어를 먼저 제거하고, 액션의 결과로 나온 실제 상태를 반영
+                LocalLayerModifier.AddItem(eval.Action.AvatarAddress, row.ItemId, 1, false);
             }
 
             if (GameConfigStateSubject.ActionPointState.ContainsKey(eval.Action.AvatarAddress))

--- a/nekoyume/Assets/_Scripts/State/LocalLayerModifier.cs
+++ b/nekoyume/Assets/_Scripts/State/LocalLayerModifier.cs
@@ -351,56 +351,24 @@ namespace Nekoyume.State
         /// </summary>
         /// <param name="avatarAddress"></param>
         /// <param name="mailId"></param>
-        /// <param name="resetState"></param>
-        public static async void RemoveNewAttachmentMail(
+        public static void RemoveNewAttachmentMail(
             Address avatarAddress,
-            Guid mailId,
-            bool resetState = true)
+            Guid mailId)
         {
             UnityEngine.Debug.Log($"[MailRead] RemoveNewAttachmentMail mailid : {mailId}");
             var modifier = new AvatarAttachmentMailNewSetter(mailId);
             LocalLayer.Instance.Remove(avatarAddress, modifier);
-
-            if (!resetState)
-            {
-                return;
-            }
-
-            await TryResetLoadedAvatarState(avatarAddress);
         }
 
-        public static async void RemoveNewMail(
+        public static void RemoveNewMail(
             Address avatarAddress,
-            Guid mailId,
-            bool resetState = true)
+            Guid mailId)
         {
             UnityEngine.Debug.Log($"[MailRead] RemoveNewMail mailid : {mailId}");
             var modifier = new AvatarMailNewSetter(mailId);
             LocalLayer.Instance.Remove(avatarAddress, modifier);
-
-            if (!resetState)
-            {
-                return;
-            }
-
-            await TryResetLoadedAvatarState(avatarAddress);
         }
 
-        public static async void RemoveAttachmentResult(
-            Address avatarAddress,
-            Guid mailId,
-            bool resetState = true)
-        {
-            var resultModifier = new AvatarAttachmentMailResultSetter(mailId);
-            LocalLayer.Instance.Remove(avatarAddress, resultModifier);
-
-            if (!resetState)
-            {
-                return;
-            }
-
-            await TryResetLoadedAvatarState(avatarAddress);
-        }
         #endregion
 
         #region Avatar / Quest

--- a/nekoyume/Assets/_Scripts/UI/Widget/Popup/CelebratesPopup.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Popup/CelebratesPopup.cs
@@ -341,10 +341,11 @@ namespace Nekoyume.UI
                 LocalLayerModifier.AddItem(
                     avatarAddress,
                     materialRow.Value.ItemId,
-                    reward.Item2);
+                    reward.Item2,
+                    false);
             }
 
-            LocalLayerModifier.RemoveReceivableQuest(avatarAddress, questId, true);
+            LocalLayerModifier.RemoveReceivableQuest(avatarAddress, questId, false);
         }
 
         private void PlayEffects()

--- a/nekoyume/Assets/_Scripts/UI/Widget/Popup/MailPopup.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Popup/MailPopup.cs
@@ -111,6 +111,7 @@ namespace Nekoyume.UI
                 if (mail.New && mail.requiredBlockIndex <= currentBlockIndex)
                 {
                     await AddRewards(mail, mailRewards);
+                    mail.New = false;
                 }
             }
 
@@ -149,7 +150,6 @@ namespace Nekoyume.UI
 
         private static async Task AddRewards(Mail mail, List<MailReward> mailRewards)
         {
-            var avatarAddress = States.Instance.CurrentAvatarState.address;
             switch (mail)
             {
                 case ProductBuyerMail productBuyerMail:
@@ -473,6 +473,7 @@ namespace Nekoyume.UI
 
             var avatarAddress = States.Instance.CurrentAvatarState.address;
             LocalLayerModifier.RemoveNewAttachmentMail(avatarAddress, mail.id);
+            mail.New = false;
             NcDebug.Log("CombinationMail LocalLayer task completed");
             ReactiveAvatarState.UpdateMailBox(States.Instance.CurrentAvatarState.mailBox);
 
@@ -507,6 +508,7 @@ namespace Nekoyume.UI
             };
             model.OnClickSubmit.Subscribe(_ =>
             {
+                orderBuyerMail.New = false;
                 LocalLayerModifier.RemoveNewMail(avatarAddress, orderBuyerMail.id);
                 ReactiveAvatarState.UpdateMailBox(States.Instance.CurrentAvatarState.mailBox);
             }).AddTo(gameObject);
@@ -520,6 +522,7 @@ namespace Nekoyume.UI
             var order = await Util.GetOrder(orderSellerMail.OrderId);
             var taxedPrice = order.Price - order.GetTax();
             LocalLayerModifier.ModifyAgentGoldAsync(agentAddress, taxedPrice).Forget();
+            orderSellerMail.New = false;
             LocalLayerModifier.RemoveNewMail(avatarAddress, orderSellerMail.id);
             ReactiveAvatarState.UpdateMailBox(States.Instance.CurrentAvatarState.mailBox);
         }
@@ -527,12 +530,14 @@ namespace Nekoyume.UI
         public void Read(GrindingMail grindingMail)
         {
             NcDebug.Log($"[{nameof(GrindingMail)}] ItemCount: {grindingMail.ItemCount}, Asset: {grindingMail.Asset}");
+            grindingMail.New = false;
             ReactiveAvatarState.UpdateMailBox(States.Instance.CurrentAvatarState.mailBox);
         }
 
         public void Read(MaterialCraftMail materialCraftMail)
         {
             NcDebug.Log($"[{nameof(MaterialCraftMail)}] ItemCount: {materialCraftMail.ItemCount}, ItemId: {materialCraftMail.ItemId}");
+            materialCraftMail.New = false;
             ReactiveAvatarState.UpdateMailBox(States.Instance.CurrentAvatarState.mailBox);
         }
 
@@ -560,6 +565,7 @@ namespace Nekoyume.UI
 
                 model.OnClickSubmit.Subscribe(_ =>
                 {
+                    productBuyerMail.New = false;
                     LocalLayerModifier.RemoveNewMail(avatarAddress, productBuyerMail.id);
                     ReactiveAvatarState.UpdateMailBox(States.Instance.CurrentAvatarState.mailBox);
                 }).AddTo(gameObject);
@@ -574,6 +580,7 @@ namespace Nekoyume.UI
                     fav,
                     () =>
                     {
+                        productBuyerMail.New = false;
                         LocalLayerModifier.RemoveNewMail(avatarAddress, productBuyerMail.id);
                         ReactiveAvatarState.UpdateMailBox(States.Instance.CurrentAvatarState.mailBox);
                     });
@@ -590,6 +597,7 @@ namespace Nekoyume.UI
             var fav = new FungibleAssetValue(currency, (int)price, 0);
             var taxedPrice = fav.DivRem(100, out _) * Action.Buy.TaxRate;
             LocalLayerModifier.ModifyAgentGoldAsync(agentAddress, taxedPrice).Forget();
+            productSellerMail.New = false;
             LocalLayerModifier.RemoveNewMail(avatarAddress, productSellerMail.id);
             ReactiveAvatarState.UpdateMailBox(States.Instance.CurrentAvatarState.mailBox);
         }
@@ -601,6 +609,7 @@ namespace Nekoyume.UI
                 L10nManager.Localize("UI_YES"),
                 () =>
                 {
+                    productCancelMail.New = false;
                     LocalLayerModifier.RemoveNewMail(avatarAddress, productCancelMail.id);
                     ReactiveAvatarState.UpdateMailBox(States.Instance.CurrentAvatarState.mailBox);
                     ReactiveShopState.SetSellProducts();
@@ -614,6 +623,7 @@ namespace Nekoyume.UI
                 L10nManager.Localize("UI_YES"),
                 () =>
                 {
+                    orderExpirationMail.New = false;
                     LocalLayerModifier.RemoveNewMail(avatarAddress, orderExpirationMail.id);
                     ReactiveAvatarState.UpdateMailBox(States.Instance.CurrentAvatarState.mailBox);
                 });
@@ -626,6 +636,7 @@ namespace Nekoyume.UI
                 L10nManager.Localize("UI_YES"),
                 () =>
                 {
+                    cancelOrderMail.New = false;
                     LocalLayerModifier.RemoveNewMail(avatarAddress, cancelOrderMail.id);
                     ReactiveAvatarState.UpdateMailBox(States.Instance.CurrentAvatarState.mailBox);
                     ReactiveShopState.SetSellProducts();
@@ -653,6 +664,7 @@ namespace Nekoyume.UI
                         result.CRYSTAL.MajorUnit);
                 }
 
+                itemEnhanceMail.New = false;
                 LocalLayerModifier.RemoveNewAttachmentMail(avatarAddress, itemEnhanceMail.id);
                 ReactiveAvatarState.UpdateMailBox(States.Instance.CurrentAvatarState.mailBox);
             }).ToObservable().SubscribeOnMainThread().Subscribe(_ =>

--- a/nekoyume/Assets/_Scripts/UI/Widget/Popup/QuestPopup.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Popup/QuestPopup.cs
@@ -152,7 +152,7 @@ namespace Nekoyume.UI
                 .Where(q => q.isReceivable && q.Complete)
                 .SelectMany(q =>
                 {
-                    LocalLayerModifier.RemoveReceivableQuest(avatarAddress, q.Id);
+                    LocalLayerModifier.RemoveReceivableQuest(avatarAddress, q.Id, false);
                     return q.Reward.ItemMap;
                 }).Select(itemMap =>
                 {
@@ -161,7 +161,7 @@ namespace Nekoyume.UI
                         itemMap.Item1);
                     var itemId = item.ItemId;
                     var count = itemMap.Item2;
-                    LocalLayerModifier.AddItem(avatarAddress, itemId, count);
+                    LocalLayerModifier.AddItem(avatarAddress, itemId, count, false);
                     return new MailReward(item, count);
                 }).ToList();
             Find<MailRewardScreen>().Show(mailRewards);


### PR DESCRIPTION
- 메일읽음처리시 블록높이따라 상태 초기화를 호출하도록 처리
- 퀘스트완료처리시 상태 초기화를 비활성화
- 축하팝업에서 상태 초기화를 비활성화
- resolve #5133 #5124 