### PR TITLE
fix mute other audio sources on android

### DIFF
--- a/nekoyume/Assets/Editor/Builder.cs
+++ b/nekoyume/Assets/Editor/Builder.cs
@@ -250,6 +250,7 @@ namespace Editor
             string[] scenes = { "Assets/_Scenes/IntroScene.unity", "Assets/_Scenes/LoadingScene.unity", "Assets/_Scenes/LoginScene.unity", "Assets/_Scenes/Game.unity" };
 #if UNITY_ANDROID || UNITY_IOS
             PlayerSettings.productName = PlayerName;
+            PlayerSettings.muteOtherAudioSources = false;
 #endif
             targetDirName ??= buildTarget.ToString();
             var locationPathName = Path.Combine(

--- a/nekoyume/ProjectSettings/ProjectSettings.asset
+++ b/nekoyume/ProjectSettings/ProjectSettings.asset
@@ -82,7 +82,7 @@ PlayerSettings:
   macRetinaSupport: 1
   runInBackground: 1
   captureSingleScreen: 0
-  muteOtherAudioSources: 1
+  muteOtherAudioSources: 0
   Prepare IOS For Recording: 0
   Force IOS Speakers When Recording: 0
   deferSystemGesturesMode: 0


### PR DESCRIPTION
ssia

해당 pr의 Action에서 나온 빌드(iOS M, Android M)로 테스트 진행했습니다.

설정 자체는 Android쪽만 수정하긴 했는데, ci빌드 과정에서 이전 빌드 옵션을 그대로 사용하는건지 iOS에도 영향이 있었습니다.

후에 안전코드용으로 builder에서 옵션 설정 코드 추가하였습니다.