### PR TITLE
Feature/packing state

### DIFF
--- a/nekoyume/Assets/_Scripts/State/PetStates.cs
+++ b/nekoyume/Assets/_Scripts/State/PetStates.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Nekoyume.Model.State;
@@ -12,7 +13,15 @@ namespace Nekoyume.State
 
         private readonly HashSet<int> _lockedPets = new();
 
-        public readonly Subject<PetStates> PetStatesSubject = new();
+        private readonly Subject<PetStates> petStatesInternal;
+        
+        public readonly IObservable<PetStates> PetStatesSubject;
+        
+        public PetStates()
+        {
+            petStatesInternal = new Subject<PetStates>();
+            PetStatesSubject = petStatesInternal.ObserveOnMainThread();
+        }
 
         public bool TryGetPetState(int id, out PetState pet)
         {
@@ -37,13 +46,12 @@ namespace Nekoyume.State
                 _lockedPets.Remove(id);
             }
 
-            PetStatesSubject.OnNext(this);
+            petStatesInternal.OnNext(this);
         }
 
         public void LockPetTemporarily(int? petId)
         {
-            if (petId.HasValue &&
-                !_lockedPets.Contains(petId.Value))
+            if (petId.HasValue)
             {
                 _lockedPets.Add(petId.Value);
             }

--- a/nekoyume/Assets/_Scripts/State/ReactiveAvatarState.cs
+++ b/nekoyume/Assets/_Scripts/State/ReactiveAvatarState.cs
@@ -15,39 +15,27 @@ namespace Nekoyume.State
     public static class ReactiveAvatarState
     {
         private static readonly ReactiveProperty<Address> AddressInternal;
-
-        public static readonly IObservable<Address> Address;
-
         private static readonly ReactiveProperty<Inventory> InventoryInternal;
-
-        public static readonly IObservable<Inventory> Inventory;
-
         private static readonly ReactiveProperty<MailBox> MailBoxInternal;
-
-        public static readonly IObservable<MailBox> MailBox;
-
         private static readonly ReactiveProperty<WorldInformation> WorldInformationInternal;
-
-        public static readonly IObservable<WorldInformation> WorldInformation;
-
         private static readonly ReactiveProperty<long> ActionPointInternal;
+        private static readonly ReactiveProperty<long> DailyRewardReceivedIndexInternal;
+        private static readonly ReactiveProperty<QuestList> QuestListInternal;
+        private static readonly ReactiveProperty<long> RelationshipInternal;
+        
+        public static readonly IObservable<Address> Address;
+        public static readonly IObservable<Inventory> Inventory;
+        public static readonly IObservable<MailBox> MailBox;
+        public static readonly IObservable<WorldInformation> WorldInformation;
+        public static readonly IObservable<long> ObservableActionPoint;
+        public static readonly IObservable<long> ObservableDailyRewardReceivedIndex;
+        public static readonly IObservable<QuestList> ObservableQuestList;
+        public static readonly IObservable<long> ObservableRelationship;
 
         public static long ActionPoint => ActionPointInternal.Value;
-        public static readonly IObservable<long> ObservableActionPoint;
-
-        private static readonly ReactiveProperty<long> DailyRewardReceivedIndexInternal;
-
         public static long DailyRewardReceivedIndex => DailyRewardReceivedIndexInternal.Value;
-        public static readonly IObservable<long> ObservableDailyRewardReceivedIndex;
-
-        private static readonly ReactiveProperty<QuestList> QuestListInternal;
-
         public static QuestList QuestList => QuestListInternal.Value;
-        public static readonly IObservable<QuestList> ObservableQuestList;
-
-        private static readonly ReactiveProperty<long> RelationshipInternal;
         public static long Relationship => RelationshipInternal.Value;
-        public static readonly IObservable<long> ObservableRelationship;
 
         static ReactiveAvatarState()
         {

--- a/nekoyume/Assets/_Scripts/State/ReactiveAvatarState.cs
+++ b/nekoyume/Assets/_Scripts/State/ReactiveAvatarState.cs
@@ -5,51 +5,70 @@ using Nekoyume.Model.State;
 using System;
 using Libplanet.Crypto;
 using UniRx;
-using UnityEngine;
 using Inventory = Nekoyume.Model.Item.Inventory;
 
 namespace Nekoyume.State
 {
     /// <summary>
-    /// 현재 선택된 AvatarState가 포함하는 값의 변화를 각각의 ReactiveProperty<T> 필드를 통해 외부에 변화를 알린다.
+    /// 현재 선택된 AvatarState가 포함하는 값의 변화를 각각의 ReactiveProperty 필드를 통해 외부에 변화를 알린다.
     /// </summary>
     public static class ReactiveAvatarState
     {
-        private static readonly ReactiveProperty<Address> _address = new();
+        private static readonly ReactiveProperty<Address> AddressInternal;
 
-        public static IObservable<Address> Address => _address.ObserveOnMainThread();
+        public static readonly IObservable<Address> Address;
 
-        private static readonly ReactiveProperty<Inventory> _inventory = new();
+        private static readonly ReactiveProperty<Inventory> InventoryInternal;
 
-        public static IObservable<Inventory> Inventory => _inventory.ObserveOnMainThread();
+        public static readonly IObservable<Inventory> Inventory;
 
-        private static readonly ReactiveProperty<MailBox> _mailBox = new();
+        private static readonly ReactiveProperty<MailBox> MailBoxInternal;
 
-        public static IObservable<MailBox> MailBox => _mailBox.ObserveOnMainThread();
+        public static readonly IObservable<MailBox> MailBox;
 
-        private static readonly ReactiveProperty<WorldInformation> _worldInformation = new();
+        private static readonly ReactiveProperty<WorldInformation> WorldInformationInternal;
 
-        public static IObservable<WorldInformation> WorldInformation => _worldInformation.ObserveOnMainThread();
+        public static readonly IObservable<WorldInformation> WorldInformation;
 
-        private static readonly ReactiveProperty<long> _actionPoint = new();
+        private static readonly ReactiveProperty<long> ActionPointInternal;
 
-        public static long ActionPoint => _actionPoint.Value;
-        public static IObservable<long> ObservableActionPoint => _actionPoint.ObserveOnMainThread();
+        public static long ActionPoint => ActionPointInternal.Value;
+        public static readonly IObservable<long> ObservableActionPoint;
 
-        private static readonly ReactiveProperty<long> _dailyRewardReceivedIndex = new();
+        private static readonly ReactiveProperty<long> DailyRewardReceivedIndexInternal;
 
-        public static long DailyRewardReceivedIndex => _dailyRewardReceivedIndex.Value;
-        public static IObservable<long> ObservableDailyRewardReceivedIndex => _dailyRewardReceivedIndex.ObserveOnMainThread();
+        public static long DailyRewardReceivedIndex => DailyRewardReceivedIndexInternal.Value;
+        public static readonly IObservable<long> ObservableDailyRewardReceivedIndex;
 
-        private static readonly ReactiveProperty<QuestList> _questList = new();
+        private static readonly ReactiveProperty<QuestList> QuestListInternal;
 
-        public static QuestList QuestList => _questList.Value;
-        public static IObservable<QuestList> ObservableQuestList => _questList.ObserveOnMainThread();
+        public static QuestList QuestList => QuestListInternal.Value;
+        public static readonly IObservable<QuestList> ObservableQuestList;
 
-        private static readonly ReactiveProperty<long> _relationship = new();
-        public static long Relationship => _relationship.Value;
-        public static IObservable<long> ObservableRelationship =>
-            _relationship.ObserveOnMainThread();
+        private static readonly ReactiveProperty<long> RelationshipInternal;
+        public static long Relationship => RelationshipInternal.Value;
+        public static readonly IObservable<long> ObservableRelationship;
+
+        static ReactiveAvatarState()
+        {
+            AddressInternal = new ReactiveProperty<Address>();
+            InventoryInternal = new ReactiveProperty<Inventory>();
+            MailBoxInternal = new ReactiveProperty<MailBox>();
+            WorldInformationInternal = new ReactiveProperty<WorldInformation>();
+            ActionPointInternal = new ReactiveProperty<long>();
+            DailyRewardReceivedIndexInternal = new ReactiveProperty<long>();
+            QuestListInternal = new ReactiveProperty<QuestList>();
+            RelationshipInternal = new ReactiveProperty<long>();
+            
+            Address = AddressInternal.ObserveOnMainThread();
+            Inventory = InventoryInternal.ObserveOnMainThread();
+            MailBox = MailBoxInternal.ObserveOnMainThread();
+            WorldInformation = WorldInformationInternal.ObserveOnMainThread();
+            ObservableActionPoint = ActionPointInternal.ObserveOnMainThread();
+            ObservableDailyRewardReceivedIndex = DailyRewardReceivedIndexInternal.ObserveOnMainThread();
+            ObservableQuestList = QuestListInternal.ObserveOnMainThread();
+            ObservableRelationship = RelationshipInternal.ObserveOnMainThread();
+        }
 
         public static void Initialize(AvatarState state)
         {
@@ -60,16 +79,16 @@ namespace Nekoyume.State
                 return;
             }
 
-            _address.SetValueAndForceNotify(state.address);
-            _inventory.SetValueAndForceNotify(state.inventory);
-            _mailBox.SetValueAndForceNotify(state.mailBox);
-            _worldInformation.SetValueAndForceNotify(state.worldInformation);
-            _questList.SetValueAndForceNotify(state.questList);
+            AddressInternal.SetValueAndForceNotify(state.address);
+            InventoryInternal.SetValueAndForceNotify(state.inventory);
+            MailBoxInternal.SetValueAndForceNotify(state.mailBox);
+            WorldInformationInternal.SetValueAndForceNotify(state.worldInformation);
+            QuestListInternal.SetValueAndForceNotify(state.questList);
         }
 
         public static void UpdateActionPoint(long actionPoint)
         {
-            _actionPoint.SetValueAndForceNotify(actionPoint);
+            ActionPointInternal.SetValueAndForceNotify(actionPoint);
         }
 
         public static void UpdateInventory(Inventory inventory)
@@ -79,12 +98,12 @@ namespace Nekoyume.State
                 return;
             }
 
-            _inventory.SetValueAndForceNotify(inventory);
+            InventoryInternal.SetValueAndForceNotify(inventory);
         }
 
         public static void UpdateDailyRewardReceivedIndex(long index)
         {
-            _dailyRewardReceivedIndex.SetValueAndForceNotify(index);
+            DailyRewardReceivedIndexInternal.SetValueAndForceNotify(index);
         }
 
         public static void UpdateMailBox(MailBox mailBox)
@@ -94,7 +113,7 @@ namespace Nekoyume.State
                 return;
             }
 
-            _mailBox.SetValueAndForceNotify(mailBox);
+            MailBoxInternal.SetValueAndForceNotify(mailBox);
         }
 
         public static void UpdateQuestList(QuestList questList)
@@ -104,12 +123,12 @@ namespace Nekoyume.State
                 return;
             }
 
-            _questList.SetValueAndForceNotify(questList);
+            QuestListInternal.SetValueAndForceNotify(questList);
         }
 
         public static void UpdateRelationship(long relationship)
         {
-            _relationship.SetValueAndForceNotify(relationship);
+            RelationshipInternal.SetValueAndForceNotify(relationship);
         }
     }
 }

--- a/nekoyume/Assets/_Scripts/State/RxProps.Arena.cs
+++ b/nekoyume/Assets/_Scripts/State/RxProps.Arena.cs
@@ -8,16 +8,12 @@ using Libplanet.Action.State;
 using Libplanet.Crypto;
 using Nekoyume.Action;
 using Nekoyume.ApiClient;
-using Nekoyume.Arena;
-using Nekoyume.Game.LiveAsset;
 using Nekoyume.GraphQL;
 using Nekoyume.Helper;
 using Nekoyume.Model.Arena;
 using Nekoyume.Model.EnumType;
 using Nekoyume.Model.State;
 using Nekoyume.UI.Model;
-using UnityEngine;
-using static Lib9c.SerializeKeys;
 
 namespace Nekoyume.State
 {
@@ -27,46 +23,38 @@ namespace Nekoyume.State
 
     public static partial class RxProps
     {
+#region RxPropInternal
         // TODO!!!! Remove [`_arenaInfoTuple`] and use [`_playersArenaParticipant`] instead.
         private static readonly
             AsyncUpdatableRxProp<(ArenaInformation current, ArenaInformation next)>
             _arenaInfoTuple = new(UpdateArenaInfoTupleAsync);
-
-        private static long _arenaInfoTupleUpdatedBlockIndex;
-
-        private static readonly ReactiveProperty<ArenaParticipantModel> _playerArenaInfo =
-            new(null);
-
-        private static readonly ReactiveProperty<int> _purchasedDuringInterval = new();
-
-        public static IReadOnlyReactiveProperty<int> PurchasedDuringInterval => _purchasedDuringInterval;
-        private static readonly ReactiveProperty<long> _lastArenaBattleBlockIndex = new();
-
-        public static IReadOnlyReactiveProperty<long> LastArenaBattleBlockIndex => _lastArenaBattleBlockIndex;
-        public static IReadOnlyReactiveProperty<ArenaParticipantModel> PlayerArenaInfo => _playerArenaInfo;
-
-        public static
-            IReadOnlyAsyncUpdatableRxProp<(ArenaInformation current, ArenaInformation next)>
-            ArenaInfoTuple =>
-            _arenaInfoTuple;
-
-        private static readonly ReactiveProperty<ArenaTicketProgress>
-            _arenaTicketsProgress = new(new ArenaTicketProgress());
-
-        public static IReadOnlyReactiveProperty<ArenaTicketProgress>
-            ArenaTicketsProgress =>
-            _arenaTicketsProgress;
-
-        private static long _arenaParticipantsOrderedWithScoreUpdatedBlockIndex;
-
         private static readonly AsyncUpdatableRxProp<List<ArenaParticipantModel>>
             _arenaInformationOrderedWithScore = new(
                 new List<ArenaParticipantModel>(),
                 UpdateArenaInformationOrderedWithScoreAsync);
+        private static readonly ReactiveProperty<ArenaParticipantModel> _playerArenaInfo =
+            new(null);
+        private static readonly ReactiveProperty<int> _purchasedDuringInterval = new();
+        private static readonly ReactiveProperty<long> _lastArenaBattleBlockIndex = new();
+        private static readonly ReactiveProperty<ArenaTicketProgress>
+            _arenaTicketsProgress = new(new ArenaTicketProgress());
+#endregion RxPropInternal
+
+#region RxPropObservable
+        public static IReadOnlyReactiveProperty<int> PurchasedDuringInterval => _purchasedDuringInterval;
+        public static IReadOnlyReactiveProperty<long> LastArenaBattleBlockIndex => _lastArenaBattleBlockIndex;
+        public static IReadOnlyReactiveProperty<ArenaParticipantModel> PlayerArenaInfo => _playerArenaInfo;
 
         public static IReadOnlyAsyncUpdatableRxProp<List<ArenaParticipantModel>>
-            ArenaInformationOrderedWithScore =>
-            _arenaInformationOrderedWithScore;
+            ArenaInformationOrderedWithScore => _arenaInformationOrderedWithScore;
+        public static IReadOnlyReactiveProperty<ArenaTicketProgress>
+            ArenaTicketsProgress => _arenaTicketsProgress;
+        public static IReadOnlyAsyncUpdatableRxProp<(ArenaInformation current, ArenaInformation next)>
+            ArenaInfoTuple => _arenaInfoTuple;
+#endregion RxPropObservable
+
+        private static long _arenaParticipantsOrderedWithScoreUpdatedBlockIndex;
+        private static long _arenaInfoTupleUpdatedBlockIndex;
 
         public static void UpdateArenaInfoToNext()
         {

--- a/nekoyume/Assets/_Scripts/State/Subjects/AgentStateSubject.cs
+++ b/nekoyume/Assets/_Scripts/State/Subjects/AgentStateSubject.cs
@@ -6,13 +6,13 @@ using UniRx;
 namespace Nekoyume.State.Subjects
 {
     /// <summary>
-    /// The change of the value included in `AgentState` is notified to the outside through each Subject<T> field.
+    /// The change of the value included in `AgentState` is notified to the outside through each Subject
     /// </summary>
     public static class AgentStateSubject
     {
-        private static readonly Subject<FungibleAssetValue> _gold;
-        private static readonly Subject<FungibleAssetValue> _crystal;
-        private static readonly Subject<FungibleAssetValue> _garage;
+        private static readonly Subject<FungibleAssetValue> GoldInternal;
+        private static readonly Subject<FungibleAssetValue> CrystalInternal;
+        private static readonly Subject<FungibleAssetValue> GarageInternal;
 
         public static readonly IObservable<FungibleAssetValue> Gold;
         public static readonly IObservable<FungibleAssetValue> Crystal;
@@ -20,19 +20,19 @@ namespace Nekoyume.State.Subjects
 
         static AgentStateSubject()
         {
-            _gold = new Subject<FungibleAssetValue>();
-            _crystal = new Subject<FungibleAssetValue>();
-            _garage = new Subject<FungibleAssetValue>();
-            Gold = _gold.ObserveOnMainThread();
-            Crystal = _crystal.ObserveOnMainThread();
-            Garage = _garage.ObserveOnMainThread();
+            GoldInternal = new Subject<FungibleAssetValue>();
+            CrystalInternal = new Subject<FungibleAssetValue>();
+            GarageInternal = new Subject<FungibleAssetValue>();
+            Gold = GoldInternal.ObserveOnMainThread();
+            Crystal = CrystalInternal.ObserveOnMainThread();
+            Garage = GarageInternal.ObserveOnMainThread();
         }
 
         public static void OnNextGold(FungibleAssetValue gold)
         {
             if (gold.Currency.Equals(States.Instance.GoldBalanceState.Gold.Currency))
             {
-                _gold.OnNext(gold);
+                GoldInternal.OnNext(gold);
             }
         }
 
@@ -40,7 +40,7 @@ namespace Nekoyume.State.Subjects
         {
             if (crystal.Currency.Equals(Currencies.Crystal))
             {
-                _crystal.OnNext(crystal);
+                CrystalInternal.OnNext(crystal);
             }
         }
 
@@ -48,7 +48,7 @@ namespace Nekoyume.State.Subjects
         {
             if (garage.Currency.Equals(Currencies.Garage))
             {
-                _garage.OnNext(garage);
+                GarageInternal.OnNext(garage);
             }
         }
     }

--- a/nekoyume/Assets/_Scripts/State/Subjects/GameConfigStateSubject.cs
+++ b/nekoyume/Assets/_Scripts/State/Subjects/GameConfigStateSubject.cs
@@ -1,3 +1,4 @@
+using System;
 using Libplanet.Crypto;
 using Nekoyume.Model.State;
 using UniRx;
@@ -6,13 +7,21 @@ namespace Nekoyume.State.Subjects
 {
     public static class GameConfigStateSubject
     {
-        public static readonly Subject<GameConfigState> GameConfigState = new();
+        private static readonly Subject<GameConfigState> GameConfigStateInternal;
+        
+        public static readonly IObservable<GameConfigState> GameConfigState;
 
         public static readonly ReactiveDictionary<Address, bool> ActionPointState = new();
+        
+        static GameConfigStateSubject()
+        {
+            GameConfigStateInternal = new Subject<GameConfigState>();
+            GameConfigState = GameConfigStateInternal.ObserveOnMainThread();
+        }
 
         public static void OnNext(GameConfigState state)
         {
-            GameConfigState.OnNext(state);
+            GameConfigStateInternal.OnNext(state);
         }
     }
 }

--- a/nekoyume/Assets/_Scripts/State/Subjects/HammerPointStatesSubject.cs
+++ b/nekoyume/Assets/_Scripts/State/Subjects/HammerPointStatesSubject.cs
@@ -6,14 +6,14 @@ namespace Nekoyume.State.Subjects
 {
     public static class HammerPointStatesSubject
     {
-        private static readonly Subject<(int, HammerPointState)> _hammerPointSubject;
+        private static readonly Subject<(int, HammerPointState)> HammerPointSubjectInternal;
 
-        public static readonly IObservable<(int, HammerPointState)> HammerPointSubject;
+        public static readonly IObservable<(int, HammerPointState)> HammerPoint;
 
         static HammerPointStatesSubject()
         {
-            _hammerPointSubject = new Subject<(int, HammerPointState)>();
-            HammerPointSubject = _hammerPointSubject.ObserveOnMainThread();
+            HammerPointSubjectInternal = new Subject<(int, HammerPointState)>();
+            HammerPoint = HammerPointSubjectInternal.ObserveOnMainThread();
         }
 
         public static void OnReplaceHammerPointState(int recipeId, HammerPointState state)
@@ -22,7 +22,7 @@ namespace Nekoyume.State.Subjects
                     States.Instance.CurrentAvatarState.address,
                     recipeId) == state.Address)
             {
-                _hammerPointSubject.OnNext((recipeId, state));
+                HammerPointSubjectInternal.OnNext((recipeId, state));
             }
         }
     }

--- a/nekoyume/Assets/_Scripts/State/Subjects/StakingSubject.cs
+++ b/nekoyume/Assets/_Scripts/State/Subjects/StakingSubject.cs
@@ -8,59 +8,57 @@ namespace Nekoyume.State.Subjects
 {
     public static class StakingSubject
     {
-        private static readonly Subject<StakeStateV2?> _stakeStateV2;
-        private static readonly Subject<FungibleAssetValue> _stakedNCG;
-        private static readonly Subject<int> _level;
-        private static readonly Subject<StakeRegularFixedRewardSheet> _stakeRegularFixedRewardSheet;
-        private static readonly Subject<StakeRegularRewardSheet> _stakeRegularRewardSheet;
+        private static readonly Subject<StakeStateV2?> StakeStateV2Internal;
+        private static readonly Subject<FungibleAssetValue> StakedNCGInternal;
+        private static readonly Subject<int> LevelInternal;
+        private static readonly Subject<StakeRegularFixedRewardSheet> StakeRegularFixedRewardSheetInternal;
+        private static readonly Subject<StakeRegularRewardSheet> StakeRegularRewardSheetInternal;
 
         public static readonly IObservable<StakeStateV2?> StakeStateV2;
         public static readonly IObservable<FungibleAssetValue> StakedNCG;
         public static readonly IObservable<int> Level;
-
         public static readonly IObservable<StakeRegularFixedRewardSheet>
             StakeRegularFixedRewardSheet;
-
         public static readonly IObservable<StakeRegularRewardSheet> StakeRegularRewardSheet;
 
         static StakingSubject()
         {
-            _stakeStateV2 = new Subject<StakeStateV2?>();
-            _stakedNCG = new Subject<FungibleAssetValue>();
-            _level = new Subject<int>();
-            _stakeRegularFixedRewardSheet = new Subject<StakeRegularFixedRewardSheet>();
-            _stakeRegularRewardSheet = new Subject<StakeRegularRewardSheet>();
+            StakeStateV2Internal = new Subject<StakeStateV2?>();
+            StakedNCGInternal = new Subject<FungibleAssetValue>();
+            LevelInternal = new Subject<int>();
+            StakeRegularFixedRewardSheetInternal = new Subject<StakeRegularFixedRewardSheet>();
+            StakeRegularRewardSheetInternal = new Subject<StakeRegularRewardSheet>();
 
-            StakeStateV2 = _stakeStateV2.ObserveOnMainThread();
-            StakedNCG = _stakedNCG.ObserveOnMainThread();
-            Level = _level.ObserveOnMainThread();
-            StakeRegularFixedRewardSheet = _stakeRegularFixedRewardSheet.ObserveOnMainThread();
-            StakeRegularRewardSheet = _stakeRegularRewardSheet.ObserveOnMainThread();
+            StakeStateV2 = StakeStateV2Internal.ObserveOnMainThread();
+            StakedNCG = StakedNCGInternal.ObserveOnMainThread();
+            Level = LevelInternal.ObserveOnMainThread();
+            StakeRegularFixedRewardSheet = StakeRegularFixedRewardSheetInternal.ObserveOnMainThread();
+            StakeRegularRewardSheet = StakeRegularRewardSheetInternal.ObserveOnMainThread();
         }
 
         public static void OnNextStakeStateV2(StakeStateV2? stakeStateV2)
         {
-            _stakeStateV2.OnNext(stakeStateV2);
+            StakeStateV2Internal.OnNext(stakeStateV2);
         }
 
         public static void OnNextStakedNCG(FungibleAssetValue stakedNCG)
         {
-            _stakedNCG.OnNext(stakedNCG);
+            StakedNCGInternal.OnNext(stakedNCG);
         }
 
         public static void OnNextLevel(int level)
         {
-            _level.OnNext(level);
+            LevelInternal.OnNext(level);
         }
 
         public static void OnNextStakeRegularFixedRewardSheet(StakeRegularFixedRewardSheet sheet)
         {
-            _stakeRegularFixedRewardSheet.OnNext(sheet);
+            StakeRegularFixedRewardSheetInternal.OnNext(sheet);
         }
 
         public static void OnNextStakeRegularRewardSheet(StakeRegularRewardSheet sheet)
         {
-            _stakeRegularRewardSheet.OnNext(sheet);
+            StakeRegularRewardSheetInternal.OnNext(sheet);
         }
     }
 }

--- a/nekoyume/Assets/_Scripts/State/Subjects/WeeklyArenaStateSubject.cs
+++ b/nekoyume/Assets/_Scripts/State/Subjects/WeeklyArenaStateSubject.cs
@@ -1,4 +1,4 @@
-using System.Numerics;
+using System;
 using Nekoyume.Model.State;
 using UniRx;
 using UnityEngine;
@@ -11,8 +11,19 @@ namespace Nekoyume.State.Subjects
     /// </summary>
     public static class WeeklyArenaStateSubject
     {
-        public static readonly Subject<WeeklyArenaState> WeeklyArenaState = new();
-        public static readonly Subject<long> ResetIndex = new();
+        private static readonly Subject<WeeklyArenaState> WeeklyArenaStateInternal;
+        private static readonly Subject<long> ResetIndexInternal;
+        
+        public static readonly IObservable<WeeklyArenaState> WeeklyArenaState;
+        public static readonly IObservable<long> ResetIndex;
+        
+        static WeeklyArenaStateSubject()
+        {
+            WeeklyArenaStateInternal = new Subject<WeeklyArenaState>();
+            ResetIndexInternal = new Subject<long>();
+            WeeklyArenaState = WeeklyArenaStateInternal.ObserveOnMainThread();
+            ResetIndex = ResetIndexInternal.ObserveOnMainThread();
+        }
 
         public static void OnNext(WeeklyArenaState state)
         {
@@ -22,8 +33,8 @@ namespace Nekoyume.State.Subjects
                 return;
             }
 
-            WeeklyArenaState.OnNext(state);
-            ResetIndex.OnNext(state.ResetIndex);
+            WeeklyArenaStateInternal.OnNext(state);
+            ResetIndexInternal.OnNext(state.ResetIndex);
         }
     }
 }

--- a/nekoyume/Assets/_Scripts/UI/Module/PetInventory.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/PetInventory.cs
@@ -96,7 +96,6 @@ namespace Nekoyume.UI.Module
             }
 
             _disposableOnDisabled = States.Instance.PetStates.PetStatesSubject
-                .ObserveOnMainThread()
                 .Subscribe(state => UpdateView(state));
             gameObject.SetActive(true);
             InitScrollPosition();
@@ -119,7 +118,6 @@ namespace Nekoyume.UI.Module
             }
 
             _disposableOnDisabled = States.Instance.PetStates.PetStatesSubject
-                .ObserveOnMainThread()
                 .Subscribe(state => UpdateView(state, craftInfo));
             gameObject.SetActive(true);
             InitScrollPosition();

--- a/nekoyume/Assets/_Scripts/UI/Widget/Craft.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Craft.cs
@@ -338,7 +338,7 @@ namespace Nekoyume.UI
                     OnClickConsumableToggle(eventConsumableToggle.isOn);
                 })
                 .AddTo(_disposablesAtShow);
-            HammerPointStatesSubject.HammerPointSubject.Subscribe(_ =>
+            HammerPointStatesSubject.HammerPoint.Subscribe(_ =>
             {
                 if (equipmentSubRecipeView.gameObject.activeSelf)
                 {


### PR DESCRIPTION
state경로 안의 Subject, RxProps들을 구독할 때 MainThread를 기준으로 메시지를 전송하는 Observable에 구독할 수 있도록 기반을 마련합니다

- ShopState의 경우 다른 State와 달리 서비스에서 데이터를 받아오는 등 구현이 달라서 해당 작업을 하지 않았습니다
- RxProps(특히 Arena)의 경우 메시지 구독이나 발송 구현이 복잡하여 한번에 이해가 안되어 코드정리 정도만 하고 해당 작업을 적용하지 않았습니다
- ReactiveAvatarState의 경우 기존 Observable 프로퍼티에 구독할 때 마다 구독 객체를 생성하는 형태로 되어 있었는데, 이걸 public field로 바꾸고 생성자에서 한번만 초기화 한 후 해당 필드에 구독하도록 변경하였습니다. 기능 변경은 해당 내용이 유일합니다.