### PR TITLE
fix duplicate battle bug

### DIFF
--- a/nekoyume/Assets/_Scripts/Game/Battle/RaidStage.cs
+++ b/nekoyume/Assets/_Scripts/Game/Battle/RaidStage.cs
@@ -9,13 +9,11 @@ using Nekoyume.Director;
 using Nekoyume.Game.Character;
 using Nekoyume.Game.Controller;
 using Nekoyume.Game.Util;
-using Nekoyume.Game.VFX;
 using Nekoyume.Game.VFX.Skill;
 using Nekoyume.Helper;
 using Nekoyume.L10n;
 using Nekoyume.Model;
 using Nekoyume.Model.BattleStatus;
-using Nekoyume.Model.Buff;
 using Nekoyume.Model.Item;
 using Nekoyume.Model.Skill;
 using Nekoyume.UI;
@@ -112,8 +110,8 @@ namespace Nekoyume.Game.Battle
         {
             if (!_isPlaying)
             {
-                _isPlaying = true;
                 ClearBattle();
+                _isPlaying       = true;
                 _currentPlayData = data;
 
                 if (data.Log?.Count > 0)
@@ -123,7 +121,7 @@ namespace Nekoyume.Game.Battle
             }
             else
             {
-                NcDebug.Log("Skip incoming battle. Battle is already simulating.");
+                NcDebug.LogWarning("Skip incoming battle. Battle is already simulating.");
             }
         }
 


### PR DESCRIPTION
### Description

RaidStage 스크립트에서 _isPlaying = true인 경우 이미 전투중이므로 새로 전투를 하지 못하도록 막고 있는데, 해당 플래그를 true로 설정해주고 ClearBattle스크립트가 호출되면서 바로 _isPlaying이 false로 바뀌며 이와 같은 방지처리를 하지 못하고 있었습니다.

### Related Links

#5177 