### PR TITLE
fix header mileage

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Module/Currency/IAPMileage.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/Currency/IAPMileage.cs
@@ -18,7 +18,7 @@ namespace Nekoyume.UI.Module
         {
             ApiClients.Instance.IAPServiceManager.CurrentMileage.Subscribe(mileage =>
             {
-                amountText.text = mileage.ToCurrencyNotation();
+                amountText.text = mileage.ToString("N0", System.Globalization.CultureInfo.CurrentCulture);
             });
         }
 

--- a/nekoyume/Assets/_Scripts/UI/Widget/Static/HeaderMenuStatic.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Static/HeaderMenuStatic.cs
@@ -504,14 +504,7 @@ namespace Nekoyume.UI.Module
                     break;
                 case AssetVisibleState.Shop:
 #if UNITY_IOS || UNITY_ANDROID
-                    if (Game.instance.IAPStoreManager.CheckCategoryName("Mileage"))
-                    {
-                        SetActiveAssets(true, false, isIapMileageActive: true, enabledMaterials: new[] { CostType.GoldDust });
-                    }
-                    else
-                    {
-                        SetActiveAssets(true, true, enabledMaterials: new[] { CostType.GoldDust });
-                    }
+                    SetActiveAssets(true, false, isIapMileageActive: true, enabledMaterials: new[] { CostType.GoldDust });
 #else
                     SetActiveAssets(true, true, enabledMaterials: new[] { CostType.GoldDust });
 #endif


### PR DESCRIPTION
마일리지 카테고리가 없더라도 iap 상점에서 헤더메뉴에 마일리지 항상보이도록 변경
(토르에서 마일리지상품이 없더라도 마일리지 적립은되는 상태로 진행하는것을 보완하기위함)

헤더메뉴 클릭시 수량 전체 표시방식으로 변경