### PR TITLE
Fix bug about 'receive all' at QuestPopup

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Widget/Popup/QuestPopup.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Popup/QuestPopup.cs
@@ -69,7 +69,7 @@ namespace Nekoyume.UI
 
         public override void Show(bool ignoreShowAnimation = false)
         {
-            _questList.Value = States.Instance.CurrentAvatarState.questList;
+            _questList.SetValueAndForceNotify(States.Instance.CurrentAvatarState.questList);
             _toggleGroup.SetToggledOffAll();
             adventureButton.SetToggledOn();
             ChangeState(0);
@@ -104,7 +104,7 @@ namespace Nekoyume.UI
                 return;
             }
 
-            _questList.Value = list;
+            _questList.SetValueAndForceNotify(list);
             ChangeState((int)filterType);
         }
 
@@ -167,7 +167,8 @@ namespace Nekoyume.UI
                     return new MailReward(item, count);
                 }).ToList();
             // 퀘스트 완료처리된 목록으로 갱신해서 레드닷 비활성화처리
-            ReactiveAvatarState.UpdateQuestList(States.Instance.CurrentAvatarState.questList);
+            ReactiveAvatarState.UpdateQuestList(questList);
+            _questList.SetValueAndForceNotify(questList);
             Find<MailRewardScreen>().Show(mailRewards);
         }
     }


### PR DESCRIPTION
### Description

1. change QuestPopup._questList set to use SetValueAndForceNotify, and update _questList when on invoking ReceiveAll()
2. _questList의 set 방식을 .value = ... 에서 SetValueAndForceNotify를 쓰게 바꿨고, Receive all을 한 뒤 QuestPopup이 갖고있는 _questList를 갱신하지 않고 있어서 이를 갱신하게 수정했습니다.

### How to test

1. receive all at QuestPopup.

### Related Links

resolve #5180 (https://github.com/planetarium/NineChronicles/issues/5180#issuecomment-2188770097)

### Screenshot

https://github.com/planetarium/NineChronicles/assets/48484989/aebc4f1f-cea2-42eb-b10f-2df6b8c76837

