### PR TITLE
qr reader backbbutton fix

### DIFF
--- a/nekoyume/Assets/Resources/UI/Prefabs/UI_IntroScreen.prefab
+++ b/nekoyume/Assets/Resources/UI/Prefabs/UI_IntroScreen.prefab
@@ -19019,7 +19019,7 @@ PrefabInstance:
     - target: {fileID: 7657312722897278047, guid: 29c5c99555c2b5f40a6f757cea5554b3,
         type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_MethodName
-      value: ShowMobile
+      value: OnClickQrReaderBackButton
       objectReference: {fileID: 0}
     - target: {fileID: 7657312722897278047, guid: 29c5c99555c2b5f40a6f757cea5554b3,
         type: 3}

--- a/nekoyume/Assets/_Scripts/UI/Widget/Screen/IntroScreen.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Screen/IntroScreen.cs
@@ -759,5 +759,10 @@ namespace Nekoyume.UI
                 L10nManager.Localize("BTN_OPEN_A_BROWSER"),
                 false);
         }
+
+        public void OnClickQrReaderBackButton()
+        {
+            keyImportButton.onClick.Invoke();
+        }
     }
 }


### PR DESCRIPTION
QR코드 Read시 Backbutton 동작안하는 문제 수정PR입니다.
Back버튼에 지워진 ShowMobile 함수를 사용하고있는것 확인했고, 임포트창 다시띄우는 버튼 불러주는방식으로 수정하였습니다.