### PR TITLE
fix key backup feature at main blocking popup

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Widget/System/IconAndButtonSystem.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/System/IconAndButtonSystem.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections;
+using System.Linq;
+using Libplanet.Crypto;
 using Nekoyume.Blockchain;
 using Nekoyume.Game.Controller;
 using Nekoyume.Helper;
@@ -8,7 +10,6 @@ using Nekoyume.Model.Mail;
 using Nekoyume.UI.Module;
 using Nekoyume.UI.Scroller;
 using TMPro;
-using UniRx;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -155,9 +156,10 @@ namespace Nekoyume.UI
         {
             CancelCallback = () =>
             {
-                var agent = Game.Game.instance.Agent;
+                var address = KeyManager.Instance.GetList().FirstOrDefault()?.Item2.Address ??
+                              new Address();
                 var cachedPassphrase = KeyManager.GetCachedPassphrase(
-                    agent.Address,
+                    address,
                     Util.AesDecrypt,
                     defaultValue: string.Empty);
                 if (cachedPassphrase.Equals(string.Empty))


### PR DESCRIPTION
### Description

1. fix key backup feature at main blocking popup
2. 메인화면에서 키 백업을 할 때 Agent initialize가 안돼있어서 address를 못찾고 뻗는 버그를 고쳤습니다.

### Related Links

resolve #5232 
