### PR TITLE
fix Combination slot migration

### DIFF
--- a/nekoyume/Assets/_Scripts/Blockchain/StateGetter.cs
+++ b/nekoyume/Assets/_Scripts/Blockchain/StateGetter.cs
@@ -134,40 +134,6 @@ namespace Nekoyume.Blockchain
 
             return new Inventory((List)inventoryState);
         }
-        
-        [Obsolete("Use AllCombinationSlotState instead.")]
-        public static CombinationSlotState GetCombinationSlotState(
-            Address avatarAddress,
-            int index)
-        {
-            var address = avatarAddress.Derive(
-                string.Format(
-                    CultureInfo.InvariantCulture,
-                    CombinationSlotState.DeriveFormat,
-                    index
-                )
-            );
-            var value = Game.Game.instance.Agent.GetState(
-                ReservedAddresses.LegacyAccount,
-                address);
-            if (value is null or Null)
-            {
-                throw new StateNullException(ReservedAddresses.LegacyAccount, address);
-            }
-
-            try
-            {
-                return new CombinationSlotState((Dictionary)value);
-            }
-            catch (Exception e)
-            {
-                Log.Error(
-                    e,
-                    "Unexpected error occurred during {CombinationSlotStateName}()",
-                    nameof(GetCombinationSlotState));
-                throw;
-            }
-        }
 
         [Obsolete("Use AllCombinationSlotState instead.")]
         public static CombinationSlotState GetCombinationSlotState(

--- a/nekoyume/Assets/_Scripts/Extensions/GetStateExtensions.cs
+++ b/nekoyume/Assets/_Scripts/Extensions/GetStateExtensions.cs
@@ -73,12 +73,23 @@ namespace Nekoyume
             }
             else
             {
-                allCombinationSlotState = AllCombinationSlotState.MigrationLegacySlotState(slotIndex =>
+                var combinationSlotAddresses = new List<Address>();
+                for (var i = 0; i < AvatarState.DefaultCombinationSlotCount; i++)
                 {
-#pragma warning disable CS0618 // Type or member is obsolete
-                    return StateGetter.GetCombinationSlotState(avatarAddress, slotIndex);
-#pragma warning restore CS0618 // Type or member is obsolete
-                }, avatarAddress);
+                    combinationSlotAddresses.Add(CombinationSlotState.DeriveAddress(avatarAddress, i));
+                }
+                var bulkStates = await agent.GetStateBulkAsync(ReservedAddresses.LegacyAccount, combinationSlotAddresses);
+                allCombinationSlotState = new AllCombinationSlotState();
+                
+                for (var i = 0; i < AvatarState.DefaultCombinationSlotCount; i++)
+                {
+                    var bulkState = bulkStates[combinationSlotAddresses[i]];
+                    var slotState = new CombinationSlotState((Dictionary)bulkState)
+                    {
+                        Index = i
+                    };
+                    allCombinationSlotState.AddSlot(slotState);
+                }
             }
 
             return allCombinationSlotState;

--- a/nekoyume/Assets/_Scripts/State/States.cs
+++ b/nekoyume/Assets/_Scripts/State/States.cs
@@ -84,7 +84,7 @@ namespace Nekoyume.State
 
         private class Workshop
         {
-            public Dictionary<int, CombinationSlotState> States { get; } = new();
+            public SortedDictionary<int, CombinationSlotState> States { get; } = new();
         }
 
         public PetStates PetStates { get; } = new();
@@ -690,7 +690,7 @@ namespace Nekoyume.State
         }
 
         [CanBeNull]
-        public Dictionary<int, CombinationSlotState> GetCombinationSlotState(AvatarState avatarState)
+        public IDictionary<int, CombinationSlotState> GetCombinationSlotState(AvatarState avatarState)
         {
             return !_slotStates.ContainsKey(avatarState.address) ? null : _slotStates[avatarState.address].States;
         }

--- a/nekoyume/Assets/_Scripts/UI/Widget/Popup/CombinationSlotsPopup.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Popup/CombinationSlotsPopup.cs
@@ -165,7 +165,7 @@ namespace Nekoyume.UI
             slots[slotIndex].SetLockLoading(isLoading);
         }
 
-        private void UpdateSlots(long blockIndex, Dictionary<int, CombinationSlotState> states)
+        private void UpdateSlots(long blockIndex, IDictionary<int, CombinationSlotState> states)
         {
             var avatarState = States.Instance.CurrentAvatarState;
             states ??= States.Instance.GetCombinationSlotState(avatarState);


### PR DESCRIPTION
StateGetter.GetCombinationSlotState로 가져오던 상태를 agent.GetStateBulkAsync로 가져오도록 변경합니다.
그리고 lib9c 수정사항을 적용합니다

## lib9c 수정사항
https://github.com/planetarium/lib9c/pull/2766

https://github.com/planetarium/lib9c/pull/2768