### PR TITLE
fix adventurebossdata apply sloth

### DIFF
--- a/nekoyume/Assets/_Scripts/Blockchain/ActionRenderHandler.cs
+++ b/nekoyume/Assets/_Scripts/Blockchain/ActionRenderHandler.cs
@@ -3665,7 +3665,7 @@ namespace Nekoyume.Blockchain
                 }
             }).ToObservable().ObserveOnMainThread().Subscribe(async _ =>
             {
-                await Game.Game.instance.AdventureBossData.RefreshAllByCurrentState();
+                await Game.Game.instance.AdventureBossData.RefreshAllByCurrentState(eval.OutputState, eval.BlockIndex);
 
                 var action = eval.Action;
 
@@ -3740,7 +3740,7 @@ namespace Nekoyume.Blockchain
                     }
 
                     //기존정보 업데이트 보상수령 정보를 갱신하기위함.
-                    Game.Game.instance.AdventureBossData.RefreshEndedSeasons().Forget();
+                    Game.Game.instance.AdventureBossData.RefreshEndedSeasons(eval.OutputState, eval.BlockIndex).Forget();
                 }
             });
         }

--- a/nekoyume/Assets/_Scripts/Extensions/GetStateExtensions.cs
+++ b/nekoyume/Assets/_Scripts/Extensions/GetStateExtensions.cs
@@ -14,6 +14,7 @@ using Nekoyume.Model.AdventureBoss;
 using Nekoyume.Model.EnumType;
 using Nekoyume.Model.State;
 using Nekoyume.Module;
+using Nekoyume.UI.Module;
 
 namespace Nekoyume
 {
@@ -129,9 +130,29 @@ namespace Nekoyume
             return new CollectionState();
         }
 
-        public static async Task<SeasonInfo> GetAdventureBossLatestSeasonAsync(this IAgent agent)
+        private static long adventureBossLatestSeasonLastBlockIndex = 0;
+        private static HashDigest<SHA256> adventureBossLatestSeasonLastStateRootHash;
+        public static async Task<SeasonInfo> GetAdventureBossLatestSeasonAsync(this IAgent agent, HashDigest<SHA256>? stateRootHash = null, long blockIndex = 0)
         {
-            var latestSeason = await agent.GetStateAsync(Addresses.AdventureBoss, AdventureBossModule.LatestSeasonAddress);
+            IValue latestSeason;
+            if (stateRootHash == null)
+            {
+                if (agent.BlockIndex <= adventureBossLatestSeasonLastBlockIndex)
+                {
+                    latestSeason = await agent.GetStateAsync(adventureBossLatestSeasonLastStateRootHash, Addresses.AdventureBoss, AdventureBossModule.LatestSeasonAddress);
+                }
+                else
+                {
+                    adventureBossLatestSeasonLastBlockIndex = agent.BlockIndex;
+                    latestSeason = await agent.GetStateAsync(Addresses.AdventureBoss, AdventureBossModule.LatestSeasonAddress);
+                }
+            }
+            else
+            {
+                adventureBossLatestSeasonLastBlockIndex = blockIndex;
+                adventureBossLatestSeasonLastStateRootHash = stateRootHash.Value;
+                latestSeason = await agent.GetStateAsync(adventureBossLatestSeasonLastStateRootHash, Addresses.AdventureBoss, AdventureBossModule.LatestSeasonAddress);
+            }
             if (latestSeason is List list)
             {
                 var result = new SeasonInfo(list);
@@ -142,15 +163,29 @@ namespace Nekoyume
             return new SeasonInfo(0, 0, 0, 0);
         }
 
-        public static async Task<SeasonInfo> GetAdventureBossLatestSeasonInfoAsync(this IAgent agent)
+        private static long adventureBossSeasonInfoLastBlockIndex = 0;
+        private static HashDigest<SHA256> adventureBossSeasonInfoLastStateRootHash;
+        public static async Task<SeasonInfo> GetAdventureBossSeasonInfoAsync(this IAgent agent, long seasonId, HashDigest<SHA256>? stateRootHash = null, long blockIndex = 0)
         {
-            var latestSeason = await agent.GetAdventureBossLatestSeasonAsync();
-            return latestSeason;
-        }
-
-        public static async Task<SeasonInfo> GetAdventureBossSeasonInfoAsync(this IAgent agent, long seasonId)
-        {
-            var seasonInfo = await agent.GetStateAsync(Addresses.AdventureBoss, new Address(AdventureBossHelper.GetSeasonAsAddressForm(seasonId)));
+            IValue seasonInfo;
+            if (stateRootHash == null)
+            {
+                if (agent.BlockIndex <= adventureBossSeasonInfoLastBlockIndex)
+                {
+                    seasonInfo = await agent.GetStateAsync(adventureBossSeasonInfoLastStateRootHash, Addresses.AdventureBoss, new Address(AdventureBossHelper.GetSeasonAsAddressForm(seasonId)));
+                }
+                else
+                {
+                    adventureBossSeasonInfoLastBlockIndex = agent.BlockIndex;
+                    seasonInfo = await agent.GetStateAsync(Addresses.AdventureBoss, new Address(AdventureBossHelper.GetSeasonAsAddressForm(seasonId)));
+                }
+            }
+            else
+            {
+                adventureBossSeasonInfoLastBlockIndex = blockIndex;
+                adventureBossSeasonInfoLastStateRootHash = stateRootHash.Value;
+                seasonInfo = await agent.GetStateAsync(adventureBossSeasonInfoLastStateRootHash, Addresses.AdventureBoss, new Address(AdventureBossHelper.GetSeasonAsAddressForm(seasonId)));
+            }
             if (seasonInfo is List list)
             {
                 var result = new SeasonInfo(list);
@@ -161,9 +196,29 @@ namespace Nekoyume
             return null;
         }
 
-        public static async Task<BountyBoard> GetBountyBoardAsync(this IAgent agent, long seasonId)
+        private static long bountyBoardLastBlockIndex = 0;
+        private static HashDigest<SHA256> bountyBoardLastStateRootHash;
+        public static async Task<BountyBoard> GetBountyBoardAsync(this IAgent agent, long seasonId, HashDigest<SHA256>? stateRootHash = null, long blockIndex = 0)
         {
-            var bountyBoard = await agent.GetStateAsync(Addresses.BountyBoard, new Address(AdventureBossHelper.GetSeasonAsAddressForm(seasonId)));
+            IValue bountyBoard;
+            if (stateRootHash == null)
+            {
+                if (agent.BlockIndex <= bountyBoardLastBlockIndex)
+                {
+                    bountyBoard = await agent.GetStateAsync(bountyBoardLastStateRootHash, Addresses.BountyBoard, new Address(AdventureBossHelper.GetSeasonAsAddressForm(seasonId)));
+                }
+                else
+                {
+                    bountyBoardLastBlockIndex = agent.BlockIndex;
+                    bountyBoard = await agent.GetStateAsync(Addresses.BountyBoard, new Address(AdventureBossHelper.GetSeasonAsAddressForm(seasonId)));
+                }
+            }
+            else
+            {
+                bountyBoardLastBlockIndex = blockIndex;
+                bountyBoardLastStateRootHash = stateRootHash.Value;
+                bountyBoard = await agent.GetStateAsync(bountyBoardLastStateRootHash, Addresses.BountyBoard, new Address(AdventureBossHelper.GetSeasonAsAddressForm(seasonId)));
+            }
             if (bountyBoard is List list)
             {
                 var result = new BountyBoard(list);
@@ -174,9 +229,29 @@ namespace Nekoyume
             return null;
         }
 
-        public static async Task<ExploreBoard> GetExploreBoardAsync(this IAgent agent, long seasonId)
+        private static long exploreBoardLastBlockIndex = 0;
+        private static HashDigest<SHA256> exploreBoardLastStateRootHash;
+        public static async Task<ExploreBoard> GetExploreBoardAsync(this IAgent agent, long seasonId, HashDigest<SHA256>? stateRootHash = null, long blockIndex = 0)
         {
-            var exploreBoard = await agent.GetStateAsync(Addresses.ExploreBoard, new Address(AdventureBossHelper.GetSeasonAsAddressForm(seasonId)));
+            IValue exploreBoard;
+            if (stateRootHash == null)
+            {
+                if (agent.BlockIndex <= exploreBoardLastBlockIndex)
+                {
+                    exploreBoard = await agent.GetStateAsync(exploreBoardLastStateRootHash, Addresses.ExploreBoard, new Address(AdventureBossHelper.GetSeasonAsAddressForm(seasonId)));
+                }
+                else
+                {
+                    exploreBoardLastBlockIndex = agent.BlockIndex;
+                    exploreBoard = await agent.GetStateAsync(Addresses.ExploreBoard, new Address(AdventureBossHelper.GetSeasonAsAddressForm(seasonId)));
+                }
+            }
+            else
+            {
+                exploreBoardLastBlockIndex = blockIndex;
+                exploreBoardLastStateRootHash = stateRootHash.Value;
+                exploreBoard = await agent.GetStateAsync(exploreBoardLastStateRootHash, Addresses.ExploreBoard, new Address(AdventureBossHelper.GetSeasonAsAddressForm(seasonId)));
+            }
             if (exploreBoard is List list)
             {
                 var result = new ExploreBoard(list);
@@ -187,9 +262,29 @@ namespace Nekoyume
             return null;
         }
 
-        public static async Task<Explorer> GetExploreInfoAsync(this IAgent agent, Address avatarAddress, long seasonId)
+        private static long exploreInfoLastBlockIndex = 0;
+        private static HashDigest<SHA256> exploreInfoLastStateRootHash;
+        public static async Task<Explorer> GetExploreInfoAsync(this IAgent agent, Address avatarAddress, long seasonId, HashDigest<SHA256>? stateRootHash = null, long blockIndex = 0)
         {
-            var exploreInfo = await agent.GetStateAsync(Addresses.ExploreBoard, avatarAddress.Derive(AdventureBossHelper.GetSeasonAsAddressForm(seasonId)));
+            IValue exploreInfo;
+            if (stateRootHash == null)
+            {
+                if (agent.BlockIndex <= exploreInfoLastBlockIndex)
+                {
+                    exploreInfo = await agent.GetStateAsync(exploreInfoLastStateRootHash, Addresses.ExploreBoard, avatarAddress.Derive(AdventureBossHelper.GetSeasonAsAddressForm(seasonId)));
+                }
+                else
+                {
+                    exploreInfoLastBlockIndex = agent.BlockIndex;
+                    exploreInfo = await agent.GetStateAsync(Addresses.ExploreBoard, avatarAddress.Derive(AdventureBossHelper.GetSeasonAsAddressForm(seasonId)));
+                }
+            }
+            else
+            {
+                exploreInfoLastBlockIndex = blockIndex;
+                exploreInfoLastStateRootHash = stateRootHash.Value;
+                exploreInfo = await agent.GetStateAsync(exploreInfoLastStateRootHash, Addresses.ExploreBoard, avatarAddress.Derive(AdventureBossHelper.GetSeasonAsAddressForm(seasonId)));
+            }
             if (exploreInfo == null || exploreInfo is Bencodex.Types.Null)
             {
                 NcDebug.LogWarning($"[AdventureBoss] No explore info for {avatarAddress}");


### PR DESCRIPTION
어드벤처보스 상태갱신 슬로스대응에 맞춰서 최신상태로만 갱신되도록 수정

- 시즌 최초 바운티 시작시 상태갱신이안되어서 시즌이 열리지 않는 것처럼 보이는문제
- 시즌 종료 후 보상수령정보 상태갱신이안되어서 결과보상 팝업이 여러번 다시 뜨는 문제

슬로스로 발생한 두 문제 수정된 것 확인하였습니다.