### PR TITLE
Remove target locked pet only

### DIFF
--- a/nekoyume/Assets/_Scripts/State/PetStates.cs
+++ b/nekoyume/Assets/_Scripts/State/PetStates.cs
@@ -10,7 +10,7 @@ namespace Nekoyume.State
     {
         private readonly Dictionary<int, PetState> _petDict = new();
 
-        private readonly HashSet<int> _lockedPets = new(); 
+        private readonly HashSet<int> _lockedPets = new();
 
         public readonly Subject<PetStates> PetStatesSubject = new();
 
@@ -32,7 +32,10 @@ namespace Nekoyume.State
         public void UpdatePetState(int id, PetState petState)
         {
             _petDict[id] = petState;
-            _lockedPets.Clear();
+            if (_lockedPets.Contains(id))
+            {
+                _lockedPets.Remove(id);
+            }
             PetStatesSubject.OnNext(this);
         }
 


### PR DESCRIPTION
- resolve #5415
- 펫스테이트 업데이트시 잠금처리를 해둔 모든 상태를 풀어버리고 있는데, 대상만 잠금을 풀도록 처리합니다.