### PR TITLE
apply rune level bonus to AvatarStats in FriendInfoPopup

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Module/AvatarInformation.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/AvatarInformation.cs
@@ -961,7 +961,7 @@ namespace Nekoyume.UI.Module
                         new StatModifier(
                             x.stat.StatType,
                             x.operationType,
-                            (long)(x.stat.BaseValue * (100000 + runeLevelBonus) / 100000m))));
+                            (long)(x.stat.TotalValue * (100000 + runeLevelBonus) / 100000m))));
             }
 
             var collectionState = Game.Game.instance.States.CollectionState;

--- a/nekoyume/Assets/_Scripts/UI/Widget/Popup/FriendInfoPopup.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Popup/FriendInfoPopup.cs
@@ -275,6 +275,11 @@ namespace Nekoyume.UI
                 return;
             }
 
+            var runeListSheet = Game.Game.instance.TableSheets.RuneListSheet;
+            var runeLevelBonusSheet = Game.Game.instance.TableSheets.RuneLevelBonusSheet;
+            var runeLevelBonus = RuneHelper.CalculateRuneLevelBonus(_allRuneState,
+                runeListSheet, runeLevelBonusSheet);
+
             var runeStatModifiers = new List<StatModifier>();
             foreach (var runeSlot in runes.GetRuneSlot())
             {
@@ -295,7 +300,7 @@ namespace Nekoyume.UI
                         new StatModifier(
                             x.stat.StatType,
                             x.operationType,
-                            x.stat.TotalValueAsLong)));
+                            (long)(x.stat.BaseValue * (100000 + runeLevelBonus) / 100000m))));
             }
 
             var collectionSheet = Game.Game.instance.TableSheets.CollectionSheet;

--- a/nekoyume/Assets/_Scripts/UI/Widget/Popup/FriendInfoPopup.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Popup/FriendInfoPopup.cs
@@ -300,7 +300,7 @@ namespace Nekoyume.UI
                         new StatModifier(
                             x.stat.StatType,
                             x.operationType,
-                            (long)(x.stat.BaseValue * (100000 + runeLevelBonus) / 100000m))));
+                            (long)(x.stat.TotalValue * (100000 + runeLevelBonus) / 100000m))));
             }
 
             var collectionSheet = Game.Game.instance.TableSheets.CollectionSheet;


### PR DESCRIPTION
### Description

- resolve #5176
  아레나에서 다른 유저의 정보를 볼 수 있는 Friend Info Popup의 Stat 수치에 룬 레벨 보너스가 적용되지 않은 것이 원인. (CP에는 룬 레벨 보너스 적용됨)

### Screenshot

같은 장비, 룬으로 UI에서 표시해주는 수치를 확인함
인벤토리 내 스탯 확인(AvatarInfoPopup)
  <img width="400" alt="image" src="https://github.com/planetarium/NineChronicles/assets/63496908/b29e5925-be14-4094-ab7d-40b863510ba2">

아레나 목록의 친구 스탯 확인(FriendInfoPopup)
**Before**
<img width="400" alt="image" src="https://github.com/planetarium/NineChronicles/assets/63496908/ad70bf10-a1a9-46b6-be28-9bb3f72910cd">

**After**
<img width="400" alt="image" src="https://github.com/planetarium/NineChronicles/assets/63496908/a9409734-c0b8-4b1d-b2eb-bae3da650101">
