### PR TITLE
ClaimItems, UnloadFromMyGarages 에서 메일 알림처리 버그 수정

### DIFF
--- a/nekoyume/Assets/_Scripts/State/LocalLayerModifier.cs
+++ b/nekoyume/Assets/_Scripts/State/LocalLayerModifier.cs
@@ -286,6 +286,9 @@ namespace Nekoyume.State
         public static void AddNewMail(AvatarState avatarState, Guid mailId)
         {
             UnityEngine.Debug.Log($"[AddNewMail] AddNewMail mailid : {mailId}");
+            var modifier = new AvatarMailNewSetter(mailId);
+            LocalLayer.Instance.Add(avatarState.address, modifier);
+            avatarState = modifier.Modify(avatarState);
             ReactiveAvatarState.UpdateMailBox(avatarState.mailBox);
         }
 


### PR DESCRIPTION
- resolve #5188
- AddNewMail에서 AvatarState를 Modify하지 않아서 해당 메일에 New flag가 바뀌지 않는게 원인이었습니다.

https://github.com/planetarium/NineChronicles/assets/3193043/803fe8e9-933d-4946-b069-895508894e57

