### PR TITLE
update skill option icon position

### DIFF
--- a/nekoyume/Assets/Resources/UI/Prefabs/UI_ItemTooltip.prefab
+++ b/nekoyume/Assets/Resources/UI/Prefabs/UI_ItemTooltip.prefab
@@ -31776,7 +31776,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 10, y: -14}
+  m_AnchoredPosition: {x: 5, y: -14}
   m_SizeDelta: {x: 20, y: 20}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &8765766207818271036
@@ -32232,7 +32232,7 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 1691207599003355518}
   m_HandleRect: {fileID: 4119769666421683849}
   m_Direction: 2
-  m_Value: 1.0000001
+  m_Value: 1.0000004
   m_Size: 0.42389327
   m_NumberOfSteps: 0
   m_OnValueChanged:


### PR DESCRIPTION
### Description

1. 스탯 옵션의 아이콘이랑 스킬 옵션의 아이콘 위치가 안맞아서 불편했던 문제를 해결합니다.


### Required Reviewers

### Screenshot
![image](https://github.com/planetarium/NineChronicles/assets/48484989/b30c467d-0583-494d-9936-6eabdb2d62f2)
