### PR TITLE
add cartItems[i].Set(null,null)

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Shop/CartView.cs
+++ b/nekoyume/Assets/_Scripts/UI/Shop/CartView.cs
@@ -85,6 +85,7 @@ namespace Nekoyume.UI.Module
                 }
                 else
                 {
+                    cartItems[i].Set(null, null);
                     cartItems[i].gameObject.SetActive(false);
                 }
             }


### PR DESCRIPTION
### Description

1. CartView를 닫을때 내용물을 비우지 않아서, 끈 뒤에 다른 상품을 추가하면 합계 가격에 합산되는 버그를 고쳤습니다.
2. 그냥 내용물을 null로 set하게 했습니다.


### Related Links

resolve #6213
