### PR TITLE
Feature/combination slot error

### DIFF
--- a/nekoyume/Assets/_Scripts/Blockchain/ActionRenderHandler.cs
+++ b/nekoyume/Assets/_Scripts/Blockchain/ActionRenderHandler.cs
@@ -460,6 +460,14 @@ namespace Nekoyume.Blockchain
                 .ObserveOnMainThread()
                 .Subscribe(ResponseRapidCombination)
                 .AddTo(_disposables);
+            
+            _actionRenderer.EveryRender<RapidCombination>()
+                .ObserveOn(Scheduler.ThreadPool)
+                .Where(ValidateEvaluationForCurrentAgent)
+                .Where(ValidateEvaluationIsTerminated)
+                .ObserveOnMainThread()
+                .Subscribe(ExceptionRapidCombination)
+                .AddTo(_disposables);
         }
 
         private void GameConfig()
@@ -1025,6 +1033,15 @@ namespace Nekoyume.Blockchain
                 }
 
                 Widget.Find<CombinationSlotsPopup>().OnCraftActionRender(slotIndex);
+            }
+        }
+
+        private void ExceptionRapidCombination(ActionEvaluation<RapidCombination> eval)
+        {
+            var combinationSlotsPopup = Widget.Find<CombinationSlotsPopup>();
+            foreach (var slotIndex in eval.Action.slotIndexList)
+            {
+                combinationSlotsPopup.ClearSlot(slotIndex);
             }
         }
 

--- a/nekoyume/Assets/_Scripts/Blockchain/ActionRenderHandler.cs
+++ b/nekoyume/Assets/_Scripts/Blockchain/ActionRenderHandler.cs
@@ -361,6 +361,14 @@ namespace Nekoyume.Blockchain
                 .ObserveOnMainThread()
                 .Subscribe(ResponseItemEnhancement)
                 .AddTo(_disposables);
+            
+            _actionRenderer.EveryRender<ItemEnhancement>()
+                .ObserveOn(Scheduler.ThreadPool)
+                .Where(ValidateEvaluationForCurrentAgent)
+                .Where(ValidateEvaluationIsTerminated)
+                .ObserveOnMainThread()
+                .Subscribe(ExceptionItemEnhancement)
+                .AddTo(_disposables);
         }
 
         private void DailyReward()
@@ -1534,6 +1542,12 @@ namespace Nekoyume.Blockchain
             }
 
             Widget.Find<CombinationSlotsPopup>().OnCraftActionRender(slotIndex);
+        }
+
+        private void ExceptionItemEnhancement(ActionEvaluation<ItemEnhancement> eval)
+        {
+            var combinationSlotsPopup = Widget.Find<CombinationSlotsPopup>();
+            combinationSlotsPopup.ClearSlot(eval.Action.slotIndex);
         }
 
         private void ResponseAuraSummon(ActionEvaluation<AuraSummon> eval)

--- a/nekoyume/Assets/_Scripts/Blockchain/ActionRenderHandler.cs
+++ b/nekoyume/Assets/_Scripts/Blockchain/ActionRenderHandler.cs
@@ -300,6 +300,14 @@ namespace Nekoyume.Blockchain
                 .ObserveOnMainThread()
                 .Subscribe(ResponseCombinationConsumable)
                 .AddTo(_disposables);
+
+            _actionRenderer.EveryRender<CombinationConsumable>()
+                .ObserveOn(Scheduler.ThreadPool)
+                .Where(ValidateEvaluationForCurrentAgent)
+                .Where(ValidateEvaluationIsTerminated)
+                .ObserveOnMainThread()
+                .Subscribe(ExceptionCombinationConsumable)
+                .AddTo(_disposables);
         }
 
         private void RegisterProduct()
@@ -574,6 +582,14 @@ namespace Nekoyume.Blockchain
                 .Select(PrepareEventConsumableItemCrafts)
                 .ObserveOnMainThread()
                 .Subscribe(ResponseEventConsumableItemCrafts)
+                .AddTo(_disposables);
+            
+            _actionRenderer.EveryRender<EventConsumableItemCrafts>()
+                .ObserveOn(Scheduler.ThreadPool)
+                .Where(ValidateEvaluationForCurrentAgent)
+                .Where(ValidateEvaluationIsTerminated)
+                .ObserveOnMainThread()
+                .Subscribe(ExceptionEventConsumableItemCrafts)
                 .AddTo(_disposables);
         }
 
@@ -1227,7 +1243,8 @@ namespace Nekoyume.Blockchain
 
             NcDebug.LogError(stringBuilder.ToString());
 
-            // TODO: workshop ui 갱신
+            var combinationSlotsPopup = Widget.Find<CombinationSlotsPopup>();
+            combinationSlotsPopup.ClearSlot(q.Action.slotIndex);
         }
 
         private void ResponseCombinationConsumable(
@@ -1265,6 +1282,12 @@ namespace Nekoyume.Blockchain
 
             Widget.Find<CombinationSlotsPopup>()
                 .OnCraftActionRender(renderArgs.Evaluation.Action.slotIndex);
+        }
+
+        private void ExceptionCombinationConsumable(ActionEvaluation<CombinationConsumable> eval)
+        {
+            var combinationSlotsPopup = Widget.Find<CombinationSlotsPopup>();
+            combinationSlotsPopup.ClearSlot(eval.Action.slotIndex);
         }
 
         private (ActionEvaluation<EventConsumableItemCrafts> Evaluation, CombinationSlotState CombinationSlotState) PrepareEventConsumableItemCrafts(
@@ -1316,6 +1339,12 @@ namespace Nekoyume.Blockchain
 
             Widget.Find<CombinationSlotsPopup>()
                 .OnCraftActionRender(renderArgs.Evaluation.Action.SlotIndex);
+        }
+
+        private void ExceptionEventConsumableItemCrafts(ActionEvaluation<EventConsumableItemCrafts> eval)
+        {
+            var combinationSlotsPopup = Widget.Find<CombinationSlotsPopup>();
+            combinationSlotsPopup.ClearSlot(eval.Action.SlotIndex);
         }
 
         private ActionEvaluation<EventMaterialItemCrafts> PrepareEventMaterialItemCrafts(ActionEvaluation<EventMaterialItemCrafts> eval)

--- a/nekoyume/Assets/_Scripts/Blockchain/ActionRenderHandler.cs
+++ b/nekoyume/Assets/_Scripts/Blockchain/ActionRenderHandler.cs
@@ -4302,6 +4302,12 @@ namespace Nekoyume.Blockchain
             }
 
             NcDebug.LogException(eval.Exception?.InnerException ?? eval.Exception);
+            
+            var combinationSlotsPopup = Widget.Find<CombinationSlotsPopup>();
+            foreach (var customCraftData in eval.Action.CraftList)
+            {
+                combinationSlotsPopup.ClearSlot(customCraftData.SlotIndex);
+            }
         }
 
         private (ActionEvaluation<CustomEquipmentCraft>, CombinationSlotState) PrepareCustomEquipmentCraft(

--- a/nekoyume/Assets/_Scripts/UI/Widget/Popup/CombinationSlotsPopup.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Popup/CombinationSlotsPopup.cs
@@ -182,6 +182,16 @@ namespace Nekoyume.UI
             UpdateSlots(blockIndex, null);
             UpdateAllOpenCost(blockIndex);
         }
+
+        public void ClearSlot(int index)
+        {
+            if (index < 0 || index >= slots.Count)
+            {
+                return;
+            }
+            
+            slots[index].Clear();
+        }
         
         public void ClearSlots()
         {


### PR DESCRIPTION
### Description

워크샵 슬롯을 사용하는 액션에 대해 에러처리를 추가합니다.

1. ResponseUnlockCombinationSlot
2. ResponseRapidCombination
3. ResponseCombinationEquipment
4. ResponseCombinationConsumable
5. ResponseEventConsumableItemCrafts
6. ResponseItemEnhancement
7. ResponseCustomEquipmentCraft

### Screenshot

#### 케이스 1. UnlockCombinationSLot

https://github.com/user-attachments/assets/a69925e0-24b7-4a66-b9dc-bacd8c3eaf9b

Unlock Loading 오브젝트를 비활성화

#### 케이스 2. RapidCombination

https://github.com/user-attachments/assets/36c7d1a2-1b70-477d-aacc-1809f3bc0517

장비가 있던 슬롯을 모래시계를 활용하여 즉시 완료시키는 액션

1. 장비가 있던 슬롯을 Clear
2. 슬롯이 Update되며 RapidCombination을 보내기 전 장비가 그대로 슬롯에 렌더링 되고 있음

#### 케이스 3. Craft & Enhancement

https://github.com/user-attachments/assets/3811ddf6-5c1f-40cd-9568-556841ccda14

비어있던 슬롯에 장비 제작을 시작하는 액션
장비가 들어가야할 슬롯을 Clear해줌으로써 상태 초기화
