### PR TITLE
iap exception handle

### DIFF
--- a/nekoyume/Assets/NineChronicles/ExternalServices/IAPService/Runtime/IAPServiceEndpoints.cs
+++ b/nekoyume/Assets/NineChronicles/ExternalServices/IAPService/Runtime/IAPServiceEndpoints.cs
@@ -12,6 +12,7 @@ namespace NineChronicles.ExternalServices.IAPService.Runtime
         public readonly Uri PurchaseStatus;
         public readonly Uri PurchaseLog;
         public readonly Uri L10N;
+        public readonly Uri PurchaseRetry;
 
         public IAPServiceEndpoints(string url)
         {
@@ -23,6 +24,7 @@ namespace NineChronicles.ExternalServices.IAPService.Runtime
             PurchaseStatus = new Uri(Url + "/api/purchase/status");
             PurchaseLog = new Uri(Url + "/api/purchase/log");
             L10N = new Uri(Url + "/api/l10n");
+            PurchaseRetry = new Uri(Url + "/api/purchase/retry");
         }
     }
 }

--- a/nekoyume/Assets/_Scripts/IAPStore/IAPStoreManager.cs
+++ b/nekoyume/Assets/_Scripts/IAPStore/IAPStoreManager.cs
@@ -272,9 +272,9 @@ namespace Nekoyume.IAPStore
             {
                 var result = await ApiClients.Instance.IAPServiceManager
                     .PurchaseLogAsync(
-                        states.AgentState.address.ToHex(),
-                        states.CurrentAvatarState.address.ToHex(),
-                        Game.Game.instance.CurrentPlanetId.ToString(),
+                        states?.AgentState?.address.ToHex(),
+                        states?.CurrentAvatarState?.address.ToHex(),
+                        Game.Game.instance?.CurrentPlanetId?.ToString(),
                         productId,
                         orderId,
                         data);
@@ -354,9 +354,9 @@ namespace Nekoyume.IAPStore
                     "Unity/Shop/IAP/ProcessPurchase",
                     ("product-id", e.purchasedProduct.definition.id),
                     ("transaction-id", e.purchasedProduct.transactionID),
-                    ("agent-address", States.Instance.AgentState.address.ToHex()),
-                    ("avatar-address", States.Instance.CurrentAvatarState.address.ToHex()),
-                    ("planet-id", Game.Game.instance.CurrentPlanetId.ToString()));
+                    ("agent-address", States.Instance?.AgentState?.address.ToHex()),
+                    ("avatar-address", States.Instance?.CurrentAvatarState?.address.ToHex()),
+                    ("planet-id", Game.Game.instance?.CurrentPlanetId?.ToString()));
             }
             catch (Exception error)
             {
@@ -381,6 +381,17 @@ namespace Nekoyume.IAPStore
                 existTxInfo = PlayerPrefs.HasKey("PURCHASE_TX_" + e.purchasedProduct.transactionID);
                 if (!existTxInfo)
                 {
+                    if (states?.AgentState?.address == null
+                        || states?.CurrentAvatarState?.address == null
+                        || Game.Game.instance?.CurrentPlanetId == null)
+                    {
+                        NcDebug.Log($"[ProcessPurchase] AgentState{states?.AgentState?.address.ToHex()}, AvatarState{states?.CurrentAvatarState?.address.ToHex()} or PlanetId{Game.Game.instance?.CurrentPlanetId.ToString()} is null");
+                        // Todo : TX 정보만 가지고 구매처리 시도해야함.
+
+
+                        return PurchaseProcessingResult.Pending;
+                    }
+
                     var purchaseReciepe = new PurchaseReciept
                     {
                         Receipt = e.purchasedProduct.receipt,


### PR DESCRIPTION
iap 초기화로 인해서 구매요청시 NRE체크 및 예외처리작업

- [x] tx만 가지고 구매요청 처리하는 api나오면 추가적용해야함.