### PR TITLE
Fix WorldButton  touch input handling

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Module/Button/WorldButton.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/Button/WorldButton.cs
@@ -170,6 +170,9 @@ namespace Nekoyume.UI.Module
         {
             AudioController.PlayClick();
             OnClickSubject.OnNext(this);
+            _animationState.SetValueAndForceNotify(IsLocked
+                        ? AnimationState.None
+                        : AnimationState.Idle);
         }
 
         private void OnEnterWorldButtonState(WorldState worldState)


### PR DESCRIPTION
월드버튼의 경우 모바일에서 터치인풋을했을경우 애니메이션상태가 초기화되지않는부분 보완
터치인풋의경우 ObservablePointerExitTrigger가 누르자마자 다른오브젝트로 가려지게되면 호출이안될수있음. 