### PR TITLE
이벤트 팝업 닫지 못하는 문제 수정

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Widget/Popup/EventReleaseNotePopup.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Popup/EventReleaseNotePopup.cs
@@ -188,6 +188,10 @@ namespace Nekoyume.UI
 
         public override void Show(bool ignoreShowAnimation = false)
         {
+            if (!_isInitialized)
+            {
+                Initialize();
+            }
             base.Show(ignoreShowAnimation);
             OnForceToggleOnEventTab();
             PlayerPrefs.SetString(LastReadingDayKey, DateTime.Today.ToString(DateTimeFormat));
@@ -195,6 +199,10 @@ namespace Nekoyume.UI
 
         public void Show(EventNoticeData eventNotice, bool ignoreStartAnimation = false)
         {
+            if (!_isInitialized)
+            {
+                Initialize();
+            }
             base.Show(ignoreStartAnimation);
             if (!eventTabButton.IsToggledOn)
             {

--- a/nekoyume/Assets/_Scripts/UI/Widget/Popup/EventReleaseNotePopup.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Popup/EventReleaseNotePopup.cs
@@ -79,6 +79,12 @@ namespace Nekoyume.UI
             }
         }
 
+        protected override void Awake()
+        {
+            base.Awake();
+            closeButton.onClick.AddListener(() => Close());
+        }
+
         public override void Initialize()
         {
             base.Initialize();
@@ -108,7 +114,6 @@ namespace Nekoyume.UI
                     }
                 }).AddTo(gameObject);
                 _tabGroup.SetToggledOn(eventTabButton);
-                closeButton.onClick.AddListener(() => Close());
 
                 eventTabButton.HasNotification.SetValueAndForceNotify(liveAssetManager.HasUnreadEvent);
                 noticeTabButton.HasNotification.SetValueAndForceNotify(liveAssetManager.HasUnreadNotice);


### PR DESCRIPTION
PromotionContainer에서 예상하지못하는 타이밍에 이벤트팝업을 띄우는 경우가 있음.
이경우 이벤트베너팝업 초기화 타이밍이 어긋나는게될경우 버튼에 이벤트가 안물릴수도있을것같아서 초기화 여부 확인 및 안되있는경우 초기화 하도록 보완.