### PR TITLE
아바타목록 collection modified 문제 회피

### DIFF
--- a/nekoyume/Assets/_Scripts/State/States.cs
+++ b/nekoyume/Assets/_Scripts/State/States.cs
@@ -54,7 +54,7 @@ namespace Nekoyume.State
 
         public CrystalRandomSkillState CrystalRandomSkillState { get; private set; }
 
-        private readonly Dictionary<int, AvatarState> _avatarStates = new();
+        private readonly ConcurrentDictionary<int, AvatarState> _avatarStates = new();
 
         public IReadOnlyDictionary<int, AvatarState> AvatarStates => _avatarStates;
 
@@ -506,7 +506,7 @@ namespace Nekoyume.State
             if (!_avatarStates.ContainsKey(index))
                 throw new KeyNotFoundException($"{nameof(index)}({index})");
 
-            _avatarStates.Remove(index);
+            _avatarStates.TryRemove(index, out _);
 
             if (index == CurrentAvatarKey)
             {


### PR DESCRIPTION
- resolve #5282

---

`InitRuneSlotStates` 가 호출된 시점에는 아바타 목록이 업데이트될일이 없는걸 기대하고 있는데, 현재 `AddorReplaceAvatarStateAsync`의 비동기처리와 함께 산발적으로 호출되는 문제가 원인으로 추정되어 오류가 발생하고 있습니다. 