### PR TITLE
fix eventDungeon result not shown

### DIFF
--- a/nekoyume/Assets/_Scripts/Game/Battle/Stage.cs
+++ b/nekoyume/Assets/_Scripts/Game/Battle/Stage.cs
@@ -498,9 +498,20 @@ namespace Nekoyume.Game.Battle
             NcDebug.Log($"[{nameof(Stage)}] {nameof(CoGuidedQuest)}() enter. stageIdToClear: {stageIdToClear}");
 #endif
             var done = false;
+            var startTime = Time.time;
             var battle = Widget.Find<UI.Battle>();
             battle.ClearStage(stageIdToClear, cleared => done = true);
-            yield return new WaitUntil(() => done);
+            yield return new WaitUntil(() =>
+            {
+                // NOTE: 5초 이상 걸리면 타임아웃 처리
+                // ClearStage onComplete 콜백체인에서 원인을 찾기 어려운 문제가 발생할수 있어 추가
+                if (Time.time >= startTime + 5f)
+                {
+                    NcDebug.LogError("CoGuidedQuest() timeout.");
+                    return true;
+                }
+                return done;
+            });
         }
 
         private static IEnumerator CoUnlockRecipe(int stageIdToFirstClear)

--- a/nekoyume/Assets/_Scripts/Game/Battle/Stage.cs
+++ b/nekoyume/Assets/_Scripts/Game/Battle/Stage.cs
@@ -498,14 +498,14 @@ namespace Nekoyume.Game.Battle
             NcDebug.Log($"[{nameof(Stage)}] {nameof(CoGuidedQuest)}() enter. stageIdToClear: {stageIdToClear}");
 #endif
             var done = false;
-            var startTime = Time.time;
+            var startTime = Time.unscaledTime;
             var battle = Widget.Find<UI.Battle>();
             battle.ClearStage(stageIdToClear, cleared => done = true);
             yield return new WaitUntil(() =>
             {
                 // NOTE: 5초 이상 걸리면 타임아웃 처리
                 // ClearStage onComplete 콜백체인에서 원인을 찾기 어려운 문제가 발생할수 있어 추가
-                if (Time.time >= startTime + 5f)
+                if (Time.unscaledTime >= startTime + 5f)
                 {
                     NcDebug.LogError("CoGuidedQuest() timeout.");
                     return true;

--- a/nekoyume/Assets/_Scripts/UI/Module/GuidedQuest.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/GuidedQuest.cs
@@ -374,9 +374,19 @@ namespace Nekoyume.UI.Module
                     $"[{nameof(GuidedQuest)}] Cannot proceed because ViewState is {_state.Value}. Try when state is {ViewState.Shown}");
                 return;
             }
-
-            SharedViewModel.avatarState = avatarState;
-            StartCoroutine(CoUpdateList(onComplete));
+            try
+            {
+                SharedViewModel.avatarState = avatarState;
+                StartCoroutine(CoUpdateList(onComplete));
+            }
+            catch (Exception e)
+            {
+                NcDebug.LogError($"[GuidedQuest UpdateList] {e}");
+            }
+            finally
+            {
+                onComplete?.Invoke();
+            }
         }
 
 #endregion
@@ -422,26 +432,31 @@ namespace Nekoyume.UI.Module
 
         private IEnumerator CoUpdateList(System.Action onComplete)
         {
-            var questList = SharedViewModel.avatarState?.questList;
-            //각 Coriutine마다 시간을 체크하여 소요시간을 로그로 남깁니다.
-            var watch = Stopwatch.StartNew();
-            yield return StartCoroutine(CoUpdateWorldQuest(questList));
-            watch.Stop();
-            NcDebug.Log($"CoUpdateWorldQuest 소요시간 : {watch.ElapsedMilliseconds}ms");
-            watch.Restart();
-            yield return StartCoroutine(CoUpdateCombinationEquipmentQuest(questList));
-            watch.Stop();
-            NcDebug.Log($"CoUpdateCombinationEquipmentQuest 소요시간 : {watch.ElapsedMilliseconds}ms");
-            watch.Restart();
-            yield return StartCoroutine(CoUpdateEventDungeonQuest());
-            watch.Stop();
-            NcDebug.Log($"CoUpdateEventDungeonQuest 소요시간 : {watch.ElapsedMilliseconds}ms");
-            watch.Restart();
-            yield return StartCoroutine(CoUpdateCraftEventItemQuest());
-            watch.Stop();
-            NcDebug.Log($"CoUpdateCraftEventItemQuest 소요시간 : {watch.ElapsedMilliseconds}ms");
-            watch.Restart();
-            onComplete?.Invoke();
+            try
+            {
+                var questList = SharedViewModel.avatarState?.questList;
+                //각 Coriutine마다 시간을 체크하여 소요시간을 로그로 남깁니다.
+                var watch = Stopwatch.StartNew();
+                yield return StartCoroutine(CoUpdateWorldQuest(questList));
+                watch.Stop();
+                NcDebug.Log($"CoUpdateWorldQuest 소요시간 : {watch.ElapsedMilliseconds}ms");
+                watch.Restart();
+                yield return StartCoroutine(CoUpdateCombinationEquipmentQuest(questList));
+                watch.Stop();
+                NcDebug.Log($"CoUpdateCombinationEquipmentQuest 소요시간 : {watch.ElapsedMilliseconds}ms");
+                watch.Restart();
+                yield return StartCoroutine(CoUpdateEventDungeonQuest());
+                watch.Stop();
+                NcDebug.Log($"CoUpdateEventDungeonQuest 소요시간 : {watch.ElapsedMilliseconds}ms");
+                watch.Restart();
+                yield return StartCoroutine(CoUpdateCraftEventItemQuest());
+                watch.Stop();
+                NcDebug.Log($"CoUpdateCraftEventItemQuest 소요시간 : {watch.ElapsedMilliseconds}ms");
+            }
+            finally
+            {
+                onComplete?.Invoke();
+            }
         }
 
         private IEnumerator CoUpdateWorldQuest(QuestList questList)
@@ -792,7 +807,7 @@ namespace Nekoyume.UI.Module
                 if (state == ViewState.ClearExistGuidedQuest &&
                     _eventDungeonQuestCell.Quest is WorldQuest quest)
                 {
-                    NcDebug.LogWarning($"[SubscribeEventDungeonQuest] HideAsClear");
+                    NcDebug.LogWarning($"[SubscribeEventDungeonQuest] HideAsClear {quest.Id}");
                     _eventDungeonQuestCell.HideAsClear(
                         ignoreQuestResult: true,
                         onComplete: _ =>
@@ -803,6 +818,7 @@ namespace Nekoyume.UI.Module
                 }
                 else
                 {
+                    NcDebug.LogWarning($"[SubscribeEventDungeonQuest] HideAsClear Faild  state:{state} questType:{_eventDungeonQuestCell.Quest.GetType()}");
                     _eventDungeonQuestCell.Hide();
                 }
             }

--- a/nekoyume/Assets/_Scripts/UI/Module/GuidedQuest.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/GuidedQuest.cs
@@ -374,19 +374,8 @@ namespace Nekoyume.UI.Module
                     $"[{nameof(GuidedQuest)}] Cannot proceed because ViewState is {_state.Value}. Try when state is {ViewState.Shown}");
                 return;
             }
-            try
-            {
-                SharedViewModel.avatarState = avatarState;
-                StartCoroutine(CoUpdateList(onComplete));
-            }
-            catch (Exception e)
-            {
-                NcDebug.LogError($"[GuidedQuest UpdateList] {e}");
-            }
-            finally
-            {
-                onComplete?.Invoke();
-            }
+            SharedViewModel.avatarState = avatarState;
+            StartCoroutine(CoUpdateList(onComplete));
         }
 
 #endregion
@@ -432,31 +421,25 @@ namespace Nekoyume.UI.Module
 
         private IEnumerator CoUpdateList(System.Action onComplete)
         {
-            try
-            {
-                var questList = SharedViewModel.avatarState?.questList;
-                //각 Coriutine마다 시간을 체크하여 소요시간을 로그로 남깁니다.
-                var watch = Stopwatch.StartNew();
-                yield return StartCoroutine(CoUpdateWorldQuest(questList));
-                watch.Stop();
-                NcDebug.Log($"CoUpdateWorldQuest 소요시간 : {watch.ElapsedMilliseconds}ms");
-                watch.Restart();
-                yield return StartCoroutine(CoUpdateCombinationEquipmentQuest(questList));
-                watch.Stop();
-                NcDebug.Log($"CoUpdateCombinationEquipmentQuest 소요시간 : {watch.ElapsedMilliseconds}ms");
-                watch.Restart();
-                yield return StartCoroutine(CoUpdateEventDungeonQuest());
-                watch.Stop();
-                NcDebug.Log($"CoUpdateEventDungeonQuest 소요시간 : {watch.ElapsedMilliseconds}ms");
-                watch.Restart();
-                yield return StartCoroutine(CoUpdateCraftEventItemQuest());
-                watch.Stop();
-                NcDebug.Log($"CoUpdateCraftEventItemQuest 소요시간 : {watch.ElapsedMilliseconds}ms");
-            }
-            finally
-            {
-                onComplete?.Invoke();
-            }
+            var questList = SharedViewModel.avatarState?.questList;
+            //각 Coriutine마다 시간을 체크하여 소요시간을 로그로 남깁니다.
+            var watch = Stopwatch.StartNew();
+            yield return StartCoroutine(CoUpdateWorldQuest(questList));
+            watch.Stop();
+            NcDebug.Log($"CoUpdateWorldQuest 소요시간 : {watch.ElapsedMilliseconds}ms");
+            watch.Restart();
+            yield return StartCoroutine(CoUpdateCombinationEquipmentQuest(questList));
+            watch.Stop();
+            NcDebug.Log($"CoUpdateCombinationEquipmentQuest 소요시간 : {watch.ElapsedMilliseconds}ms");
+            watch.Restart();
+            yield return StartCoroutine(CoUpdateEventDungeonQuest());
+            watch.Stop();
+            NcDebug.Log($"CoUpdateEventDungeonQuest 소요시간 : {watch.ElapsedMilliseconds}ms");
+            watch.Restart();
+            yield return StartCoroutine(CoUpdateCraftEventItemQuest());
+            watch.Stop();
+            NcDebug.Log($"CoUpdateCraftEventItemQuest 소요시간 : {watch.ElapsedMilliseconds}ms");
+            onComplete?.Invoke();
         }
 
         private IEnumerator CoUpdateWorldQuest(QuestList questList)
@@ -818,7 +801,7 @@ namespace Nekoyume.UI.Module
                 }
                 else
                 {
-                    NcDebug.LogWarning($"[SubscribeEventDungeonQuest] HideAsClear Faild  state:{state} questType:{_eventDungeonQuestCell.Quest.GetType()}");
+                    NcDebug.LogWarning($"[SubscribeEventDungeonQuest] HideAsClear Failed  state:{state} questType:{_eventDungeonQuestCell.Quest.GetType()}");
                     _eventDungeonQuestCell.Hide();
                 }
             }


### PR DESCRIPTION
이벤트 던전에서 간헐적으로 결과창이 나오지 않아서 진행이 불가한문제 예외처리작업진행 및 원인 분석로그 추가하였습니다.

```battle.ClearStage(stageIdToClear, cleared => done = true);```
의 콜백체인에서 cleared 콜백이 불리지않거나 중간에 익셉션이 불려 콜백체인이 끊킨다거나하는 이슈로  결과창이 안나올수 있는문제가있어, 5초정도 기다린뒤에도 콜백이 불리지않으면 일단 결과창띄워 진행을 막지않는 방식으로 예외처리 추가하였습니다.