### PR TITLE
add force-updating for HAS rendering

### DIFF
--- a/nekoyume/Assets/_Scripts/State/States.cs
+++ b/nekoyume/Assets/_Scripts/State/States.cs
@@ -691,9 +691,9 @@ namespace Nekoyume.State
 #endregion
 
         /// <summary>
-        /// `CurrentAvatarKey`에 따라서 `CurrentAvatarState`를 업데이트 한다.
+        /// AvatarState를 받아 Update하는 메소드입니다. 무조건 깨끗한 상태의 체인에서 받아온 AvatarState를 넣는걸 목적으로 합니다.
         /// </summary>
-        private void UpdateCurrentAvatarState(AvatarState state,
+        public void UpdateCurrentAvatarState(AvatarState state,
             bool initializeReactiveState = true)
         {
             CurrentAvatarState = state;


### PR DESCRIPTION
### Description

1. HAS 렌더시 로컬의 상태와 체인상의 상태가 불일치해서 전투의 재현 결과가 다를 수 있는 문제가 있었습니다.
2. AvatarState, AllRuneState, CollectionState를 강제로 previousState로 갱신한 뒤 전투를 재현하도록 수정했습니다.

### Related Links

resolve #4355 

### Required Reviewers

@ipdae @eugene-doobu @tyrosine1153 @jonny-jeahyunchoi 
