### PR TITLE
add force exit game

### DIFF
--- a/nekoyume/Assets/_Scripts/Blockchain/Agent.cs
+++ b/nekoyume/Assets/_Scripts/Blockchain/Agent.cs
@@ -209,7 +209,7 @@ namespace Nekoyume.Blockchain
                 else
                 {
                     popup.Show("UI_RESET_STORE", "UI_RESET_STORE_CONTENT");
-                    popup.SetConfirmCallbackToExit();
+                    popup.SetConfirmCallbackToExit(true);
                 }
             }
 

--- a/nekoyume/Assets/_Scripts/Game/Game.cs
+++ b/nekoyume/Assets/_Scripts/Game/Game.cs
@@ -603,7 +603,7 @@ namespace Nekoyume.Game
                     L10nManager.Localize("UI_QUIT"),
                     false,
                     IconAndButtonSystem.SystemType.BlockChainError);
-                popup.SetConfirmCallbackToExit();
+                popup.SetConfirmCallbackToExit(true);
 
                 return;
             }
@@ -625,7 +625,7 @@ namespace Nekoyume.Game
 
             popup = Widget.Find<IconAndButtonSystem>();
             popup.Show("UI_ERROR", "UI_ERROR_RPC_CONNECTION", "UI_QUIT");
-            popup.SetConfirmCallbackToExit();
+            popup.SetConfirmCallbackToExit(true);
         }
 
         /// <summary>

--- a/nekoyume/Assets/_Scripts/UI/Widget/Base/SystemWidget.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Base/SystemWidget.cs
@@ -10,6 +10,9 @@ namespace Nekoyume.UI
         private CapturedImage _capturedImage;
         private UIBackground _background;
 
+        public CapturedImage CapturedImage => _capturedImage;
+        public UIBackground Background => _background;
+
         protected override void Awake()
         {
             base.Awake();

--- a/nekoyume/Assets/_Scripts/UI/Widget/System/IconAndButtonSystem.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/System/IconAndButtonSystem.cs
@@ -142,8 +142,23 @@ namespace Nekoyume.UI
 #endif
         }
 
-        public void SetConfirmCallbackToExit()
+        public void SetConfirmCallbackToExit(bool forceExit = false)
         {
+            if (forceExit)
+            {
+                CloseWidget = Confirm;
+
+                if (CapturedImage)
+                {
+                    CapturedImage.OnClick = CloseWidget;
+                }
+
+                if (Background)
+                {
+                    Background.OnClick = CloseWidget;
+                }
+            }
+
             ConfirmCallback = () =>
             {
 #if UNITY_EDITOR


### PR DESCRIPTION
강제로 게임이 종료되야 할 것 같은 상황에서 종료되지 않는 케이스가 있어 강제로 종료하는 기능을 만들었습니다.

적용대상
```
public void SetConfirmCallbackToExit(bool forceExit = false)
```

적용 스택
- Agent.InitAsync -> 로컬 초기화 실패한 경우(InvalidGenesisBlockException)
- Game.QuitWithAgentConnectionError -> rpc 초기화 자체가 불가능하거나 재접속 이 불가능한 경우

미적용 스택
- EventRewardPopup.ShowQuitConfirmPopup
- RPCAgent.OnException
