### PR TITLE
split pledge api for no token

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Login/PortalConnect.cs
+++ b/nekoyume/Assets/_Scripts/UI/Login/PortalConnect.cs
@@ -77,6 +77,7 @@ namespace Nekoyume.UI
         public const string AppleAuthEndpoint = "/api/auth/login/apple";
         private const string RequestCodeEndpoint = "/api/auth/code";
         private const string RequestPledgeEndpoint = "/api/account/mobile/contract";
+        private const string RequestPledgeWithoutTokenPath = "/address";
         private const string AccessTokenEndpoint = "/api/auth/token";
         private const string RefreshTokenEndpoint = "/api/auth/mobile/refresh";
         private const string ReferralEndpoint = "/api/invitations/mobile/referral";
@@ -640,7 +641,7 @@ namespace Nekoyume.UI
 
         public IEnumerator RequestPledge(PlanetId planetId, Address address)
         {
-            var url = $"{PortalUrl}{RequestPledgeEndpoint}";
+            var url = $"{PortalUrl}{RequestPledgeEndpoint}{(HasAccessToken ? string.Empty : RequestPledgeWithoutTokenPath)}";
             var os = string.Empty;
 #if UNITY_ANDROID
             os = "android";
@@ -658,7 +659,10 @@ namespace Nekoyume.UI
 
             var request = UnityWebRequest.Post(url, form);
             request.timeout = Timeout;
-            request.SetRequestHeader("authorization", $"Bearer {accessToken}");
+            if (HasAccessToken)
+            {
+                request.SetRequestHeader("authorization", $"Bearer {accessToken}");
+            }
 
             yield return request.SendWebRequest();
 


### PR DESCRIPTION
### Description

1. 이미 다른 플래닛에서 플렛지가 된적이 있지만, 소셜로그인 없이 타 플래닛에서 새로 시작하려는 유저는 플렛지를 못하는 상태였습니다.
2. 그래서 소셜로그인이 안된 상태로 플렛지를 시도하는 경우, 백엔드에서 이미 가입한적 있는 유저인지 체크한 뒤 플렛지를 해주는 api를 만들어주셨습니다.
3. 이에 대한 대응을 추가한 PR입니다.

### Related Links

resolve #6401 
확인과정: https://planetariumhq.slack.com/archives/CBU2JFAF3/p1732066705422459
