### PR TITLE
remove MimisLevel field

### DIFF
--- a/nekoyume/Assets/_Scripts/Extensions/InventoryExtensions.cs
+++ b/nekoyume/Assets/_Scripts/Extensions/InventoryExtensions.cs
@@ -114,10 +114,7 @@ namespace Nekoyume
                     foreach (var i in current)
                     {
                         var requirementLevel = i.GetRequirementLevel(
-                            requirementSheet,
-                            recipeSheet,
-                            subRecipeSheet,
-                            itemOptionSheet);
+                            requirementSheet);
 
                         if (level >= requirementLevel && CPHelper.GetCP(i) < cp)
                         {

--- a/nekoyume/Assets/_Scripts/Helper/Util.cs
+++ b/nekoyume/Assets/_Scripts/Helper/Util.cs
@@ -157,23 +157,13 @@ namespace Nekoyume.Helper
             switch (itemBase.ItemType)
             {
                 case ItemType.Equipment:
-                    var equipment = (Equipment)itemBase;
-                    if (!requirementSheet.TryGetValue(itemBase.Id, out var equipmentRow))
+                    if (requirementSheet.TryGetValue(itemBase.Id, out var equipmentRow))
                     {
-                        NcDebug.LogError($"[ItemRequirementSheet] item id does not exist {itemBase.Id}");
-                        return 0;
+                        return equipmentRow.Level;
                     }
 
-                    var recipeSheet = sheets.EquipmentItemRecipeSheet;
-                    var subRecipeSheet = sheets.EquipmentItemSubRecipeSheetV2;
-                    var itemOptionSheet = sheets.EquipmentItemOptionSheet;
-                    var isMadeWithMimisbrunnrRecipe = equipment.IsMadeWithMimisbrunnrRecipe(
-                        recipeSheet,
-                        subRecipeSheet,
-                        itemOptionSheet
-                    );
-
-                    return isMadeWithMimisbrunnrRecipe ? equipmentRow.MimisLevel : equipmentRow.Level;
+                    NcDebug.LogError($"[ItemRequirementSheet] item id does not exist {itemBase.Id}");
+                    return 0;
                 default:
                     return requirementSheet.TryGetValue(itemBase.Id, out var row) ? row.Level : 0;
             }

--- a/nekoyume/Assets/_Scripts/UI/Combination/SubRecipeView.cs
+++ b/nekoyume/Assets/_Scripts/UI/Combination/SubRecipeView.cs
@@ -523,8 +523,7 @@ namespace Nekoyume.UI
                     }
                     else
                     {
-                        var level = isMimisbrunnrSubRecipe ? row.MimisLevel : row.Level;
-                        levelText.text = $"Lv {level}";
+                        levelText.text = $"Lv {row.Level}";
                         levelText.enabled = true;
                     }
 


### PR DESCRIPTION
현재 제대로 사용되고 있지 않은 필드인 MimisLevel 필드를 제거합니다

- 현재 Level 필드와 값이 다른건 몇개의 음식 아이템 뿐(201035~201040)
- 이외의 아이템은 level필드로 대체가 가능하고 위 level 구분은 의미가 크게 없다고 생각했습니다
