### PR TITLE
fix rendering sequence about CustomEquipmentCraft action

### DIFF
--- a/nekoyume/Assets/_Scripts/Blockchain/ActionRenderHandler.cs
+++ b/nekoyume/Assets/_Scripts/Blockchain/ActionRenderHandler.cs
@@ -4274,7 +4274,6 @@ namespace Nekoyume.Blockchain
             UpdateCombinationSlotState(avatarAddress, slotIndex, slot);
             UpdateAgentStateAsync(eval).Forget();
             UpdateCurrentAvatarStateAsync(eval).Forget();
-            LoadingHelper.CustomEquipmentCraft.Value = false;
 
             return (eval, slot);
         }
@@ -4326,6 +4325,7 @@ namespace Nekoyume.Blockchain
             // ~Notify
 
             Widget.Find<CombinationSlotsPopup>().OnCraftActionRender(slotIndex);
+            LoadingHelper.CustomEquipmentCraft.Value = false;
         }
 
         /// <summary>

--- a/nekoyume/Assets/_Scripts/Blockchain/ActionRenderHandler.cs
+++ b/nekoyume/Assets/_Scripts/Blockchain/ActionRenderHandler.cs
@@ -872,7 +872,7 @@ namespace Nekoyume.Blockchain
                 {
                     UpdatePetState(avatarAddress, slotState.PetId.Value, eval.OutputState);
                 }
-                
+
                 slotStates.Add(slotState);
             }
 
@@ -884,7 +884,7 @@ namespace Nekoyume.Blockchain
         {
             var avatarAddress = renderArgs.Evaluation.Action.avatarAddress;
             var slotIndexList = renderArgs.Evaluation.Action.slotIndexList;
-            
+
             if (renderArgs.CombinationSlotStates is null)
             {
                 NcDebug.LogError("CombinationSlotState is null.");
@@ -896,7 +896,7 @@ namespace Nekoyume.Blockchain
                 NcDebug.LogError("AvatarState is null.");
                 return;
             }
-            
+
             foreach (var slotIndex in slotIndexList)
             {
                 var index = slotIndex;
@@ -904,13 +904,13 @@ namespace Nekoyume.Blockchain
                     .Where(state => state.Index == index)
                     .Select(state => (RapidCombination5.ResultModel)state.Result)
                     .FirstOrDefault();
-                
+
                 if (result is null)
                 {
                     NcDebug.LogError("Result is null.");
                     continue;
                 }
-                
+
                 string formatKey;
                 var currentBlockIndex = Game.Game.instance.Agent.BlockIndex;
 
@@ -4267,15 +4267,14 @@ namespace Nekoyume.Blockchain
         {
             var avatarAddress = eval.Action.AvatarAddress;
             var slotIndex = eval.Action.CraftList.FirstOrDefault().SlotIndex;
+            ReactiveAvatarState.UpdateRelationship(
+                (Integer)StateGetter.GetState(eval.OutputState, Addresses.Relationship, avatarAddress)
+            );
             var slot = GetStateExtensions.GetCombinationSlotState(eval.OutputState, avatarAddress, slotIndex);
-            LoadingHelper.CustomEquipmentCraft.Value = false;
             UpdateCombinationSlotState(avatarAddress, slotIndex, slot);
             UpdateAgentStateAsync(eval).Forget();
             UpdateCurrentAvatarStateAsync(eval).Forget();
-
-            ReactiveAvatarState.UpdateProficiency(
-                (Integer)StateGetter.GetState(eval.OutputState, Addresses.Relationship, avatarAddress)
-            );
+            LoadingHelper.CustomEquipmentCraft.Value = false;
 
             return (eval, slot);
         }

--- a/nekoyume/Assets/_Scripts/State/ReactiveAvatarState.cs
+++ b/nekoyume/Assets/_Scripts/State/ReactiveAvatarState.cs
@@ -107,9 +107,9 @@ namespace Nekoyume.State
             _questList.SetValueAndForceNotify(questList);
         }
 
-        public static void UpdateProficiency(long proficiency)
+        public static void UpdateRelationship(long relationship)
         {
-            _relationship.SetValueAndForceNotify(proficiency);
+            _relationship.SetValueAndForceNotify(relationship);
         }
     }
 }

--- a/nekoyume/Assets/_Scripts/State/States.cs
+++ b/nekoyume/Assets/_Scripts/State/States.cs
@@ -619,7 +619,7 @@ namespace Nekoyume.State
             ReactiveAvatarState.UpdateDailyRewardReceivedIndex(listStates[3] is Integer index
                 ? index
                 : curAvatarState.dailyRewardReceivedIndex);
-            ReactiveAvatarState.UpdateProficiency(listStates[4] is Integer proficiency
+            ReactiveAvatarState.UpdateRelationship(listStates[4] is Integer proficiency
                 ? proficiency
                 : 0);
 


### PR DESCRIPTION
### Description

1. CustomEquipmentCraft 액션을 렌더할때 상태를 병렬로 가져오지 않고 순차적으로 가져오는데, 이때 LoadingHelper의 값이 갱신되면서 제작은 가능해졌지만 실제로 드는 비용 따위는 늦게 갱신되는 경우가 있어 이를 수정했습니다.

### Related Links

resolve #5718

