### PR TITLE
5238 adventureboss getstate bug fix

### DIFF
--- a/nekoyume/Assets/_Scripts/Extensions/GetStateExtensions.cs
+++ b/nekoyume/Assets/_Scripts/Extensions/GetStateExtensions.cs
@@ -134,6 +134,8 @@ namespace Nekoyume
         private static HashDigest<SHA256> adventureBossLatestSeasonLastStateRootHash;
         public static async Task<SeasonInfo> GetAdventureBossLatestSeasonAsync(this IAgent agent, HashDigest<SHA256>? stateRootHash = null, long blockIndex = 0)
         {
+            string stateroot = stateRootHash == null ? "null" : stateRootHash.Value.ToString();
+            NcDebug.Log($"[AdventureBoss] Get LatestSeason blockIndex: {blockIndex} stateRootHash: {stateroot} agentBlockIndex: {agent.BlockIndex}");
             IValue latestSeason;
             if (stateRootHash == null)
             {
@@ -143,7 +145,7 @@ namespace Nekoyume
                 }
                 else
                 {
-                    adventureBossLatestSeasonLastBlockIndex = agent.BlockIndex;
+                    adventureBossLatestSeasonLastBlockIndex = agent.BlockIndex - 1;
                     latestSeason = await agent.GetStateAsync(Addresses.AdventureBoss, AdventureBossModule.LatestSeasonAddress);
                 }
             }
@@ -167,6 +169,8 @@ namespace Nekoyume
         private static HashDigest<SHA256> adventureBossSeasonInfoLastStateRootHash;
         public static async Task<SeasonInfo> GetAdventureBossSeasonInfoAsync(this IAgent agent, long seasonId, HashDigest<SHA256>? stateRootHash = null, long blockIndex = 0)
         {
+            string stateroot = stateRootHash == null ? "null" : stateRootHash.Value.ToString();
+            NcDebug.Log($"[AdventureBoss] Get SeasonInfo Season: {seasonId} blockIndex: {blockIndex} stateRootHash: {stateroot} agentBlockIndex: {agent.BlockIndex}");
             IValue seasonInfo;
             if (stateRootHash == null)
             {
@@ -176,7 +180,7 @@ namespace Nekoyume
                 }
                 else
                 {
-                    adventureBossSeasonInfoLastBlockIndex = agent.BlockIndex;
+                    adventureBossSeasonInfoLastBlockIndex = agent.BlockIndex - 1;
                     seasonInfo = await agent.GetStateAsync(Addresses.AdventureBoss, new Address(AdventureBossHelper.GetSeasonAsAddressForm(seasonId)));
                 }
             }
@@ -200,6 +204,8 @@ namespace Nekoyume
         private static HashDigest<SHA256> bountyBoardLastStateRootHash;
         public static async Task<BountyBoard> GetBountyBoardAsync(this IAgent agent, long seasonId, HashDigest<SHA256>? stateRootHash = null, long blockIndex = 0)
         {
+            string stateroot = stateRootHash == null ? "null" : stateRootHash.Value.ToString();
+            NcDebug.Log($"[AdventureBoss] Get BountyBoard Season: {seasonId} blockIndex: {blockIndex} stateRootHash: {stateroot} agentBlockIndex: {agent.BlockIndex}");
             IValue bountyBoard;
             if (stateRootHash == null)
             {
@@ -209,7 +215,7 @@ namespace Nekoyume
                 }
                 else
                 {
-                    bountyBoardLastBlockIndex = agent.BlockIndex;
+                    bountyBoardLastBlockIndex = agent.BlockIndex - 1;
                     bountyBoard = await agent.GetStateAsync(Addresses.BountyBoard, new Address(AdventureBossHelper.GetSeasonAsAddressForm(seasonId)));
                 }
             }
@@ -233,6 +239,8 @@ namespace Nekoyume
         private static HashDigest<SHA256> exploreBoardLastStateRootHash;
         public static async Task<ExploreBoard> GetExploreBoardAsync(this IAgent agent, long seasonId, HashDigest<SHA256>? stateRootHash = null, long blockIndex = 0)
         {
+            string stateroot = stateRootHash == null ? "null" : stateRootHash.Value.ToString();
+            NcDebug.Log($"[AdventureBoss] Get ExploreBoard Season: {seasonId} blockIndex: {blockIndex} stateRootHash: {stateroot} agentBlockIndex: {agent.BlockIndex}");
             IValue exploreBoard;
             if (stateRootHash == null)
             {
@@ -242,7 +250,7 @@ namespace Nekoyume
                 }
                 else
                 {
-                    exploreBoardLastBlockIndex = agent.BlockIndex;
+                    exploreBoardLastBlockIndex = agent.BlockIndex - 1;
                     exploreBoard = await agent.GetStateAsync(Addresses.ExploreBoard, new Address(AdventureBossHelper.GetSeasonAsAddressForm(seasonId)));
                 }
             }
@@ -266,6 +274,8 @@ namespace Nekoyume
         private static HashDigest<SHA256> exploreInfoLastStateRootHash;
         public static async Task<Explorer> GetExploreInfoAsync(this IAgent agent, Address avatarAddress, long seasonId, HashDigest<SHA256>? stateRootHash = null, long blockIndex = 0)
         {
+            string stateroot = stateRootHash == null ? "null" : stateRootHash.Value.ToString();
+            NcDebug.Log($"[AdventureBoss] Get ExploreInfo Avatar: {avatarAddress}  Season: {seasonId} blockIndex: {blockIndex} stateRootHash: {stateroot} agentBlockIndex: {agent.BlockIndex}");
             IValue exploreInfo;
             if (stateRootHash == null)
             {
@@ -275,7 +285,7 @@ namespace Nekoyume
                 }
                 else
                 {
-                    exploreInfoLastBlockIndex = agent.BlockIndex;
+                    exploreInfoLastBlockIndex = agent.BlockIndex - 1;
                     exploreInfo = await agent.GetStateAsync(Addresses.ExploreBoard, avatarAddress.Derive(AdventureBossHelper.GetSeasonAsAddressForm(seasonId)));
                 }
             }

--- a/nekoyume/Assets/_Scripts/UI/Module/WorldMapAdventureBoss.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/WorldMapAdventureBoss.cs
@@ -122,7 +122,15 @@ namespace Nekoyume.UI.Module
         private void RefreshBlockIndexText(long blockIndex, long targetBlock)
         {
             _remainingBlockIndex = targetBlock - blockIndex;
-            var timeText = $"{_remainingBlockIndex:#,0}({_remainingBlockIndex.BlockRangeToTimeSpanString()})";
+            var timeText = "(-)";
+            if (_remainingBlockIndex >= 0)
+            {
+                timeText = _remainingBlockIndex.BlockRangeToTimeSpanString();
+            }
+            else
+            {
+                NcDebug.LogError($"RemainingBlockIndex is negative blockIndex: {blockIndex}, targetBlock: {targetBlock}");
+            }
             foreach (var text in remainingBlockIndexs)
             {
                 text.text = timeText;


### PR DESCRIPTION
어드벤처보스 관련 GetState 실패 관련 문제 수정.
sloth 대응으로 캐싱하는 최신 블록인덱스를 roothash로 갱신하지않는경우 현재블록인덱스에서 하나를뺸것으로 캐싱하도록 수정.

rootHash없이 스테이트를 가져오는경우 캐싱된 블록인덱스와 현재인덱스가 같거나 캐싱된블록인덱스가 큰 경우 캐싱된 rootHash를 사용하여 갱신하는데 현재인덱스로만 갱신을 두번연속하게되는경우 문제가발생할수있었음.

---
gpt요약
문제점: 기존 로직에서 rootHash 없이 상태를 요청할 때 현재 블록 인덱스와 캐싱된 블록 인덱스를 비교하지 않고 직접 갱신하였을 때 문제 발생 가능성 확인

수정 내용:

stateRootHash가 null일 경우 캐싱된 rootHash와 블록 인덱스를 이용하여 안전하게 상태를 조회
현재 블록 인덱스가 캐싱된 블록 인덱스보다 클 경우, 캐싱된 블록 인덱스를 현재 블록 인덱스에서 하나 뺀 값으로 갱신하여 동기화 문제 해결
이러한 변경을 통해 상태 조회의 안정성을 높이고, 잠재적인 동기화 오류를 방지함.