### PR TITLE
use another secret at 9cK android build

### DIFF
--- a/.github/workflows/android-build-and-release-for-9ck.yml
+++ b/.github/workflows/android-build-and-release-for-9ck.yml
@@ -64,7 +64,7 @@ jobs:
     environment:
       name: k
     env:
-      GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
+      GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON_K }}
 
     steps:
       - name: Set CRLF


### PR DESCRIPTION
### Description

1. use another secret at 9cK android build
2. 9cK 안드로이드에서 firebase 통계가 안잡히고 있어서 불확실한 env 대신 아예 다른 secret key를 쓰게 변경했습니다.