### PR TITLE
remove MarketServiceClient calling at Read(ProductSellerMail)

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Widget/Popup/MailPopup.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Popup/MailPopup.cs
@@ -612,14 +612,11 @@ namespace Nekoyume.UI
             ReactiveAvatarState.UpdateMailBox(States.Instance.CurrentAvatarState.mailBox);
         }
 
-        public async void Read(ProductSellerMail productSellerMail)
+        public void Read(ProductSellerMail productSellerMail)
         {
             var avatarAddress = States.Instance.CurrentAvatarState.address;
             var agentAddress = States.Instance.AgentState.address;
-            var (_, itemProduct, favProduct) = await ApiClients.Instance.MarketServiceClient.GetProductInfo(productSellerMail.ProductId);
-            var currency = States.Instance.GoldBalanceState.Gold.Currency;
-            var price = itemProduct?.Price ?? favProduct.Price;
-            var fav = new FungibleAssetValue(currency, (int)price, 0);
+            var fav = productSellerMail.Product.Price;
             var taxedPrice = fav.DivRem(100, out _) * Buy.TaxRate;
             LocalLayerModifier.ModifyAgentGoldAsync(agentAddress, taxedPrice).Forget();
             productSellerMail.New = false;


### PR DESCRIPTION
### Description

1. 200230 이후로 계속 판매 메일을 읽어도 읽음 처리가 안되고 있는 상태였습니다. 이걸 고치는 pr이고
2. 판매 메일이 마켓 서비스를 불러서 가격을 로딩하는 대신 Product 정보에 포함된 가격으로 처리하게 바꿨습니다.


### Related Links

resolve #6104 
