### PR TITLE
remove _questList at QuestPopup.cs

### DIFF
--- a/nekoyume/Assets/_Scripts/State/ReactiveAvatarState.cs
+++ b/nekoyume/Assets/_Scripts/State/ReactiveAvatarState.cs
@@ -50,7 +50,8 @@ namespace Nekoyume.State
         private static readonly ReactiveProperty<QuestList> _questList
             = new ReactiveProperty<QuestList>();
 
-        public static IObservable<QuestList> QuestList => _questList.ObserveOnMainThread();
+        public static QuestList QuestList => _questList.Value;
+        public static IObservable<QuestList> ObservableQuestList => _questList.ObserveOnMainThread();
 
         public static void Initialize(AvatarState state)
         {

--- a/nekoyume/Assets/_Scripts/UI/Widget/Craft.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Craft.cs
@@ -194,7 +194,7 @@ namespace Nekoyume.UI
                 SharedModel.UpdateUnlockedRecipesAsync(address);
             }).AddTo(gameObject);
 
-            ReactiveAvatarState.QuestList
+            ReactiveAvatarState.ObservableQuestList
                 .Subscribe(SubscribeQuestList)
                 .AddTo(gameObject);
 

--- a/nekoyume/Assets/_Scripts/UI/Widget/Static/HeaderMenuStatic.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Static/HeaderMenuStatic.cs
@@ -602,7 +602,6 @@ namespace Nekoyume.UI.Module
             var hasNotification =
                 questList.Any(quest => quest.IsPaidInAction && quest.isReceivable);
             _toggleNotifications[ToggleType.Quest].Value = hasNotification;
-            Find<QuestPopup>().SetList(questList);
         }
 
         private void SubscribeInventory(Nekoyume.Model.Item.Inventory inventory)

--- a/nekoyume/Assets/_Scripts/UI/Widget/Static/HeaderMenuStatic.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Static/HeaderMenuStatic.cs
@@ -434,7 +434,7 @@ namespace Nekoyume.UI.Module
         {
             base.OnEnable();
             _disposablesAtOnEnable.DisposeAllAndClear();
-            ReactiveAvatarState.QuestList?.Subscribe(SubscribeAvatarQuestList)
+            ReactiveAvatarState.ObservableQuestList?.Subscribe(SubscribeAvatarQuestList)
                 .AddTo(_disposablesAtOnEnable);
             LocalMailHelper.Instance.ObservableMailBox.Subscribe(SubscribeAvatarMailBox)
                 .AddTo(_disposablesAtOnEnable);


### PR DESCRIPTION
### Description

1. remove _questList at QuestPopup.cs
2. QuestPopup이 모델을 ReactiveAvatarState같은데서 가져다 쓰지 않고 혼자 갖고있길래 지워버리고 무조건 ReactiveAvatarState에서 관리하도록 했습니다.

### How to test

1. First step.

### Related Links

### Required Reviewers

### Screenshot
