### PR TITLE
fix costume equipment error

### DIFF
--- a/nekoyume/Assets/_Scripts/Blockchain/ActionHandler.cs
+++ b/nekoyume/Assets/_Scripts/Blockchain/ActionHandler.cs
@@ -15,6 +15,7 @@ using Nekoyume.Game;
 using Nekoyume.Helper;
 using Nekoyume.L10n;
 using Nekoyume.Model.EnumType;
+using Nekoyume.Model.Item;
 using Nekoyume.Model.Mail;
 using Nekoyume.Model.Stake;
 using Nekoyume.Model.State;
@@ -423,6 +424,18 @@ namespace Nekoyume.Blockchain
                 avatarState.address,
                 battleType);
             States.Instance.UpdateItemSlotState(itemSlotState);
+            //simulator에서 CurrentItemSlotStates를 사용하지않고 AvatarState.inventory의 착용정보를 직접사용함으로 인해 추가적으로 갱신
+            foreach (var inventoryItem in States.Instance.CurrentAvatarState.inventory.Items)
+            {
+                if(inventoryItem.item is Equipment equipment)
+                {
+                    equipment.equipped = itemSlotState.Equipments.Exists(e => e == equipment.ItemId);
+                }
+                else if(inventoryItem.item is Costume costume)
+                {
+                    costume.equipped = itemSlotState.Costumes.Exists(c => c == costume.ItemId);
+                }
+            }
         }
 
         protected static void UpdateCurrentAvatarRuneSlotState<T>(


### PR DESCRIPTION
# 원인
- PrepareHackAndSlash 액션전의 아바타스테이트를 갱신한뒤 착용정보를 outputstate로 현재 AvatarState를 갱신시키는 과정에서 정상적으로 착용정보가 갱신되지않는것으로 파악됨.
- UpdateCurrentAvatarItemSlotState함수에서는 CurrentItemSlotStates 정보만을 갱신시킴.
- 스테이지 시뮬레이터에서 착용정보를 찾는방식은 AvatarState의 아이템중 착용된 아이템을 확인하는 방식으로 진행됨. ([Player.Equip 메소드](https://github.com/planetarium/lib9c/blob/4e68199dd3aee71b0f0b984af0a4bc97a6b352b8/Lib9c/Model/Character/Player.cs#L283))

# 해결
- UpdateCurrentAvatarItemSlotState시 AvatarState의 인벤토리에 착용정보도 갱신시키는 방향으로 수정
- 에디터에서 수정 확인 완료.

# 추가
- 나름 히스토리를 파악해보려했으나 전부 수정된지 오래된코드로보여 언제부터 해당상황이 발생했는지는 확인하기 어려움.
- 기존에는 시뮬레이터에서 아이템슬롯정보를 직접 넣었던것이 바뀌면서 발생한문제인것같기도함.
- 수정이 사이드이팩트가 없을지 확인 필요.
- 클라에서는 코스튬뿐만아니라 장비까지도 액션이전의것으로  시뮬레이션하기때문에 스팩이 확달라지는경우 결과가 달라졌을수있었음.