### PR TITLE
아이템 강화시 결과 아이템이 보이지 않는 문제 수정

### DIFF
--- a/nekoyume/Assets/_Scripts/Blockchain/ActionRenderHandler.cs
+++ b/nekoyume/Assets/_Scripts/Blockchain/ActionRenderHandler.cs
@@ -1325,6 +1325,7 @@ namespace Nekoyume.Blockchain
                    out var avatarState))
             {
                 // 액션을 스테이징한 시점에 미리 반영해둔 아이템의 레이어를 먼저 제거하고, 액션의 결과로 나온 실제 상태를 반영
+                LocalLayerModifier.AddNonFungibleItem(avatarAddress, eval.Action.itemId, false);
                 foreach (var tradableId in result.materialItemIdList)
                 {
                     if (avatarState.inventory.TryGetNonFungibleItem(


### PR DESCRIPTION


https://github.com/planetarium/NineChronicles/assets/3193043/87d7d09a-597d-4188-b225-7f92d771fb96


---
- resolve #5306
- 아이템 강화시 재료 레이어만 정리를 하고 강화에 사용한 아이템의 레이어를 정리하지 않는게 원인으로 보여서 수정했습니다.