### PR TITLE
fix add hammer popup bugs

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Widget/Enhancement.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Enhancement.cs
@@ -198,7 +198,7 @@ namespace Nekoyume.UI
             var (baseItem, materialItems, hammers) = enhancementInventory.GetSelectedModels();
 
             // Equip Upgrade ToDO
-            if (!IsInteractableButton(baseItem, materialItems))
+            if (!IsInteractableButton(baseItem, materialItems, hammers))
             {
                 NotificationSystem.Push(MailType.System, _errorMessage,
                     NotificationCell.NotificationType.Alert);
@@ -287,9 +287,12 @@ namespace Nekoyume.UI
             enhancementInventory.DeselectBaseItem();
         }
 
-        private bool IsInteractableButton(IItem item, List<Equipment> materials)
+        private bool IsInteractableButton(
+            IItem item,
+            List<Equipment> materials,
+            Dictionary<int, int> hammers)
         {
-            if (item is null || materials.Count == 0)
+            if (item is null || materials.Count + hammers.Count == 0)
             {
                 _errorMessage = L10nManager.Localize("UI_SELECT_MATERIAL_TO_UPGRADE");
                 return false;

--- a/nekoyume/Assets/_Scripts/UI/Widget/Popup/AddHammerPopup.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Popup/AddHammerPopup.cs
@@ -129,7 +129,7 @@ namespace Nekoyume.UI
             base.Show();
 
             _baseItem = baseModel;
-            _baseExp = GetBaseExp(baseModel, materialModels);
+            _baseExp = GetBaseExp(baseModel, materialModels, hammerItem.ItemBase);
             _hammerItem = new CountEditableItem(
                 hammerItem.ItemBase,
                 hammerItem.SelectedMaterialCount.Value,
@@ -153,7 +153,8 @@ namespace Nekoyume.UI
 
         private static long GetBaseExp(
             Equipment baseItem,
-            List<EnhancementInventoryItem> materialModels)
+            List<EnhancementInventoryItem> materialModels,
+            ItemBase ignoreItem)
         {
             var equipmentItemSheet = Game.Game.instance.TableSheets.EquipmentItemSheet;
             var enhancementCostSheet = Game.Game.instance.TableSheets.EnhancementCostSheetV3;
@@ -163,7 +164,8 @@ namespace Nekoyume.UI
                 enhancementCostSheet);
             var materialItemsExp = materialModels.Sum(inventoryItem =>
             {
-                if (ItemEnhancement.HammerIds.Contains(inventoryItem.ItemBase.Id))
+                if (ItemEnhancement.HammerIds.Contains(inventoryItem.ItemBase.Id) &&
+                    inventoryItem.ItemBase.Id != ignoreItem.Id)
                 {
                     var hammerExp = Equipment.GetHammerExp(
                         inventoryItem.ItemBase.Id,


### PR DESCRIPTION
### Description

아래 오류 수정했습니다.
- 해머만 재료로 넣었을 때 버튼이 눌리지 않음
- 재료로 넣었던 해머의 개수를 수정할 때 예상 경험치가 잘못 계산됨
