### PR TITLE
fix refresh world boss state

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Widget/Popup/WorldBossResultPopup.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Popup/WorldBossResultPopup.cs
@@ -141,8 +141,7 @@ namespace Nekoyume.UI
         {
             if (_killRewards is not null && _killRewards.Any())
             {
-                Find<WorldBossRewardScreen>().Show(_killRewards,
-                    () => { Find<WorldBoss>().ShowAsync().Forget(); });
+                Find<WorldBossRewardScreen>().Show(_killRewards, () => { Find<WorldBoss>().ShowAsync().Forget(); });
             }
             else
             {

--- a/nekoyume/Assets/_Scripts/UI/Widget/Screen/WorldBossRewardScreen.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Screen/WorldBossRewardScreen.cs
@@ -124,6 +124,7 @@ namespace Nekoyume.UI
             }
 
             _closeCallback?.Invoke();
+            _closeCallback = null;
             base.Close(ignoreCloseAnimation);
         }
 

--- a/nekoyume/Assets/_Scripts/UI/Widget/WorldBoss.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/WorldBoss.cs
@@ -149,7 +149,7 @@ namespace Nekoyume.UI
         protected override void OnEnable()
         {
             Game.Game.instance.Agent.BlockIndexSubject
-                .Subscribe(x => UpdateViewAsync(x))
+                .Subscribe(x => UpdateViewAsync(x).Forget())
                 .AddTo(_disposables);
         }
 
@@ -176,17 +176,33 @@ namespace Nekoyume.UI
             _headerMenu.Show(assetVisibleState, showHeaderMenuAnimation);
         }
 
-        private async Task UpdateViewAsync(long currentBlockIndex,
-            bool forceUpdate = false,
+        private async UniTask UpdateViewAsync(long currentBlockIndex,
+            bool forceUpdateState = false,
             bool ignoreHeaderMenuAnimation = false,
             bool ignoreHeaderMenu = false)
         {
-            if (forceUpdate)
+            var avatarAddress = States.Instance.CurrentAvatarState.address;
+            await UpdateWorldBossState(currentBlockIndex, avatarAddress, forceUpdateState, ignoreHeaderMenuAnimation, ignoreHeaderMenu);
+            
+            var raiderState = WorldBossStates.GetRaiderState(avatarAddress);
+            var refillInterval = States.Instance.GameConfigState.DailyWorldBossInterval;
+            _headerMenu.WorldBossTickets.UpdateTicket(raiderState, currentBlockIndex, refillInterval);
+            var secondsPerBlock = LiveAssetManager.instance.GameConfig.SecondsPerBlock;
+            UpdateRemainTimer(_period, currentBlockIndex, secondsPerBlock);
+            SetActiveQueryLoading(false);
+        }
+
+        private async UniTask UpdateWorldBossState(long currentBlockIndex,
+            Address avatarAddress,
+            bool forceUpdateState = false,
+            bool ignoreHeaderMenuAnimation = false,
+            bool ignoreHeaderMenu = false)
+        {
+            if (forceUpdateState)
             {
                 _status = WorldBossStatus.None;
             }
 
-            var avatarAddress = States.Instance.CurrentAvatarState.address;
             var curStatus = WorldBossFrontHelper.GetStatus(currentBlockIndex);
             if (_status != curStatus)
             {
@@ -232,13 +248,6 @@ namespace Nekoyume.UI
                         throw new ArgumentOutOfRangeException();
                 }
             }
-
-            var raiderState = WorldBossStates.GetRaiderState(avatarAddress);
-            var refillInterval = States.Instance.GameConfigState.DailyWorldBossInterval;
-            _headerMenu.WorldBossTickets.UpdateTicket(raiderState, currentBlockIndex, refillInterval);
-            var secondsPerBlock = LiveAssetManager.instance.GameConfig.SecondsPerBlock;
-            UpdateRemainTimer(_period, currentBlockIndex, secondsPerBlock);
-            SetActiveQueryLoading(false);
         }
 
         private void UpdateOffSeason(long currentBlockIndex)


### PR DESCRIPTION
### Description

1. 월드보스 리워드 UI에서 무조건 WorldBoss UI로 향하던 기능을 제거합니다(Close시 Callback 초기화)
2. UI갱신을 통해 월드보스 상태를 강제 갱신시키는 부분을 마지막으로 갱신된 blockIndex와 비교하여 업데이트하는것으로 변경합니다.

### Related Links

#5481 
