### PR TITLE
fix y position refresh while shake

### DIFF
--- a/nekoyume/Assets/_Scripts/Game/ActionCamera.cs
+++ b/nekoyume/Assets/_Scripts/Game/ActionCamera.cs
@@ -266,7 +266,6 @@ namespace Nekoyume.Game
 
             if (_targetTemp)
             {
-                pos = Transform.position;
                 pos.x = CalulateChaseXPos(_targetTemp.position, chase);
             }
 


### PR DESCRIPTION
연속해서 화면흔들기 연출이나올때 카메라 y위치가 뒤틀리는 문제 수정.
화면흔들기 끝나기 전 y위치로 갱신해야되는데 타겟이있을경우 현재위치 기준으로 y위치를 갱신하면서 틀어지는 문제로 확인.
y값은 기준점이 변하지않으므로 갱신하지않는것으로 수정.