### PR TITLE
update headermenu when only enabled state

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Widget/Summon.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Summon.cs
@@ -188,7 +188,11 @@ namespace Nekoyume.UI
         public void OnActionRender(ActionEvaluation<AuraSummon> eval)
         {
             LoadingHelper.Summon.Value = null;
-            Find<HeaderMenuStatic>().UpdateAssets(HeaderMenuStatic.AssetVisibleState.Summon);
+            if (isActiveAndEnabled)
+            {
+                Find<HeaderMenuStatic>().UpdateAssets(HeaderMenuStatic.AssetVisibleState.Summon);
+            }
+
             var summonRow = Game.Game.instance.TableSheets.EquipmentSummonSheet[eval.Action.GroupId];
             var summonCount = eval.Action.SummonCount;
             var random = new ActionRenderHandler.LocalRandom(eval.RandomSeed);
@@ -199,7 +203,11 @@ namespace Nekoyume.UI
         public void OnActionRender(ActionEvaluation<RuneSummon> eval)
         {
             LoadingHelper.Summon.Value = null;
-            Find<HeaderMenuStatic>().UpdateAssets(HeaderMenuStatic.AssetVisibleState.Summon);
+            if (isActiveAndEnabled)
+            {
+                Find<HeaderMenuStatic>().UpdateAssets(HeaderMenuStatic.AssetVisibleState.Summon);
+            }
+
             var summonRow = Game.Game.instance.TableSheets.RuneSummonSheet[eval.Action.GroupId];
             var summonCount = eval.Action.SummonCount;
             var random = new ActionRenderHandler.LocalRandom(eval.RandomSeed);
@@ -210,7 +218,11 @@ namespace Nekoyume.UI
         public void OnActionRender(ActionEvaluation<CostumeSummon> eval)
         {
             LoadingHelper.Summon.Value = null;
-            Find<HeaderMenuStatic>().UpdateAssets(HeaderMenuStatic.AssetVisibleState.Summon);
+            if (isActiveAndEnabled)
+            {
+                Find<HeaderMenuStatic>().UpdateAssets(HeaderMenuStatic.AssetVisibleState.Summon);
+            }
+
             var summonRow = Game.Game.instance.TableSheets.CostumeSummonSheet[eval.Action.GroupId];
             var summonCount = eval.Action.SummonCount;
             var random = new ActionRenderHandler.LocalRandom(eval.RandomSeed);


### PR DESCRIPTION
### Description

1. Summon*** 액션 렌더에 헤더메뉴의 재화를 갱신하는 코드를 넣었더니, Summon UI가 꺼져있어도 각종 가루들이 나오는 버그가 생겼습니다.
2. 그래서 그걸 Summon Widget이 활성화 되어있을때만 갱신하도록 수정했습니다.

### Related Links

resolve #6402 
