### PR TITLE
fix black screen issue

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Widget/MobileShop.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/MobileShop.cs
@@ -149,8 +149,7 @@ namespace Nekoyume.UI
             {
                 NcDebug.LogError(e.Message);
                 loading.Close();
-                base.Show(ignoreShowAnimation);
-                Close();
+                Game.Event.OnRoomEnter.Invoke(false);
                 if (Game.LiveAsset.GameConfig.IsKoreanBuild)
                 {
                     Find<IconAndButtonSystem>().Show(


### PR DESCRIPTION
https://github.com/planetarium/NineChronicles/issues/5183
해당 수정의 사이드 이팩트로 모바일 샾 예외처리시 로비화면이 나오지않고 검은화면만 나오는 이슈를 수정합니다.