### PR TITLE
improve inventory ordering

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Module/EnhancementInventory.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/EnhancementInventory.cs
@@ -329,10 +329,9 @@ namespace Nekoyume.UI.Module
 
             if (usableItems.Any())
             {
-                var bestItem = usableItems
-                    .OrderByDescending(x => CPHelper.GetCP(x.ItemBase as Equipment)).First();
-                usableItems = usableItems.OrderByDescending(x => x.Equals(bestItem))
-                    .ToList();
+                usableItems = usableItems
+                    .OrderByDescending(x => x.ItemBase.Grade)
+                    .ThenByDescending(x => CPHelper.GetCP(x.ItemBase as Equipment)).ToList();
             }
 
             usableItems.AddRange(unusableItems);

--- a/nekoyume/Assets/_Scripts/UI/Module/Inventory.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/Inventory.cs
@@ -84,6 +84,9 @@ namespace Nekoyume.UI.Module
             CostType.SilverDust, CostType.GoldDust, CostType.RubyDust, CostType.EmeraldDust
         }.Select(cost => (int)cost).ToArray();
 
+        // TODO: hammer의 id를 추가해둬야 합니다. 몰라서 인터페이스만 추가해뒀습니다
+        private readonly int[] hammerIds = { };
+
         private static readonly ItemType[] ItemTypes = Enum.GetValues(typeof(ItemType)) as ItemType[];
 
         private InventoryItem _selectedModel;
@@ -456,8 +459,8 @@ namespace Nekoyume.UI.Module
             return _materials
                 .OrderByDescending(x => dustIds.Contains(x.ItemBase.Id))
                 .ThenByDescending(x =>
-                    x.ItemBase.ItemSubType == ItemSubType.ApStone ||
-                    x.ItemBase.ItemSubType == ItemSubType.Hourglass)
+                    x.ItemBase.ItemSubType is ItemSubType.ApStone or ItemSubType.Hourglass)
+                .ThenByDescending(x => hammerIds.Contains(x.ItemBase.Id))
                 .ThenBy(x => x.ItemBase is ITradableItem).ToList();
         }
 


### PR DESCRIPTION
### Description

1. change ordering at EnhancementInventory: order by grade -> then by cp
2. 더스트, ap포션에 이어 새 아이템이 상위 목록에 추가될 수 있도록 추가함

### Related Links

resolve #5226 

### Screenshot
![image](https://github.com/planetarium/NineChronicles/assets/48484989/242ca8f2-38a2-4c5d-9bbc-c1ed28e3cdca)
