### PR TITLE
fix summon itemview grade color error

### DIFF
--- a/nekoyume/Assets/AddressableAssets/UI/Module/ItemView/SummonItemView.prefab
+++ b/nekoyume/Assets/AddressableAssets/UI/Module/ItemView/SummonItemView.prefab
@@ -11,7 +11,6 @@ GameObject:
   - component: {fileID: 4908474618568497325}
   - component: {fileID: 7963293041277191095}
   - component: {fileID: 5288106951053044577}
-  - component: {fileID: 8216407591408215217}
   m_Layer: 5
   m_Name: IconImage
   m_TagString: Untagged
@@ -77,22 +76,6 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
---- !u!114 &8216407591408215217
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 11084338915560972}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 97bc2ebab6563400c95b036136d26ea6, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Inverse: 0
-  m_MaskInteraction: 85
-  m_UseStencil: 1
-  m_RaycastFilter: 0
 --- !u!1 &494620282712414925
 GameObject:
   m_ObjectHideFlags: 0
@@ -9944,7 +9927,7 @@ MonoBehaviour:
   itemViewData: {fileID: 11400000, guid: 7bbcb13078addb548a8707df8e95df63, type: 2}
   iconImage: {fileID: 5288106951053044577}
   gradeImage: {fileID: 9218489218979148616}
-  gradeHsv: {fileID: 7172440194635937498}
+  gradeHsv: {fileID: 0}
   animator: {fileID: 2132912527656166809}
   touchHandler: {fileID: 1797049770047718727}
   canvasGroup: {fileID: 4201367411927262499}
@@ -10137,99 +10120,6 @@ MonoBehaviour:
   defaultWordSpacing: 0
   defaultLineSpacingInitialized: 0
   defaultLineSpacing: 0
---- !u!1 &2237777006182496273
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2914966720252801347}
-  - component: {fileID: 4832361910141591836}
-  - component: {fileID: 8784752764743186334}
-  - component: {fileID: 3114072894713190246}
-  m_Layer: 5
-  m_Name: BackgroundImage
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &2914966720252801347
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2237777006182496273}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 7233842297873165774}
-  m_RootOrder: 3
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 62, y: 62}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &4832361910141591836
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2237777006182496273}
-  m_CullTransparentMesh: 0
---- !u!114 &8784752764743186334
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2237777006182496273}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 55b5e2d7f2f307844939c873f7a058c7, type: 3}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
---- !u!114 &3114072894713190246
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2237777006182496273}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 97bc2ebab6563400c95b036136d26ea6, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Inverse: 0
-  m_MaskInteraction: 85
-  m_UseStencil: 1
-  m_RaycastFilter: 0
 --- !u!1 &2316973135441634955
 GameObject:
   m_ObjectHideFlags: 0
@@ -19811,7 +19701,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 7233842297873165774}
-  m_RootOrder: 5
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -25400,7 +25290,7 @@ RectTransform:
   m_Children:
   - {fileID: 8100980266661764181}
   m_Father: {fileID: 7233842297873165774}
-  m_RootOrder: 6
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -30334,7 +30224,7 @@ RectTransform:
   - {fileID: 3027692564940151922}
   - {fileID: 4908474618568497325}
   m_Father: {fileID: 7233842297873165774}
-  m_RootOrder: 4
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -30439,8 +30329,6 @@ GameObject:
   - component: {fileID: 3027692564940151922}
   - component: {fileID: 1947752386840436873}
   - component: {fileID: 9218489218979148616}
-  - component: {fileID: 7172440194635937498}
-  - component: {fileID: 361273114218163825}
   m_Layer: 5
   m_Name: GradeImage
   m_TagString: Untagged
@@ -30506,39 +30394,6 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
---- !u!114 &7172440194635937498
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8159311473944753679}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: efe700dddcd8341ff8607ac2c827b4b5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_TargetColor: {r: 1, g: 1, b: 1, a: 1}
-  m_Range: 0.5
-  m_Hue: 0
-  m_Saturation: 0
-  m_Value: 0
---- !u!114 &361273114218163825
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8159311473944753679}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 97bc2ebab6563400c95b036136d26ea6, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Inverse: 0
-  m_MaskInteraction: 85
-  m_UseStencil: 1
-  m_RaycastFilter: 0
 --- !u!1 &8261827014740876137
 GameObject:
   m_ObjectHideFlags: 0
@@ -30724,7 +30579,6 @@ RectTransform:
   - {fileID: 1344169856969857481}
   - {fileID: 2232134034628610377}
   - {fileID: 487191167397987383}
-  - {fileID: 2914966720252801347}
   - {fileID: 4002679878424156869}
   - {fileID: 4639365657279045822}
   - {fileID: 1872739771817790549}
@@ -31103,7 +30957,7 @@ PrefabInstance:
     - target: {fileID: 6934701905363954657, guid: 5b8d64f2198d3dd449f2e353dc79925d,
         type: 3}
       propertyPath: m_RootOrder
-      value: 7
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 6934701905363954657, guid: 5b8d64f2198d3dd449f2e353dc79925d,
         type: 3}

--- a/nekoyume/Assets/_Scripts/UI/Module/Item/VanillaItemView.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/Item/VanillaItemView.cs
@@ -61,13 +61,21 @@ namespace Nekoyume.UI.Module
                 return;
             }
 
-            var data = GetItemViewData(itemBase);
-            gradeImage.overrideSprite = data.GradeBackground;
+            // 오브젝트가 과도하게 많을경우 hsv를 사용하지않고 image만사용하는 케이스에 사용하기위해 분기 추가.
+            if(gradeHsv == null)
+            {
+                gradeImage.sprite = SpriteHelper.GetItemBackground(itemBase.Grade);
+            }
+            else
+            {
+                var data = GetItemViewData(itemBase);
+                gradeImage.overrideSprite = data.GradeBackground;
 
-            gradeHsv.range = data.GradeHsvRange;
-            gradeHsv.hue = data.GradeHsvHue;
-            gradeHsv.saturation = data.GradeHsvSaturation;
-            gradeHsv.value = data.GradeHsvValue;
+                gradeHsv.range = data.GradeHsvRange;
+                gradeHsv.hue = data.GradeHsvHue;
+                gradeHsv.saturation = data.GradeHsvSaturation;
+                gradeHsv.value = data.GradeHsvValue;
+            }
 
             iconImage.enabled = true;
             iconImage.overrideSprite = itemBase.GetIconSprite();
@@ -103,14 +111,22 @@ namespace Nekoyume.UI.Module
                 grade = petRow.Grade;
             }
 
-            var data = itemViewData.GetItemViewData(grade);
 
-            gradeHsv.range = data.GradeHsvRange;
-            gradeHsv.hue = data.GradeHsvHue;
-            gradeHsv.saturation = data.GradeHsvSaturation;
-            gradeHsv.value = data.GradeHsvValue;
+            if (gradeHsv == null)
+            {
+                gradeImage.sprite = SpriteHelper.GetItemBackground(grade);
+            }
+            else
+            {
+                var data = itemViewData.GetItemViewData(grade);
 
-            gradeImage.overrideSprite = data.GradeBackground;
+                gradeHsv.range = data.GradeHsvRange;
+                gradeHsv.hue = data.GradeHsvHue;
+                gradeHsv.saturation = data.GradeHsvSaturation;
+                gradeHsv.value = data.GradeHsvValue;
+                gradeImage.overrideSprite = data.GradeBackground;
+            }
+
             iconImage.enabled = true;
             iconImage.overrideSprite = fav.GetIconSprite();
             iconImage.SetNativeSize();


### PR DESCRIPTION
110뽑시 소환 아이템의 등급 배경이 정상 적용되지않는 문제 수정.

hsv 관련스크립트가 오브젝트가 많은 경우 정상동작하지않는문제로 보임. 등급별이미지를 직접사용하는식으로 변경.