### PR TITLE
use SetActiveSafe for customCraftArea and fix SeasonPassItemView prefab

### DIFF
--- a/nekoyume/Assets/AddressableAssets/UI/Module/ItemView/SeasonPassItemView.prefab
+++ b/nekoyume/Assets/AddressableAssets/UI/Module/ItemView/SeasonPassItemView.prefab
@@ -306,7 +306,11 @@ MonoBehaviour:
   loadingObject: {fileID: 663870208434522378}
   itemGradeParticle: {fileID: 0}
   grindingCountObject: {fileID: 8900674294457559387}
-  grindingCountText: {fileID: 7273815503661342529}
+  runeNotificationObj: {fileID: 1254456819714753765}
+  runeSelectMove: {fileID: 1254456819714753765}
+  selectCollectionObject: {fileID: 1254456819714753765}
+  selectArrowObject: {fileID: 1254456819714753765}
+  customCraftArea: {fileID: 1254456819714753765}
   RewardReceived: {fileID: 7678607451601508907}
 --- !u!222 &5490539752949421042
 CanvasRenderer:
@@ -802,6 +806,42 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &1254456819714753765
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6844841729902261806}
+  m_Layer: 5
+  m_Name: RealEmpty
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &6844841729902261806
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1254456819714753765}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3174630399916965876}
+  m_RootOrder: 27
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &1459277309609423357
 GameObject:
   m_ObjectHideFlags: 0
@@ -1152,7 +1192,7 @@ MonoBehaviour:
   m_PixelsPerUnitMultiplier: 1
 --- !u!95 &8485222189839187468
 Animator:
-  serializedVersion: 4
+  serializedVersion: 5
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -1169,7 +1209,8 @@ Animator:
   m_WarningMessage: 
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
-  m_KeepAnimatorControllerStateOnDisable: 0
+  m_KeepAnimatorStateOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 0
 --- !u!114 &944456892095014490
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1836,7 +1877,7 @@ MonoBehaviour:
   m_PixelsPerUnitMultiplier: 1
 --- !u!95 &6972984062813391576
 Animator:
-  serializedVersion: 4
+  serializedVersion: 5
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -1853,7 +1894,8 @@ Animator:
   m_WarningMessage: 
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
-  m_KeepAnimatorControllerStateOnDisable: 0
+  m_KeepAnimatorStateOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 0
 --- !u!1 &2684463462337599159
 GameObject:
   m_ObjectHideFlags: 0
@@ -7777,7 +7819,7 @@ RectTransform:
   m_GameObject: {fileID: 4603446637799985294}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 159.99998, y: 159.99998, z: 159.99998}
+  m_LocalScale: {x: 0, y: 0, z: 0}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 6314138194883482364}
@@ -12596,13 +12638,19 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls: []
   m_IsTrail: 0
-  m_IgnoreCanvasScaler: 1
-  m_Scale: 100
+  m_IgnoreCanvasScaler: 0
+  m_AbsoluteMode: 0
   m_Scale3D: {x: 1.2, y: 1.2, z: 1.2}
   m_AnimatableProperties: []
   m_Particles:
   - {fileID: 639234007666031358}
-  m_ShrinkByMaterial: 0
+  m_MeshSharing: 0
+  m_GroupId: 0
+  m_GroupMaxId: 0
+  m_PositionMode: 0
+  m_AutoScaling: 0
+  m_AutoScalingMode: 2
+  m_ResetScaleOnEnable: 0
 --- !u!1 &4976708273243322031
 GameObject:
   m_ObjectHideFlags: 0
@@ -13295,7 +13343,7 @@ MonoBehaviour:
   m_PixelsPerUnitMultiplier: 1
 --- !u!95 &8758886794064268997
 Animator:
-  serializedVersion: 4
+  serializedVersion: 5
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -13312,7 +13360,8 @@ Animator:
   m_WarningMessage: 
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
-  m_KeepAnimatorControllerStateOnDisable: 0
+  m_KeepAnimatorStateOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 0
 --- !u!114 &7860907535144198917
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -14387,7 +14436,7 @@ MonoBehaviour:
   m_PixelsPerUnitMultiplier: 1
 --- !u!95 &6672605960807650873
 Animator:
-  serializedVersion: 4
+  serializedVersion: 5
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -14404,7 +14453,8 @@ Animator:
   m_WarningMessage: 
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
-  m_KeepAnimatorControllerStateOnDisable: 0
+  m_KeepAnimatorStateOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 0
 --- !u!114 &6672605960807650872
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -14871,7 +14921,7 @@ MonoBehaviour:
   m_PixelsPerUnitMultiplier: 1
 --- !u!95 &5742638572275037974
 Animator:
-  serializedVersion: 4
+  serializedVersion: 5
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -14888,7 +14938,8 @@ Animator:
   m_WarningMessage: 
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
-  m_KeepAnimatorControllerStateOnDisable: 0
+  m_KeepAnimatorStateOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 0
 --- !u!114 &2559572434878060900
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -15006,7 +15057,7 @@ MonoBehaviour:
   m_PixelsPerUnitMultiplier: 1
 --- !u!95 &7145728809206494971
 Animator:
-  serializedVersion: 4
+  serializedVersion: 5
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -15023,7 +15074,8 @@ Animator:
   m_WarningMessage: 
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
-  m_KeepAnimatorControllerStateOnDisable: 0
+  m_KeepAnimatorStateOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 0
 --- !u!1 &7254874581677598448
 GameObject:
   m_ObjectHideFlags: 0
@@ -15346,7 +15398,7 @@ RectTransform:
   m_GameObject: {fileID: 8078826455249421205}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: -6.5}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalScale: {x: 0, y: 0, z: 0}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2832045160651503515}
@@ -15388,14 +15440,20 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls: []
   m_IsTrail: 0
-  m_IgnoreCanvasScaler: 1
-  m_Scale: 100
+  m_IgnoreCanvasScaler: 0
+  m_AbsoluteMode: 0
   m_Scale3D: {x: 1, y: 1, z: 1}
   m_AnimatableProperties: []
   m_Particles:
   - {fileID: 5276816783153177569}
   - {fileID: 4205776582665742052}
-  m_ShrinkByMaterial: 0
+  m_MeshSharing: 0
+  m_GroupId: 0
+  m_GroupMaxId: 0
+  m_PositionMode: 0
+  m_AutoScaling: 0
+  m_AutoScalingMode: 2
+  m_ResetScaleOnEnable: 0
 --- !u!114 &3358962776364646813
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -15501,6 +15559,7 @@ RectTransform:
   - {fileID: 2463502996513632192}
   - {fileID: 4613217625708418906}
   - {fileID: 161394433782232538}
+  - {fileID: 6844841729902261806}
   m_Father: {fileID: 428582801816782635}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/nekoyume/Assets/_Scripts/UI/Module/Item/BaseItemView.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/Item/BaseItemView.cs
@@ -215,12 +215,12 @@ namespace Nekoyume
             SelectObject.SetActive(false);
             FocusObject.SetActive(false);
             NotificationObject.SetActive(false);
-            GrindingCountObject.SetActive(false);
-            LevelLimitObject.SetActive(false);
-            RewardReceived.SetActive(false);
-            LevelLimitObject.SetActive(false);
+            GrindingCountObject.SetActiveSafe(false);
+            LevelLimitObject.SetActiveSafe(false);
+            RewardReceived.SetActiveSafe(false);
+            LevelLimitObject.SetActiveSafe(false);
             RuneNotificationObj.SetActiveSafe(false);
-            customCraftArea.SetActive(false);
+            customCraftArea.SetActiveSafe(false);
         }
 
         public void ItemViewSetCurrencyData(FungibleAssetValue fav)


### PR DESCRIPTION
### Description

1. BaseItemView에서 SetActiveSafe를 써서 null 체크를 하게 했습니다.
2. SeasonPassItemView에서 없어서 NRE가 뜨는 오브젝트에 빈 오브젝트를 넣어놨습니다.

### Related Links

#6037 
