### PR TITLE
fix iap refresh nre

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Widget/MobileShop.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/MobileShop.cs
@@ -352,6 +352,11 @@ namespace Nekoyume.UI
 
         private void RefreshGridByCategory(string categoryName)
         {
+            if(string.IsNullOrEmpty(categoryName))
+            {
+                return;
+            }
+
             Analyzer.Instance.Track("Unity/Shop/IAP/Tab/Click", ("category-name", categoryName));
 
             var evt = new AirbridgeEvent("IAP_Tab_Click");


### PR DESCRIPTION
모바일상점 페이지를 한번도 들어가지않고 시즌패스 결제를 하는 경우 구매 완료처리시 NRE 로인해 ConfirmPendingPurchase 이 정상적을 불리지 않는 문제 수정.
빈문자열로 카테고리 딕셔너리를 참조하다가 NRE 발생.