### PR TITLE
Feature/openapi generator refactoring

### DIFF
--- a/nekoyume/Assets/Editor/OpenAPIGenerator.cs
+++ b/nekoyume/Assets/Editor/OpenAPIGenerator.cs
@@ -757,10 +757,12 @@ namespace Nekoyume
 
         private static void AppendWebRequestsFromPaths(StringBuilder sb, JsonNode pathsNode)
         {
+            Dictionary<string, int> methodNameCounter = new Dictionary<string, int>();
+
             foreach (var pathItem in pathsNode as JsonObject)
             {
                 var path = pathItem.Key;
-                if (!path.Contains("api"))
+                if (path.Contains("."))
                 {
                     continue;
                 }
@@ -880,6 +882,19 @@ namespace Nekoyume
 
                                 hasReturnType = true;
                             }
+                        }
+
+                        // 중복 체크를 위해 key 생성
+                        string key = $"{methodName}-{parameterDefinitions}-{returnType}";
+
+                        if (methodNameCounter.ContainsKey(key))
+                        {
+                            methodNameCounter[key]++;
+                            methodName += methodNameCounter[key].ToString(); // 중복될 경우 숫자 추가
+                        }
+                        else
+                        {
+                            methodNameCounter[key] = 1; // 처음 발견된 경우
                         }
 
                         sb.AppendLine($"    public async Task {methodName}({parameterDefinitions}Action<{returnType}> onSuccess, Action<string> onError)");

--- a/nekoyume/Assets/Editor/OpenAPIGenerator.cs
+++ b/nekoyume/Assets/Editor/OpenAPIGenerator.cs
@@ -899,7 +899,7 @@ namespace Nekoyume
 
                         sb.AppendLine($"    public async Task {methodName}({parameterDefinitions}Action<{returnType}> onSuccess, Action<string> onError)");
                         sb.AppendLine("    {");
-                        sb.AppendLine($"        string url = Url + $\"{path}\";");
+                        sb.AppendLine($"        string url = $\"{{Url}}{path}\";");
                         sb.AppendLine($"        using (var request = new UnityWebRequest(url, \"{httpMethod}\"))");
                         sb.AppendLine("        {");
                         sb.Append(parameterUsages);

--- a/nekoyume/Assets/_Scripts/ApiClient/GeneratedApi/SeasonPassServiceClient.cs
+++ b/nekoyume/Assets/_Scripts/ApiClient/GeneratedApi/SeasonPassServiceClient.cs
@@ -16,6 +16,7 @@ using System.Net.Http;
 using UnityEngine.Networking;
 using Cysharp.Threading.Tasks;
 using System.Text;
+using System.Linq;
 
 public class SeasonPassServiceClient
 {
@@ -42,6 +43,9 @@ public class SeasonPassServiceClient
 
     public class ActionTypeTypeConverter : JsonConverter<ActionType>
     {
+        public static readonly Dictionary<string, string> InvalidEnumMapping = new Dictionary<string, string>
+        {
+        };
         public override ActionType Read(
             ref Utf8JsonReader reader,
             Type typeToConvert,
@@ -50,7 +54,7 @@ public class SeasonPassServiceClient
             return reader.TokenType switch
             {
                 JsonTokenType.Number => (ActionType)reader.GetInt32(),
-                JsonTokenType.String => Enum.Parse<ActionType>(reader.GetString()),
+                JsonTokenType.String => Enum.Parse<ActionType>(InvalidEnumMapping.TryGetValue(reader.GetString(), out var validName) ? validName : reader.GetString()),
                 _ => throw new JsonException(
                     $"Expected token type to be {string.Join(" or ", new[] { JsonTokenType.Number, JsonTokenType.String })} but got {reader.TokenType}")
             };
@@ -60,7 +64,12 @@ public class SeasonPassServiceClient
             ActionType value,
             JsonSerializerOptions options)
         {
-            writer.WriteStringValue(value.ToString());
+            var enumString = value.ToString();
+            if (InvalidEnumMapping.ContainsValue(enumString))
+            {
+                enumString = InvalidEnumMapping.First(kvp => kvp.Value == enumString).Key;
+            }
+            writer.WriteStringValue(enumString);
         }
     }
 
@@ -191,6 +200,15 @@ public class SeasonPassServiceClient
 
     public class PlanetIDTypeConverter : JsonConverter<PlanetID>
     {
+        public static readonly Dictionary<string, string> InvalidEnumMapping = new Dictionary<string, string>
+        {
+            { "0x000000000000", "_0x000000000000" },
+            { "0x000000000001", "_0x000000000001" },
+            { "0x000000000002", "_0x000000000002" },
+            { "0x100000000000", "_0x100000000000" },
+            { "0x100000000001", "_0x100000000001" },
+            { "0x100000000002", "_0x100000000002" },
+        };
         public override PlanetID Read(
             ref Utf8JsonReader reader,
             Type typeToConvert,
@@ -199,7 +217,7 @@ public class SeasonPassServiceClient
             return reader.TokenType switch
             {
                 JsonTokenType.Number => (PlanetID)reader.GetInt32(),
-                JsonTokenType.String => Enum.Parse<PlanetID>("_"+reader.GetString()),
+                JsonTokenType.String => Enum.Parse<PlanetID>(InvalidEnumMapping.TryGetValue(reader.GetString(), out var validName) ? validName : reader.GetString()),
                 _ => throw new JsonException(
                     $"Expected token type to be {string.Join(" or ", new[] { JsonTokenType.Number, JsonTokenType.String })} but got {reader.TokenType}")
             };
@@ -209,7 +227,12 @@ public class SeasonPassServiceClient
             PlanetID value,
             JsonSerializerOptions options)
         {
-            writer.WriteStringValue(value.ToString().Substring(1));
+            var enumString = value.ToString();
+            if (InvalidEnumMapping.ContainsValue(enumString))
+            {
+                enumString = InvalidEnumMapping.First(kvp => kvp.Value == enumString).Key;
+            }
+            writer.WriteStringValue(enumString);
         }
     }
 
@@ -335,7 +358,7 @@ public class SeasonPassServiceClient
 
     public async Task GetSeasonpassCurrentAsync(Action<SeasonPassSchema> onSuccess, Action<string> onError)
     {
-        string url = Url + "/api/season-pass/current";
+        string url = Url + $"/api/season-pass/current";
         using (var request = new UnityWebRequest(url, "GET"))
         {
             request.downloadHandler = new DownloadHandlerBuffer();
@@ -363,7 +386,7 @@ public class SeasonPassServiceClient
 
     public async Task GetSeasonpassCurrentNewAsync(Action<NewSeasonPassSchema> onSuccess, Action<string> onError)
     {
-        string url = Url + "/api/season-pass/current/new";
+        string url = Url + $"/api/season-pass/current/new";
         using (var request = new UnityWebRequest(url, "GET"))
         {
             request.downloadHandler = new DownloadHandlerBuffer();
@@ -391,7 +414,7 @@ public class SeasonPassServiceClient
 
     public async Task GetSeasonpassLevelAsync(Action<LevelInfoSchema[]> onSuccess, Action<string> onError)
     {
-        string url = Url + "/api/season-pass/level";
+        string url = Url + $"/api/season-pass/level";
         using (var request = new UnityWebRequest(url, "GET"))
         {
             request.downloadHandler = new DownloadHandlerBuffer();
@@ -419,7 +442,7 @@ public class SeasonPassServiceClient
 
     public async Task GetSeasonpassExpAsync(Action<ExpInfoSchema[]> onSuccess, Action<string> onError)
     {
-        string url = Url + "/api/season-pass/exp";
+        string url = Url + $"/api/season-pass/exp";
         using (var request = new UnityWebRequest(url, "GET"))
         {
             request.downloadHandler = new DownloadHandlerBuffer();
@@ -447,7 +470,7 @@ public class SeasonPassServiceClient
 
     public async Task GetUserStatusAsync(int season_id, string avatar_addr, string planet_id, Action<UserSeasonPassSchema> onSuccess, Action<string> onError)
     {
-        string url = Url + "/api/user/status";
+        string url = Url + $"/api/user/status";
         using (var request = new UnityWebRequest(url, "GET"))
         {
             url += $"?season_id={season_id}&avatar_addr={avatar_addr}&planet_id={planet_id}";
@@ -477,7 +500,7 @@ public class SeasonPassServiceClient
 
     public async Task PostUserUpgradeAsync(string authorization, UpgradeRequestSchema requestBody, Action<UserSeasonPassSchema> onSuccess, Action<string> onError)
     {
-        string url = Url + "/api/user/upgrade";
+        string url = Url + $"/api/user/upgrade";
         using (var request = new UnityWebRequest(url, "POST"))
         {
             request.uri = new Uri(url);
@@ -511,7 +534,7 @@ public class SeasonPassServiceClient
 
     public async Task PostUserClaimAsync(ClaimRequestSchema requestBody, Action<ClaimResultSchema> onSuccess, Action<string> onError)
     {
-        string url = Url + "/api/user/claim";
+        string url = Url + $"/api/user/claim";
         using (var request = new UnityWebRequest(url, "POST"))
         {
             var bodyString = System.Text.Json.JsonSerializer.Serialize(requestBody);
@@ -543,7 +566,7 @@ public class SeasonPassServiceClient
 
     public async Task PostUserClaimprevAsync(ClaimRequestSchema requestBody, Action<ClaimResultSchema> onSuccess, Action<string> onError)
     {
-        string url = Url + "/api/user/claim-prev";
+        string url = Url + $"/api/user/claim-prev";
         using (var request = new UnityWebRequest(url, "POST"))
         {
             var bodyString = System.Text.Json.JsonSerializer.Serialize(requestBody);
@@ -575,7 +598,7 @@ public class SeasonPassServiceClient
 
     public async Task PostTmpRegisterAsync(RegisterRequestSchema requestBody, Action<UserSeasonPassSchema> onSuccess, Action<string> onError)
     {
-        string url = Url + "/api/tmp/register";
+        string url = Url + $"/api/tmp/register";
         using (var request = new UnityWebRequest(url, "POST"))
         {
             var bodyString = System.Text.Json.JsonSerializer.Serialize(requestBody);
@@ -607,7 +630,7 @@ public class SeasonPassServiceClient
 
     public async Task PostTmpPremiumAsync(PremiumRequestSchema requestBody, Action<UserSeasonPassSchema> onSuccess, Action<string> onError)
     {
-        string url = Url + "/api/tmp/premium";
+        string url = Url + $"/api/tmp/premium";
         using (var request = new UnityWebRequest(url, "POST"))
         {
             var bodyString = System.Text.Json.JsonSerializer.Serialize(requestBody);
@@ -639,7 +662,7 @@ public class SeasonPassServiceClient
 
     public async Task PostTmpLevelAsync(LevelRequestSchema requestBody, Action<UserSeasonPassSchema> onSuccess, Action<string> onError)
     {
-        string url = Url + "/api/tmp/level";
+        string url = Url + $"/api/tmp/level";
         using (var request = new UnityWebRequest(url, "POST"))
         {
             var bodyString = System.Text.Json.JsonSerializer.Serialize(requestBody);
@@ -671,7 +694,7 @@ public class SeasonPassServiceClient
 
     public async Task PostTmpChangeseasonAsync(SeasonChangeRequestSchema requestBody, Action<SeasonPassSchema> onSuccess, Action<string> onError)
     {
-        string url = Url + "/api/tmp/change-season";
+        string url = Url + $"/api/tmp/change-season";
         using (var request = new UnityWebRequest(url, "POST"))
         {
             var bodyString = System.Text.Json.JsonSerializer.Serialize(requestBody);
@@ -703,7 +726,7 @@ public class SeasonPassServiceClient
 
     public async Task GetBlockstatusAsync(Action<string> onSuccess, Action<string> onError)
     {
-        string url = Url + "/api/block-status";
+        string url = Url + $"/api/block-status";
         using (var request = new UnityWebRequest(url, "GET"))
         {
             request.SetRequestHeader("accept", "application/json");
@@ -729,9 +752,36 @@ public class SeasonPassServiceClient
 
     public async Task GetInvalidclaimAsync(Action<string> onSuccess, Action<string> onError)
     {
-        string url = Url + "/api/invalid-claim";
+        string url = Url + $"/api/invalid-claim";
         using (var request = new UnityWebRequest(url, "GET"))
         {
+            request.SetRequestHeader("accept", "application/json");
+            request.SetRequestHeader("Content-Type", "application/json");
+            request.timeout = 10;
+            try
+            {
+                await request.SendWebRequest();
+                if (request.result != UnityWebRequest.Result.Success)
+                {
+                    onError?.Invoke(request.error);
+                    return;
+                }
+                string responseBody = request.downloadHandler.text;
+                onSuccess?.Invoke(responseBody);
+            }
+            catch (Exception ex)
+            {
+                onError?.Invoke(ex.Message);
+            }
+        }
+    }
+
+    public async Task GetBalanceAsync(string planet, Action<string> onSuccess, Action<string> onError)
+    {
+        string url = Url + $"/api/balance/{planet}";
+        using (var request = new UnityWebRequest(url, "GET"))
+        {
+            request.uri = new Uri(url);
             request.SetRequestHeader("accept", "application/json");
             request.SetRequestHeader("Content-Type", "application/json");
             request.timeout = 10;


### PR DESCRIPTION
openapi enum 스팩이 c# enum 선언 기준과 다를 경우 예외처리하는 과정 리팩토링진행.
기존: 숫자인경우 앞부분 '_' 추가, '-' 를 '_' 로 치환.  전처리시 각 예외처리기준에따라 '_' 제거 및 치환
변경: 매핑 테이블을 만들어서 c# enum 선언 기준에 맞춘것으로 강제치환한것과 본래값을 매핑. 및 전처리시 복원하도록 수정.

추가로 관리되는 cs 파일 Path가 변경되어 반영 및 스크립트 정리, 기존 생성된 cs 최신화 진행하였습니다.

메소드 생성규칙을 수정하였습니다.(보다 넓은 범위의 path들을 메소드화시키도록 수정)
기존: path에 api 문자열이 포함된경우.
변경: path에 .이 포함되지 않은 경우.

중복 메소드이름의경우 뒤에 숫자를 추가해서 생성하는식으로 수정하였습니다.(파라메터까지 전부같을경우에만)