### PR TITLE
어드벤처보스관련 스테이트갱신이 끝나기전에 갱신하는경우 기다리도록 lock처리 및 로딩스크린 제거안되던이슈 수정.

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Module/Item/BaseItemView.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/Item/BaseItemView.cs
@@ -219,6 +219,7 @@ namespace Nekoyume
 
         public void ItemViewSetCurrencyData(FungibleAssetValue fav)
         {
+            _disposables.DisposeAllAndClear();
             gameObject.SetActive(true);
             ClearItem();
             ItemImage.overrideSprite = SpriteHelper.GetFavIcon(fav.Currency.Ticker);
@@ -228,6 +229,7 @@ namespace Nekoyume
 
         public void ItemViewSetCurrencyData(string ticker, decimal amount)
         {
+            _disposables.DisposeAllAndClear();
             gameObject.SetActive(true);
             ClearItem();
             ItemImage.overrideSprite = SpriteHelper.GetFavIcon(ticker);
@@ -237,12 +239,12 @@ namespace Nekoyume
 
         public bool ItemViewSetCurrencyData(int favId, decimal amount)
         {
+            _disposables.DisposeAllAndClear();
             RuneSheet runeSheet = Game.Game.instance.TableSheets.RuneSheet;
             runeSheet.TryGetValue(favId, out var runeRow);
             if (runeRow != null)
             {
                 ItemViewSetCurrencyData(runeRow.Ticker, amount);
-                _disposables.DisposeAllAndClear();
                 touchHandler.OnClick.Subscribe(_ =>
                 {
                     Widget.Find<FungibleAssetTooltip>().Show(runeRow.Ticker, ((BigInteger)amount).ToCurrencyNotation(), null);

--- a/nekoyume/Assets/_Scripts/UI/Widget/AdventureBossResultPopup.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/AdventureBossResultPopup.cs
@@ -164,10 +164,11 @@ namespace Nekoyume.UI
             {
                 if(!worldMapLoading.isActiveAndEnabled)
                 {
-                    worldMapLoading.Show(LoadingScreen.LoadingType.AdventureBoss);
+                    worldMapLoading.Show(LoadingScreen.LoadingType.AdventureBoss, ignoreShowAnimation: true);
                 }
                 await UniTask.WaitForEndOfFrame();
             }
+            worldMapLoading.Close();
         }
 
         public void OnClickTower()


### PR DESCRIPTION
어드벤처보스관련 스테이트갱신이 끝나기전에 갱신하는경우 기다리도록 lock처리 및 로딩스크린 제거안되던이슈 수정.
메인페이지에서 리워드 정상적으로 보이지않던 문제 수정
