### PR TITLE
fix collection effect ordering by stattype

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Module/CollectionEffect.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/CollectionEffect.cs
@@ -35,6 +35,7 @@ namespace Nekoyume.UI.Module
 
             var data = stats
                 .GroupBy(stat => stat.StatType)
+                .OrderBy(grouping => grouping.Key)
                 .Select(grouping => (
                     StatType: grouping.Key,
                     AddValue: grouping


### PR DESCRIPTION
### Description

- fix #5414 

### Screenshot

캐릭터 정보 화면의 스탯 순서와 같은 순서로 정렬함
![image](https://github.com/user-attachments/assets/fc743127-894d-48c0-be6e-156e0f34fc72)
![image](https://github.com/user-attachments/assets/c7c79e98-f644-4ac1-9db3-570a3effba0c)

