### PR TITLE
fix pledge check

### DIFF
--- a/nekoyume/Assets/_Scripts/Game/Scene/LoginScene.cs
+++ b/nekoyume/Assets/_Scripts/Game/Scene/LoginScene.cs
@@ -288,11 +288,11 @@ namespace Nekoyume.Game.Scene
                     Game.QuitWithMessage(L10nManager.Localize("ERROR_INITIALIZE_FAILED"), "Failed to Get Tokens.");
                     yield break;
                 }
+            }
 
-                if (!planetContext.IsSelectedPlanetAccountPledged)
-                {
-                    yield return StartCoroutine(game.CoCheckPledge(planetContext.SelectedPlanetInfo.ID));
-                }
+            if (!planetContext.IsSelectedPlanetAccountPledged)
+            {
+                yield return StartCoroutine(game.CoCheckPledge(planetContext.SelectedPlanetInfo.ID));
             }
 #endif
 


### PR DESCRIPTION
### Description

1. 키 임포트를 해서 소셜로그인을 스킵한 경우엔 애시당초 플렛지를 안하고있어서 그거랑 별개로 플렛지 체크는 하도록 고쳤습니다

### Related Links

resolve #6401 
