### PR TITLE
Feature/fix pet button in workshop

### DIFF
--- a/nekoyume/Assets/Resources/UI/Prefabs/CombinationSlot.prefab
+++ b/nekoyume/Assets/Resources/UI/Prefabs/CombinationSlot.prefab
@@ -9979,6 +9979,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 17b02b95bdb156841b56b22378f3b58f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  lockButton: {fileID: 1187452486021232400}
   costText: {fileID: 3172165208916715075}
   loadingIndicator: {fileID: 6150848573912631196}
   lockPriceObject: {fileID: 579591126688764477}

--- a/nekoyume/Assets/_Scripts/UI/Module/CombinationSlot.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/CombinationSlot.cs
@@ -336,7 +336,7 @@ namespace Nekoyume.UI.Module
             long currentBlockIndex,
             CombinationSlotState? state)
         {
-            petSelectButton.SetData(state?.PetId ?? null);
+            UpdatePetButton(uiState, state);
 
             switch (uiState)
             {
@@ -394,6 +394,24 @@ namespace Nekoyume.UI.Module
                     SetContainer(true, false, false, false);
                     itemView.Clear();
                     break;
+            }
+        }
+        
+        private void UpdatePetButton(SlotUIState uiState, CombinationSlotState? state)
+        {
+            switch (uiState)
+            {
+                case SlotUIState.Locked:
+                case SlotUIState.Empty:
+                    petSelectButton.SetData(null);
+                    break;
+                case SlotUIState.Appraise:
+                case SlotUIState.Working:
+                case SlotUIState.WaitingReceive:
+                    petSelectButton.SetData(state?.PetId ?? null);
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(uiState), uiState, null);
             }
         }
 

--- a/nekoyume/Assets/_Scripts/UI/Module/CombinationSlot.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/CombinationSlot.cs
@@ -403,9 +403,9 @@ namespace Nekoyume.UI.Module
             {
                 case SlotUIState.Locked:
                 case SlotUIState.Empty:
+                case SlotUIState.Appraise:
                     petSelectButton.SetData(null);
                     break;
-                case SlotUIState.Appraise:
                 case SlotUIState.Working:
                 case SlotUIState.WaitingReceive:
                     petSelectButton.SetData(state?.PetId ?? null);

--- a/nekoyume/Assets/_Scripts/UI/Module/CombinationSlot.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/CombinationSlot.cs
@@ -410,8 +410,6 @@ namespace Nekoyume.UI.Module
                 case SlotUIState.WaitingReceive:
                     petSelectButton.SetData(state?.PetId ?? null);
                     break;
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(uiState), uiState, null);
             }
         }
 

--- a/nekoyume/Assets/_Scripts/UI/Module/CombinationSlotLockObject.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/CombinationSlotLockObject.cs
@@ -1,8 +1,6 @@
 #nullable enable
 
 using System;
-using System.Collections;
-using System.Collections.Generic;
 using System.Numerics;
 using Nekoyume.Blockchain;
 using Nekoyume.Game.Controller;
@@ -11,17 +9,17 @@ using Nekoyume.State;
 using Nekoyume.TableData;
 using TMPro;
 using UnityEngine;
-using UnityEngine.Serialization;
 using UnityEngine.UI;
 
 namespace Nekoyume.UI.Model
 {
     public class CombinationSlotLockObject : MonoBehaviour
     {
-        private Button _button = null!;
-
         // TODO: 동적으로 이미지 변경?
         // private Image _costImage;
+
+        [SerializeField]
+        private Button lockButton = null!;
 
         [SerializeField]
         private TMP_Text costText = null!;
@@ -38,8 +36,7 @@ namespace Nekoyume.UI.Model
 #region MonoBehavior
         private void Awake()
         {
-            _button = GetComponent<Button>();
-            _button.onClick.AddListener(() =>
+            lockButton.onClick.AddListener(() =>
             {
                 AudioController.PlayClick();
                 ShowPaymentPopup();
@@ -56,6 +53,7 @@ namespace Nekoyume.UI.Model
         {
             loadingIndicator.SetActive(isLoading);
             lockPriceObject.SetActive(!isLoading);
+            lockButton.interactable = !isLoading;
         }
 
         private void ShowPaymentPopup()


### PR DESCRIPTION
1. 이전 슬롯에 있던 펫 상태가 빈(혹은 lock상태의)슬롯에 적용되지 않도록 변경합니다
2. lock상태의 슬롯에 unlock액션을 보낸 후 로딩중일 때 클릭이 안되도록 설정합니다. 