### PR TITLE
eventDungeonInfo.Value NRE check

### DIFF
--- a/nekoyume/Assets/_Scripts/Helper/ShortcutHelper.cs
+++ b/nekoyume/Assets/_Scripts/Helper/ShortcutHelper.cs
@@ -447,6 +447,7 @@ namespace Nekoyume.Helper
             {
                 case PlaceType.EventDungeonStage:
                     var playableStageId =
+                        RxProps.EventDungeonInfo.Value is null ||
                         !RxProps.EventDungeonInfo.HasValue ||
                         RxProps.EventDungeonInfo.Value.ClearedStageId == 0
                             ? RxProps.EventDungeonRow.StageBegin


### PR DESCRIPTION
eventDungeonInfo.Value NRE check
eventDungeonInfo.Value가 null인 시점에 shortcuthelper에서 사용하는부분이있어서 예외처리진행.
