### PR TITLE
remove slot update in Appraise state

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Module/CombinationSlot.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/CombinationSlot.cs
@@ -93,15 +93,15 @@ namespace Nekoyume.UI.Module
         private CombinationSlotLockObject _lockObject = null!;
         private CombinationSlotState? _state;
         private int _slotIndex;
-        
+
         // TODO: 클라이언트 액션 에러처리 추가
         private long _sendActionBlockIndex;
         // 액션 렌더보다 block 업데이트가 더 빠른 경우, _state가 갱신이 안됬는데
         // BlockIndex가 갱신되어 UI가 잘못 갱신될 수 있음
         private bool _isWaitingCombinationActionRender;
-        
+
         private readonly List<IDisposable> _disposablesOfOnEnable = new();
-        
+
         public CombinationSlotState? State => _state;
 
         public SlotUIState UIState { get; private set; } = SlotUIState.Locked;
@@ -125,12 +125,12 @@ namespace Nekoyume.UI.Module
             {
                 NcDebug.LogWarning("Invalid UIState.");
             }
-            
+
             UIState = SlotUIState.WaitingReceive;
             UpdateInformation(Game.instance.Agent.BlockIndex);
             _isWaitingCombinationActionRender = false;
         }
-        
+
         public void OnSendCombinationAction(long requiredBlockIndex, ItemUsable itemUsable)
         {
             if (UIState != SlotUIState.Empty)
@@ -138,9 +138,9 @@ namespace Nekoyume.UI.Module
                 NcDebug.LogWarning("Invalid UIState.");
             }
             _isWaitingCombinationActionRender = true;
-            
+
             UIState = SlotUIState.Appraise;
-            
+
             var currentBlockIndex = Game.instance.Agent.BlockIndex;
             UpdateItemInformation(itemUsable, UIState);
             UpdateRequiredBlockInformation(
@@ -157,7 +157,7 @@ namespace Nekoyume.UI.Module
                 AudioController.PlayClick();
                 OnClickSlot(UIState, _state, _slotIndex, Game.instance.Agent.BlockIndex);
             }).AddTo(gameObject);
-            
+
             _lockObject = lockContainer.GetComponent<CombinationSlotLockObject>();
         }
 
@@ -192,7 +192,7 @@ namespace Nekoyume.UI.Module
                 _lockObject.SetData(data);
             }
         }
-        
+
         public void SetLockLoading(bool isLoading)
         {
             _lockObject.SetLoading(isLoading);
@@ -264,7 +264,7 @@ namespace Nekoyume.UI.Module
                     break;
             }
         }
-        
+
         private void OnBlockRenderEmpty(long currentBlockIndex)
         {
             // state result에 값이 있고, 슬롯을 사용할 수 없는 경우 Empty로 변경
@@ -277,7 +277,7 @@ namespace Nekoyume.UI.Module
             UIState = SlotUIState.Working;
             UpdateInformation(currentBlockIndex);
         }
-        
+
         private void OnBlockRenderAppraise(long currentBlockIndex)
         {
             if (_state == null)
@@ -286,7 +286,7 @@ namespace Nekoyume.UI.Module
                 UpdateInformation(currentBlockIndex);
                 return;
             }
-            
+
             var startBlockIndex = Math.Max(_sendActionBlockIndex, _state.StartBlockIndex);
             if (currentBlockIndex <= startBlockIndex || _isWaitingCombinationActionRender)
             {
@@ -296,9 +296,9 @@ namespace Nekoyume.UI.Module
             UIState = SlotUIState.Working;
             UpdateInformation(currentBlockIndex);
         }
-        
+
         private void OnBlockRenderWorking(long currentBlockIndex)
-        { 
+        {
             if (_state?.Result == null || _sendActionBlockIndex >= currentBlockIndex || !_state.ValidateV2(currentBlockIndex))
             {
                 return;
@@ -307,7 +307,7 @@ namespace Nekoyume.UI.Module
             UIState = SlotUIState.Empty;
             UpdateInformation(currentBlockIndex);
         }
-        
+
         private void OnBlockRenderWaitingReceive(long currentBlockIndex)
         {
             // Not Cached && slot null
@@ -319,7 +319,7 @@ namespace Nekoyume.UI.Module
             UIState = SlotUIState.Empty;
             UpdateInformation(currentBlockIndex);
         }
-        
+
         private void OnBlockRenderLocked(long currentBlockIndex)
         {
             // Do nothing.
@@ -349,15 +349,6 @@ namespace Nekoyume.UI.Module
                     SetContainer(false, true, false, false);
                     preparingContainer.gameObject.SetActive(true);
                     workingContainer.gameObject.SetActive(false);
-                    if (state is { Result: not null })
-                    {
-                        UpdateItemInformation(state.Result.itemUsable, uiState);
-                        UpdateHourglass(state, currentBlockIndex);
-                        UpdateRequiredBlockInformation(
-                            state.UnlockBlockIndex,
-                            state.StartBlockIndex,
-                            currentBlockIndex);
-                    }
                     hasNotificationImage.enabled = false;
                     break;
 
@@ -389,14 +380,14 @@ namespace Nekoyume.UI.Module
                                 true));
                     }
                     break;
-                
+
                 case SlotUIState.Locked:
                     SetContainer(true, false, false, false);
                     itemView.Clear();
                     break;
             }
         }
-        
+
         private void UpdatePetButton(SlotUIState uiState, CombinationSlotState? state)
         {
             switch (uiState)
@@ -467,13 +458,13 @@ namespace Nekoyume.UI.Module
             var row = Game.instance.TableSheets.MaterialItemSheet
                 .OrderedList?
                 .FirstOrDefault(r => r.ItemSubType == ItemSubType.Hourglass);
-            
+
             if (row == null)
             {
                 hasNotificationImage.enabled = false;
                 return;
             }
-            
+
             var isEnough = States.Instance.CurrentAvatarState.inventory
                 .HasFungibleItem(row.ItemId, currentBlockIndex, cost);
             hasNotificationImage.enabled = isEnough;


### PR DESCRIPTION
## 작업설명

- 클라이언트에서 장비 제작 관련 액션을 보내고 나면 해당 슬롯에 또 액션을 보낼 수 없도록 감정 상태가 됩니다.
- 감정상태일 때에는 클라이언트에서 임시로 설정한 아이템이 표시되어야 하고, 이를 액션의 응답이 오면 업데이트 합니다.
- 지금 클라이언트에서 액션을 보내고 슬롯에 임시 장비 상태를 업데이트하는거까지는 되어있는데, 슬롯 업데이트 과정에서 이전에 작업했던 장비 상태를 가져와서 렌더하고 있습니다.
- 이전에 있던 상태를 가져와서 렌더하는거 자체가 불필요한 동작이라 판단하고 제거하였습니다.