### PR TITLE
remove event trigger component and check mouseposition and manually c…

### DIFF
--- a/nekoyume/Assets/Resources/UI/Prefabs/UI_FungibleAssetTooltip.prefab
+++ b/nekoyume/Assets/Resources/UI/Prefabs/UI_FungibleAssetTooltip.prefab
@@ -4652,7 +4652,6 @@ GameObject:
   - component: {fileID: 8345192229530743519}
   - component: {fileID: 2201705437051731774}
   - component: {fileID: 3367752127855427622}
-  - component: {fileID: 9979499077861398}
   m_Layer: 5
   m_Name: Detail
   m_TagString: Untagged
@@ -4823,51 +4822,6 @@ MonoBehaviour:
   - {fileID: 0}
   - {fileID: 0}
   skillTooltip: {fileID: 0}
---- !u!114 &9979499077861398
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3367752127855427621}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d0b148fe25e99eb48b9724523833bab1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Delegates:
-  - eventID: 0
-    callback:
-      m_PersistentCalls:
-        m_Calls:
-        - m_Target: {fileID: 4693993570970967307}
-          m_TargetAssemblyTypeName: Nekoyume.UI.FungibleAssetTooltip, Nekoyume
-          m_MethodName: OnEnterButtonArea
-          m_Mode: 6
-          m_Arguments:
-            m_ObjectArgument: {fileID: 0}
-            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-            m_IntArgument: 0
-            m_FloatArgument: 0
-            m_StringArgument: 
-            m_BoolArgument: 1
-          m_CallState: 2
-  - eventID: 1
-    callback:
-      m_PersistentCalls:
-        m_Calls:
-        - m_Target: {fileID: 4693993570970967307}
-          m_TargetAssemblyTypeName: Nekoyume.UI.FungibleAssetTooltip, Nekoyume
-          m_MethodName: OnEnterButtonArea
-          m_Mode: 6
-          m_Arguments:
-            m_ObjectArgument: {fileID: 0}
-            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-            m_IntArgument: 0
-            m_FloatArgument: 0
-            m_StringArgument: 
-            m_BoolArgument: 0
-          m_CallState: 2
 --- !u!1 &3551271071411875570
 GameObject:
   m_ObjectHideFlags: 0

--- a/nekoyume/Assets/Resources/UI/Prefabs/UI_ItemTooltip.prefab
+++ b/nekoyume/Assets/Resources/UI/Prefabs/UI_ItemTooltip.prefab
@@ -26235,7 +26235,6 @@ GameObject:
   - component: {fileID: 3896249707496191288}
   - component: {fileID: 6578722246314146009}
   - component: {fileID: 7745908641049577409}
-  - component: {fileID: 4009962878873633376}
   m_Layer: 5
   m_Name: Detail
   m_TagString: Untagged
@@ -26410,27 +26409,6 @@ MonoBehaviour:
   - {fileID: 8388860368712792571}
   - {fileID: 602040730996652373}
   skillTooltip: {fileID: 2807283668600384627}
---- !u!114 &4009962878873633376
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7745908641049577410}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d0b148fe25e99eb48b9724523833bab1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Delegates:
-  - eventID: 0
-    callback:
-      m_PersistentCalls:
-        m_Calls: []
-  - eventID: 1
-    callback:
-      m_PersistentCalls:
-        m_Calls: []
 --- !u!1 &7810504448802739411
 GameObject:
   m_ObjectHideFlags: 0
@@ -32875,8 +32853,8 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 1691207599003355518}
   m_HandleRect: {fileID: 4119769666421683849}
   m_Direction: 2
-  m_Value: 1.0000001
-  m_Size: 0.42389327
+  m_Value: 1.0000004
+  m_Size: 0.4238933
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:

--- a/nekoyume/Assets/Resources/UI/Prefabs/UI_RuneTooltip.prefab
+++ b/nekoyume/Assets/Resources/UI/Prefabs/UI_RuneTooltip.prefab
@@ -18112,7 +18112,6 @@ GameObject:
   - component: {fileID: 809503376454329747}
   - component: {fileID: 4488528141123949981}
   - component: {fileID: 5986524016789002364}
-  - component: {fileID: 57876145140963390}
   m_Layer: 5
   m_Name: Detail
   m_TagString: Untagged
@@ -18220,51 +18219,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_HorizontalFit: 0
   m_VerticalFit: 2
---- !u!114 &57876145140963390
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7144618008289060711}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d0b148fe25e99eb48b9724523833bab1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Delegates:
-  - eventID: 0
-    callback:
-      m_PersistentCalls:
-        m_Calls:
-        - m_Target: {fileID: 836228864728598928}
-          m_TargetAssemblyTypeName: Nekoyume.UI.RuneTooltip, Nekoyume
-          m_MethodName: OnEnterButtonArea
-          m_Mode: 6
-          m_Arguments:
-            m_ObjectArgument: {fileID: 0}
-            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-            m_IntArgument: 0
-            m_FloatArgument: 0
-            m_StringArgument: 
-            m_BoolArgument: 1
-          m_CallState: 2
-  - eventID: 1
-    callback:
-      m_PersistentCalls:
-        m_Calls:
-        - m_Target: {fileID: 836228864728598928}
-          m_TargetAssemblyTypeName: Nekoyume.UI.RuneTooltip, Nekoyume
-          m_MethodName: OnEnterButtonArea
-          m_Mode: 6
-          m_Arguments:
-            m_ObjectArgument: {fileID: 0}
-            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-            m_IntArgument: 0
-            m_FloatArgument: 0
-            m_StringArgument: 
-            m_BoolArgument: 0
-          m_CallState: 2
 --- !u!1 &7153467487710132124
 GameObject:
   m_ObjectHideFlags: 0
@@ -20965,7 +20919,7 @@ MonoBehaviour:
   m_HandleRect: {fileID: 3563590063448151596}
   m_Direction: 2
   m_Value: 0.99999976
-  m_Size: 0.68664783
+  m_Size: 0.6866479
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:

--- a/nekoyume/Assets/_Scripts/UI/Widget/Tooltip/FungibleAssetTooltip.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Tooltip/FungibleAssetTooltip.cs
@@ -317,7 +317,8 @@ namespace Nekoyume.UI
             {
                 if (Input.GetMouseButtonDown(0))
                 {
-                    _isClickedTooltipArea = _isPointerOnTooltipArea;
+                    UnityEngine.Vector2 mousePos = Input.mousePosition;
+                    _isClickedTooltipArea = RectTransformUtility.RectangleContainsScreenPoint(panel, mousePos, MainCanvas.instance.Canvas.worldCamera) || _isPointerOnTooltipArea;
                 }
 
                 var current = TouchHandler.currentSelectedGameObject;

--- a/nekoyume/Assets/_Scripts/UI/Widget/Tooltip/ItemTooltip.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Tooltip/ItemTooltip.cs
@@ -339,7 +339,7 @@ namespace Nekoyume.UI
                 if (Input.GetMouseButtonDown(0))
                 {
                     UnityEngine.Vector2 mousePos = Input.mousePosition;
-                    _isClickedTooltipArea = RectTransformUtility.RectangleContainsScreenPoint(panel, mousePos, MainCanvas.instance.Canvas.worldCamera);
+                    _isClickedTooltipArea = RectTransformUtility.RectangleContainsScreenPoint(panel, mousePos, MainCanvas.instance.Canvas.worldCamera) || _isPointerOnTooltipArea;
                 }
 
                 var current = TouchHandler.currentSelectedGameObject;

--- a/nekoyume/Assets/_Scripts/UI/Widget/Tooltip/RuneTooltip.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Tooltip/RuneTooltip.cs
@@ -91,8 +91,8 @@ namespace Nekoyume.UI
         private System.Action _onEnhancement;
         private System.Action _onClose;
 
-        private bool _isPointerOnScrollArea;
-        private bool _isClickedButtonArea;
+        private bool _isPointerOnTooltipArea;
+        private bool _isClickedTooltipArea;
 
         protected override PivotPresetType TargetPivotPresetType => PivotPresetType.TopRight;
 
@@ -128,8 +128,8 @@ namespace Nekoyume.UI
         public override void Close(bool ignoreCloseAnimation = false)
         {
             _onClose?.Invoke();
-            _isPointerOnScrollArea = false;
-            _isClickedButtonArea = false;
+            _isPointerOnTooltipArea = false;
+            _isClickedTooltipArea = false;
             base.Close(ignoreCloseAnimation);
         }
 
@@ -354,13 +354,12 @@ namespace Nekoyume.UI
                 yield return null;
             }
 
-            var positionCache = selectedGameObjectCache.transform.position;
-
             while (enabled)
             {
                 if (Input.GetMouseButtonDown(0))
                 {
-                    _isClickedButtonArea = _isPointerOnScrollArea;
+                    UnityEngine.Vector2 mousePos = Input.mousePosition;
+                    _isClickedTooltipArea = RectTransformUtility.RectangleContainsScreenPoint(panel, mousePos, MainCanvas.instance.Canvas.worldCamera) || _isPointerOnTooltipArea;
                 }
 
                 var current = TouchHandler.currentSelectedGameObject;
@@ -373,7 +372,7 @@ namespace Nekoyume.UI
                         continue;
                     }
 
-                    if (!_isClickedButtonArea)
+                    if (!_isClickedTooltipArea)
                     {
                         Close();
                         yield break;
@@ -386,7 +385,7 @@ namespace Nekoyume.UI
                         yield break;
                     }
 
-                    if (!_isClickedButtonArea)
+                    if (!_isClickedTooltipArea)
                     {
                         Close();
                         yield break;
@@ -399,7 +398,7 @@ namespace Nekoyume.UI
 
         public void OnEnterButtonArea(bool value)
         {
-            _isPointerOnScrollArea = value;
+            _isPointerOnTooltipArea = value;
         }
     }
 }


### PR DESCRIPTION
툴팁이 의도와 다르게 닫히거나 닫히지 않는 문제를 수정하였습니다.

1. 기존에 사용하던 **EventTrigger** 컴포넌트를 통해 포인터의 진입 여부를 체크하는 방식을 수정하였습니다.  
2. 이 과정에서 **EventTrigger**를 제거하고, 대신 스크립트로 마우스의 위치와 오브젝트의 위치 및 크기를 비교하여 처리하도록 변경하였습니다.  
3. **EventTrigger** 방식에서는 특히 모바일 환경에서 문제가 발생하였습니다.  
    - 마우스는 위치가 변경될 때마다 포인터 진입 여부를 확인하지만, 터치는 눌렀을 때만 인식되기 때문에 모바일에서만 발생하는 빈도 차이가 있었습니다.  
4. 이로 인해 발생하던 모바일 전용 이슈도 함께 해결되었습니다.
5. 수동으로 마우스위치가 툴팁외부에 위치하더라도 플레그를 변경하는 케이스가있어 해당케이스보완조치도 진행하였습니다.

연관 이슈
https://github.com/planetarium/NineChronicles/issues/6209
https://github.com/planetarium/NineChronicles/issues/6058