### PR TITLE
fix seasonpass title duplicated when locked

### DIFF
--- a/nekoyume/Assets/AddressableAssets/UI/Module/Lobby/SeasonPassBtn.prefab
+++ b/nekoyume/Assets/AddressableAssets/UI/Module/Lobby/SeasonPassBtn.prefab
@@ -74,6 +74,7 @@ MonoBehaviour:
   - {fileID: 7417154762282368217}
   unlockObjects:
   - {fileID: 7526970204179609854}
+  - {fileID: 4727898122556568819}
   hoverScaleTweener: {fileID: 8856110352657579696}
   premiumIcon: {fileID: 3190434344910893947}
   premiumPlusIcon: {fileID: 5649134867725522539}


### PR DESCRIPTION
시즌패스버튼 잠겨있을경우 이름중복해서 나오는문제 수정.