### PR TITLE
fix refresh timing

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Module/WorldMapAdventureBoss.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/WorldMapAdventureBoss.cs
@@ -69,12 +69,12 @@ namespace Nekoyume.UI.Module
 
         private void OnEnable()
         {
+            Game.Game.instance.AdventureBossData.CurrentState.Subscribe(OnAdventureBossStateChanged).AddTo(_disposables);
+
             Game.Game.instance.Agent.BlockIndexSubject
                 .StartWith(Game.Game.instance.Agent.BlockIndex)
                 .Subscribe(UpdateViewAsync)
                 .AddTo(_disposables);
-
-            Game.Game.instance.AdventureBossData.CurrentState.Subscribe(OnAdventureBossStateChanged).AddTo(_disposables);
 
             Game.Game.instance.AdventureBossData.IsRewardLoading.Subscribe(isLoading =>
             {


### PR DESCRIPTION
월드맵 진입시 어드벤처보스 블록갱신이 바로되지않는문제 수정
블록인덱스 갱신을 CurrentState변경에서 예외처리로 초기화해주는부분에서 덮어쓰고있어서 순서변경한것으로 수정진행