### PR TITLE
fix grimoire bug in inventory

### DIFF
--- a/nekoyume/Assets/_Scripts/Helper/UnlockHelper.cs
+++ b/nekoyume/Assets/_Scripts/Helper/UnlockHelper.cs
@@ -1,0 +1,55 @@
+using System.Collections.Generic;
+using Nekoyume.Model.Item;
+using Nekoyume.Model.State;
+
+namespace Nekoyume.Helper
+{
+    public static class UnlockHelper
+    {
+        public static List<(ItemSubType, int)> GetAvailableEquipmentSlots(
+            int level,
+            GameConfigState gameConfigState)
+        {
+            var availableSlots = new List<(ItemSubType, int)>();
+
+            if (level >= gameConfigState.RequireCharacterLevel_EquipmentSlotWeapon)
+            {
+                availableSlots.Add((ItemSubType.Weapon, 1));
+            }
+
+            if (level >= gameConfigState.RequireCharacterLevel_EquipmentSlotArmor)
+            {
+                availableSlots.Add((ItemSubType.Armor, 1));
+            }
+
+            if (level >= gameConfigState.RequireCharacterLevel_EquipmentSlotBelt)
+            {
+                availableSlots.Add((ItemSubType.Belt, 1));
+            }
+
+            if (level >= gameConfigState.RequireCharacterLevel_EquipmentSlotNecklace)
+            {
+                availableSlots.Add((ItemSubType.Necklace, 1));
+            }
+
+            if (level >= gameConfigState.RequireCharacterLevel_EquipmentSlotRing1)
+            {
+                if (level >= gameConfigState.RequireCharacterLevel_EquipmentSlotRing2)
+                {
+                    availableSlots.Add((ItemSubType.Ring, 2));
+                }
+                else
+                {
+                    availableSlots.Add((ItemSubType.Ring, 1));
+                }
+            }
+
+            if (level >= gameConfigState.RequireCharacterLevel_EquipmentSlotAura)
+            {
+                availableSlots.Add((ItemSubType.Aura, 1));
+            }
+
+            return availableSlots;
+        }
+    }
+}

--- a/nekoyume/Assets/_Scripts/Helper/UnlockHelper.cs
+++ b/nekoyume/Assets/_Scripts/Helper/UnlockHelper.cs
@@ -49,6 +49,11 @@ namespace Nekoyume.Helper
                 availableSlots.Add((ItemSubType.Aura, 1));
             }
 
+            if (level >= gameConfigState.RequireCharacterLevel_EquipmentSlotGrimoire)
+            {
+                availableSlots.Add((ItemSubType.Grimoire, 1));
+            }
+
             return availableSlots;
         }
     }

--- a/nekoyume/Assets/_Scripts/Helper/UnlockHelper.cs.meta
+++ b/nekoyume/Assets/_Scripts/Helper/UnlockHelper.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: dee49ca302574a96ac8d3d28b88bc0db
+timeCreated: 1719467086

--- a/nekoyume/Assets/_Scripts/UI/Module/Inventory.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/Inventory.cs
@@ -555,7 +555,8 @@ namespace Nekoyume.UI.Module
             }
 
             var level = currentAvatarState.level;
-            var availableSlots = UnlockHelper.GetAvailableEquipmentSlots(level);
+            var availableSlots =
+                UnlockHelper.GetAvailableEquipmentSlots(level, States.Instance.GameConfigState);
 
             var bestItems = new List<InventoryItem>();
             var selectedEquipments = new Dictionary<ItemSubType, List<InventoryItem>>();

--- a/nekoyume/Assets/_Scripts/UI/Widget/Static/HeaderMenuStatic.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Static/HeaderMenuStatic.cs
@@ -629,7 +629,8 @@ namespace Nekoyume.UI.Module
                 sheets.ItemRequirementSheet,
                 sheets.EquipmentItemRecipeSheet,
                 sheets.EquipmentItemSubRecipeSheetV2,
-                sheets.EquipmentItemOptionSheet) ?? false;
+                sheets.EquipmentItemOptionSheet,
+                States.Instance.GameConfigState) ?? false;
             UpdateInventoryNotification(hasNotification);
         }
 


### PR DESCRIPTION
### Description

- to resolve #5205 
  - move unnessesary methods(`GetAvailableEquipmentSlots`...) from lib9c to client
    (https://github.com/planetarium/lib9c/pull/2657)
  - add grimoire to `GetAvailableEquipmentSlots`

### Screenshot

슬랙에 첨부합니다