### PR TITLE
fix adventure boss reward miss calculate

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Model/AdventureBossData.cs
+++ b/nekoyume/Assets/_Scripts/UI/Model/AdventureBossData.cs
@@ -356,8 +356,8 @@ namespace Nekoyume.UI.Model
                                         ExploreInfo.Value,
                                         ExploreInfo.Value.AvatarAddress,
                                         TableSheets.Instance.AdventureBossNcgRewardRatioSheet,
-                                        States.Instance.GameConfigState.AdventureBossNcgRuneRatio,
                                         States.Instance.GameConfigState.AdventureBossNcgApRatio,
+                                        States.Instance.GameConfigState.AdventureBossNcgRuneRatio,
                                         false,
                                         out var ncgReward);
                 }
@@ -453,8 +453,8 @@ namespace Nekoyume.UI.Model
                                     ExploreInfo.Value,
                                     ExploreInfo.Value.AvatarAddress,
                                     TableSheets.Instance.AdventureBossNcgRewardRatioSheet,
-                                    States.Instance.GameConfigState.AdventureBossNcgRuneRatio,
                                     States.Instance.GameConfigState.AdventureBossNcgApRatio,
+                                    States.Instance.GameConfigState.AdventureBossNcgRuneRatio,
                                     false,
                                     out var ncgReward);
             }

--- a/nekoyume/Assets/_Scripts/UI/Widget/Popup/AdventureBossRewardPopup.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Popup/AdventureBossRewardPopup.cs
@@ -229,8 +229,8 @@ namespace Nekoyume.UI
                                                             exploreInfo,
                                                             Game.instance.States.CurrentAvatarState.address,
                                                             TableSheets.Instance.AdventureBossNcgRewardRatioSheet,
-                                                            States.Instance.GameConfigState.AdventureBossNcgRuneRatio,
                                                             States.Instance.GameConfigState.AdventureBossNcgApRatio,
+                                                            States.Instance.GameConfigState.AdventureBossNcgRuneRatio,
                                                             false,
                                                             out var explorerReward);
                         if (_lastSeasonId < seasonInfo.Season)


### PR DESCRIPTION
입력값 순서가 뒤집혀있어서 정상적으로 수량이 갱신되지 않던 문제 수정하였습니다.