### PR TITLE
슈퍼크래프트 갱신 버그 수정

### DIFF
--- a/nekoyume/Assets/_Scripts/State/States.cs
+++ b/nekoyume/Assets/_Scripts/State/States.cs
@@ -70,14 +70,14 @@ namespace Nekoyume.State
 
         public AllRuneState AllRuneState { get; private set; }
 
-        public readonly Dictionary<int, Dictionary<BattleType, RuneSlotState>>
+        public readonly ConcurrentDictionary<int, Dictionary<BattleType, RuneSlotState>>
             RuneSlotStates = new();
 
-        public readonly Dictionary<int, Dictionary<BattleType, ItemSlotState>>
+        public readonly ConcurrentDictionary<int, Dictionary<BattleType, ItemSlotState>>
             ItemSlotStates = new();
 
-        public Dictionary<BattleType, RuneSlotState> CurrentRuneSlotStates { get; } = new();
-        public Dictionary<BattleType, ItemSlotState> CurrentItemSlotStates { get; } = new();
+        public ConcurrentDictionary<BattleType, RuneSlotState> CurrentRuneSlotStates { get; } = new();
+        public ConcurrentDictionary<BattleType, ItemSlotState> CurrentItemSlotStates { get; } = new();
 
         private class Workshop
         {
@@ -204,20 +204,20 @@ namespace Nekoyume.State
         public async UniTask InitRuneSlotStates()
         {
             CurrentRuneSlotStates.Clear();
-            CurrentRuneSlotStates.Add(
+            CurrentRuneSlotStates.TryAdd(
                 BattleType.Adventure,
                 new RuneSlotState(BattleType.Adventure));
-            CurrentRuneSlotStates.Add(BattleType.Arena, new RuneSlotState(BattleType.Arena));
-            CurrentRuneSlotStates.Add(BattleType.Raid, new RuneSlotState(BattleType.Raid));
+            CurrentRuneSlotStates.TryAdd(BattleType.Arena, new RuneSlotState(BattleType.Arena));
+            CurrentRuneSlotStates.TryAdd(BattleType.Raid, new RuneSlotState(BattleType.Raid));
 
             RuneSlotStates.Clear();
             foreach (var (index, avatarState) in _avatarStates)
             {
-                RuneSlotStates.Add(index, new Dictionary<BattleType, RuneSlotState>());
-                RuneSlotStates[index].Add(BattleType.Adventure,
+                RuneSlotStates.TryAdd(index, new Dictionary<BattleType, RuneSlotState>());
+                RuneSlotStates[index].TryAdd(BattleType.Adventure,
                     new RuneSlotState(BattleType.Adventure));
-                RuneSlotStates[index].Add(BattleType.Arena, new RuneSlotState(BattleType.Arena));
-                RuneSlotStates[index].Add(BattleType.Raid, new RuneSlotState(BattleType.Raid));
+                RuneSlotStates[index].TryAdd(BattleType.Arena, new RuneSlotState(BattleType.Arena));
+                RuneSlotStates[index].TryAdd(BattleType.Raid, new RuneSlotState(BattleType.Raid));
 
                 var addresses = new List<Address>
                 {
@@ -272,22 +272,22 @@ namespace Nekoyume.State
         public async UniTask InitItemSlotStates()
         {
             CurrentItemSlotStates.Clear();
-            CurrentItemSlotStates.Add(
+            CurrentItemSlotStates.TryAdd(
                 BattleType.Adventure,
                 new ItemSlotState(BattleType.Adventure));
-            CurrentItemSlotStates.Add(BattleType.Arena, new ItemSlotState(BattleType.Arena));
-            CurrentItemSlotStates.Add(BattleType.Raid, new ItemSlotState(BattleType.Raid));
+            CurrentItemSlotStates.TryAdd(BattleType.Arena, new ItemSlotState(BattleType.Arena));
+            CurrentItemSlotStates.TryAdd(BattleType.Raid, new ItemSlotState(BattleType.Raid));
 
             ItemSlotStates.Clear();
             var agent = Game.Game.instance.Agent;
             foreach (var (index, avatarState) in _avatarStates)
             {
-                ItemSlotStates.Add(index, new Dictionary<BattleType, ItemSlotState>());
-                ItemSlotStates[index].Add(
+                ItemSlotStates.TryAdd(index, new Dictionary<BattleType, ItemSlotState>());
+                ItemSlotStates[index].TryAdd(
                     BattleType.Adventure,
                     new ItemSlotState(BattleType.Adventure));
-                ItemSlotStates[index].Add(BattleType.Arena, new ItemSlotState(BattleType.Arena));
-                ItemSlotStates[index].Add(BattleType.Raid, new ItemSlotState(BattleType.Raid));
+                ItemSlotStates[index].TryAdd(BattleType.Arena, new ItemSlotState(BattleType.Arena));
+                ItemSlotStates[index].TryAdd(BattleType.Raid, new ItemSlotState(BattleType.Raid));
 
                 var addresses = new List<Address>
                 {
@@ -319,12 +319,12 @@ namespace Nekoyume.State
                 return;
             }
 
-            ItemSlotStates.Add(slotIndex, new Dictionary<BattleType, ItemSlotState>());
-            ItemSlotStates[slotIndex].Add(
+            ItemSlotStates.TryAdd(slotIndex, new Dictionary<BattleType, ItemSlotState>());
+            ItemSlotStates[slotIndex].TryAdd(
                 BattleType.Adventure,
                 new ItemSlotState(BattleType.Adventure));
-            ItemSlotStates[slotIndex].Add(BattleType.Arena, new ItemSlotState(BattleType.Arena));
-            ItemSlotStates[slotIndex].Add(BattleType.Raid, new ItemSlotState(BattleType.Raid));
+            ItemSlotStates[slotIndex].TryAdd(BattleType.Arena, new ItemSlotState(BattleType.Arena));
+            ItemSlotStates[slotIndex].TryAdd(BattleType.Raid, new ItemSlotState(BattleType.Raid));
 
             var addresses = new List<Address>
             {

--- a/nekoyume/Assets/_Scripts/UI/Widget/Craft.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Craft.cs
@@ -17,6 +17,7 @@ using Nekoyume.L10n;
 using Nekoyume.Model.Mail;
 using Nekoyume.Model.Quest;
 using System.Linq;
+using Libplanet.Crypto;
 using Libplanet.Types.Assets;
 using Nekoyume.Blockchain;
 using Nekoyume.Game;
@@ -101,6 +102,8 @@ namespace Nekoyume.UI
 
         private List<IDisposable> _disposables = new List<IDisposable>();
 
+        private Address _currentAvatarAddress;
+
         protected override void Awake()
         {
             base.Awake();
@@ -184,13 +187,15 @@ namespace Nekoyume.UI
                 : JsonSerializer.Deserialize<CombinationSubRecipeTabs>(jsonAsset.text);
             SubRecipeTabs = subRecipeTabs?.SubRecipeTabs.ToList();
 
+            // TODO SelectAvatar를 실제 아바타가 변경됐을때 최초 한번만 호출하면 불필요한 초기화를 안하도록 고칠 수 있음
             ReactiveAvatarState.Address.Subscribe(address =>
             {
-                if (address.Equals(default))
+                if (address.Equals(default) || _currentAvatarAddress == address)
                 {
                     return;
                 }
 
+                _currentAvatarAddress = address;
                 SharedModel.UpdateUnlockedRecipesAsync(address);
             }).AddTo(gameObject);
 


### PR DESCRIPTION
- resolve #5260 
- avoid collection was modified when select avatar

---

렌더등을 통해 아바타가 업데이트됐을때 ReactiveAvatarState.Address를 구독하고 있는곳에서 상태를 갱신하려다 발생하는 버그로, 원래 의도로 보이는 게임에서 선택된 아바타가 변경됐을때만 상태를 초기화하고 그 이후에는 렌더러에서 업데이트한 상태만 사용하도록 변경합니다.