### PR TITLE
add check raid enter popup

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Widget/RaidPreparation.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/RaidPreparation.cs
@@ -89,7 +89,6 @@ namespace Nekoyume.UI
         [SerializeField]
         private GameObject currencyContainer;
 
-        private int _requiredCost;
         private int _bossId;
         private readonly List<IDisposable> _disposables = new();
         private HeaderMenuStatic _headerMenu;
@@ -217,7 +216,13 @@ namespace Nekoyume.UI
                     var raiderState = WorldBossStates.GetRaiderState(avatarState.address);
                     if (raiderState is null)
                     {
-                        StartCoroutine(CoRaid());
+                        var cost = GetEntranceFee(avatarState);
+                        var balance = States.Instance.CrystalBalance.MajorUnit;
+                        Find<PaymentPopup>().ShowCheckPaymentCrystal(
+                            balance,
+                            cost,
+                            L10nManager.Localize("UI_BOSS_JOIN_THE_SEASON"),
+                            () => StartCoroutine(CoRaid()));
                     }
                     else
                     {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/eaa024b1-61b5-4655-985d-b1d804bc3bec)

월드보스 상태가 없는 경우 월드보스 진입시 위 팝업을 통해 크리스탈 체크를 하는 로직을 추가하였습니다.