### PR TITLE
bump lib9c and fix ProductMail

### DIFF
--- a/nekoyume/Assets/_Scripts/Extensions/LocalizationExtensions.cs
+++ b/nekoyume/Assets/_Scripts/Extensions/LocalizationExtensions.cs
@@ -16,6 +16,7 @@ using Nekoyume.Model.Elemental;
 using Nekoyume.Model.EnumType;
 using Nekoyume.Model.Item;
 using Nekoyume.Model.Mail;
+using Nekoyume.Model.Market;
 using Nekoyume.Model.Quest;
 using Nekoyume.Model.Stat;
 using Nekoyume.State;
@@ -205,23 +206,40 @@ namespace Nekoyume
                                 .ProductId);
                     return L10nManager.Localize("UI_SELL_CANCEL_MAIL_FORMAT", productName);
                 case ProductBuyerMail productBuyerMail:
-                    var (buyProductName, _, _) =
-                        await ApiClients.Instance.MarketServiceClient.GetProductInfo(productBuyerMail
-                            .ProductId);
-                    return L10nManager.Localize("UI_BUYER_MAIL_FORMAT", buyProductName);
+                    // 아이템을 구매한 경우
+                    if (productBuyerMail.Product is ItemProduct itemProd &&
+                        States.Instance.CurrentAvatarState.inventory.TryGetTradableItem(itemProd.TradableItem.TradableId, itemProd.TradableItem.RequiredBlockIndex, 1, out var realItem))
+                    {
+                        return L10nManager.Localize("UI_BUYER_MAIL_FORMAT", realItem.item.GetLocalizedName());
+                    }
+
+                    // FAV, 영혼석이나 룬 조각을 구매한 경우
+                    if (productBuyerMail.Product is FavProduct favProd)
+                    {
+                        return L10nManager.Localize("UI_BUYER_MAIL_FORMAT", favProd.Asset.GetLocalizedInformation());
+                    }
+
+                    // 상태에서 아이템을 찾을 수 없는 경우, 메일은 이제 네거야! 라는 문장이 나옵니다.
+                    return L10nManager.Localize("UI_BUYER_MAIL_FORMAT", L10nManager.Localize("UI_MAIL"));
                 case ProductSellerMail productSellerMail:
-                    var (sellProductName, item, fav) =
-                        await ApiClients.Instance.MarketServiceClient.GetProductInfo(
-                            productSellerMail.ProductId);
-                    var price = item?.Price ?? fav?.Price ?? 0;
+                    if (productSellerMail.Product == null)
+                    {
+                        // 이제 Product가 없는 이전의 상품은 무엇을 팔아서 얼마를 얻었는지 알 수 없습니다.
+                        return L10nManager.Localize("UI_SELLER_MAIL_FORMAT", "?", "?");
+                    }
+
+                    var price = (int)productSellerMail.Product.Price.MajorUnit;
                     var tax = decimal.Divide(price, 100) * Buy.TaxRate;
                     var tp = price - tax;
                     var currency = States.Instance.GoldBalanceState.Gold.Currency;
                     var majorUnit = (int)tp;
                     var minorUnit = (int)((tp - majorUnit) * 100);
                     var fungibleAsset = new FungibleAssetValue(currency, majorUnit, minorUnit);
+                    var productType = productSellerMail.Product is ItemProduct itemProduct
+                        ? itemProduct.TradableItem.ItemSubType.GetLocalizedString()
+                        : ((FavProduct) productSellerMail.Product).Asset.GetLocalizedInformation();
                     return L10nManager.Localize("UI_SELLER_MAIL_FORMAT", fungibleAsset,
-                        sellProductName);
+                        productType);
                 case UnloadFromMyGaragesRecipientMail unloadFromMyGaragesRecipientMail:
                     return await unloadFromMyGaragesRecipientMail.GetCellContentAsync();
                 case ClaimItemsMail claimItemsMail:

--- a/nekoyume/Assets/_Scripts/Extensions/LocalizationExtensions.cs
+++ b/nekoyume/Assets/_Scripts/Extensions/LocalizationExtensions.cs
@@ -216,7 +216,7 @@ namespace Nekoyume
                     // FAV, 영혼석이나 룬 조각을 구매한 경우
                     if (productBuyerMail.Product is FavProduct favProd)
                     {
-                        return L10nManager.Localize("UI_BUYER_MAIL_FORMAT", favProd.Asset.GetLocalizedInformation());
+                        return L10nManager.Localize("UI_BUYER_MAIL_FORMAT", favProd.Asset.GetLocalizedName());
                     }
 
                     // 상태에서 아이템을 찾을 수 없는 경우, 메일은 이제 네거야! 라는 문장이 나옵니다.
@@ -237,7 +237,7 @@ namespace Nekoyume
                     var fungibleAsset = new FungibleAssetValue(currency, majorUnit, minorUnit);
                     var productType = productSellerMail.Product is ItemProduct itemProduct
                         ? itemProduct.TradableItem.ItemSubType.GetLocalizedString()
-                        : ((FavProduct) productSellerMail.Product).Asset.GetLocalizedInformation();
+                        : ((FavProduct) productSellerMail.Product).Asset.GetLocalizedName();
                     return L10nManager.Localize("UI_SELLER_MAIL_FORMAT", fungibleAsset,
                         productType);
                 case UnloadFromMyGaragesRecipientMail unloadFromMyGaragesRecipientMail:

--- a/nekoyume/Assets/_Scripts/UI/Widget/Popup/MailPopup.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Popup/MailPopup.cs
@@ -12,6 +12,7 @@ using Nekoyume.Helper;
 using Nekoyume.L10n;
 using Nekoyume.Model.Item;
 using Nekoyume.Model.Mail;
+using Nekoyume.Model.Market;
 using Nekoyume.Model.State;
 using Nekoyume.State;
 using Nekoyume.UI.Model;
@@ -157,26 +158,22 @@ namespace Nekoyume.UI
             switch (mail)
             {
                 case ProductBuyerMail productBuyerMail:
-                    var productId = productBuyerMail.ProductId;
-                    var (_, itemProduct, favProduct) = await ApiClients.Instance.MarketServiceClient.GetProductInfo(productId);
-                    if (itemProduct is not null)
+                    if (productBuyerMail.Product is ItemProduct itemProduct)
                     {
                         var item = States.Instance.CurrentAvatarState.inventory.Items
                             .FirstOrDefault(i => i.item is ITradableItem item &&
-                                item.TradableId.Equals(itemProduct.TradableId));
+                                item.TradableId.Equals(itemProduct.TradableItem.TradableId));
                         if (item?.item is null)
                         {
                             return;
                         }
 
-                        mailRewards.Add(new MailReward(item.item, (int)itemProduct.Quantity, true));
+                        mailRewards.Add(new MailReward(item.item, itemProduct.ItemCount, true));
                     }
 
-                    if (favProduct is not null)
+                    if (productBuyerMail.Product is FavProduct favProduct)
                     {
-                        var currency = Currency.Legacy(favProduct.Ticker, 0, null);
-                        var fav = new FungibleAssetValue(currency, (int)favProduct.Quantity, 0);
-                        mailRewards.Add(new MailReward(fav, (int)favProduct.Quantity, true));
+                        mailRewards.Add(new MailReward(favProduct.Asset, (int)favProduct.Asset.MajorUnit, true));
                     }
 
                     break;
@@ -564,17 +561,15 @@ namespace Nekoyume.UI
             ReactiveAvatarState.UpdateMailBox(States.Instance.CurrentAvatarState.mailBox);
         }
 
-        public async void Read(ProductBuyerMail productBuyerMail)
+        public void Read(ProductBuyerMail productBuyerMail)
         {
             var avatarAddress = States.Instance.CurrentAvatarState.address;
-            var productId = productBuyerMail.ProductId;
-            var (_, itemProduct, favProduct) = await ApiClients.Instance.MarketServiceClient.GetProductInfo(productId);
-            if (itemProduct is not null)
+            if (productBuyerMail.Product is ItemProduct itemProduct)
             {
-                var count = (int)itemProduct.Quantity;
+                var count = itemProduct.ItemCount;
                 var item = States.Instance.CurrentAvatarState.inventory.Items
                     .FirstOrDefault(i => i.item is ITradableItem item &&
-                        item.TradableId.Equals(itemProduct.TradableId));
+                        item.TradableId.Equals(itemProduct.TradableItem.TradableId));
                 if (item is null || item.item is null)
                 {
                     return;
@@ -593,12 +588,13 @@ namespace Nekoyume.UI
                     ReactiveAvatarState.UpdateMailBox(States.Instance.CurrentAvatarState.mailBox);
                 }).AddTo(gameObject);
                 Find<BuyItemInformationPopup>().Pop(model);
+                return;
             }
 
-            if (favProduct is not null)
+            if (productBuyerMail.Product is FavProduct favProduct)
             {
-                var currency = Currency.Legacy(favProduct.Ticker, 0, null);
-                var fav = new FungibleAssetValue(currency, (int)favProduct.Quantity, 0);
+                var currency = Currency.Legacy(favProduct.Asset.Currency.Ticker, 0, null);
+                var fav = new FungibleAssetValue(currency, (int)favProduct.Asset.MajorUnit, 0);
                 Find<BuyFungibleAssetInformationPopup>().Show(
                     fav,
                     () =>
@@ -607,7 +603,12 @@ namespace Nekoyume.UI
                         LocalLayerModifier.RemoveNewMail(avatarAddress, productBuyerMail.id);
                         ReactiveAvatarState.UpdateMailBox(States.Instance.CurrentAvatarState.mailBox);
                     });
+                return;
             }
+
+            productBuyerMail.New = false;
+            LocalLayerModifier.RemoveNewMail(avatarAddress, productBuyerMail.id);
+            ReactiveAvatarState.UpdateMailBox(States.Instance.CurrentAvatarState.mailBox);
         }
 
         public async void Read(ProductSellerMail productSellerMail)


### PR DESCRIPTION
### Description

1. lib9c의 변경사항을 반영합니다. lib9c#2854, lib9c#2855
2. MarketService에서 더 이상 판매된 아이템을 저장하지 않기에, 이 정보를 Mail에 저장하기로 했습니다. 이 내용을 클라에서 처리합니다.
3. 액션 렌더도 마켓 서비스에 의존하고 있었어서 고쳤습니다.

### Related Links

#6001 #6003 #6004
