### PR TITLE
fix frostbite animation on disapper aura

### DIFF
--- a/nekoyume/Assets/_Scripts/Game/Aura/AuraIceShield.cs
+++ b/nekoyume/Assets/_Scripts/Game/Aura/AuraIceShield.cs
@@ -148,6 +148,11 @@ namespace Nekoyume.Game
 
         private IEnumerator OnFrostBite()
         {
+            if (!_isPlaying)
+            {
+                yield break;
+            }
+            
             var castingTrack = summonedSpine.AnimationState.SetAnimation(0, CastingAnimation, false);
             frostBiteParticle.Play();
             while (!castingTrack.IsComplete)
@@ -155,10 +160,7 @@ namespace Nekoyume.Game
                 yield return null;
             }
 
-            if (_isPlaying)
-            {
-                summonedSpine.AnimationState.SetAnimation(0, IdleAnimation, true);
-            }
+            summonedSpine.AnimationState.SetAnimation(0, IdleAnimation, true);
         }
         
         public static bool IsFrostBiteBuff(int buffId)


### PR DESCRIPTION
### Description

스킬 순서가 꼬였을 때 발생할 수 있는, ice shield버프가 끝났는데 frostbite 애니메이션을 수행하고 굳는 현상을 방지합니다

#5398 