### PR TITLE
fix worldboss practice reward

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Widget/Popup/WorldBossResultPopup.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Popup/WorldBossResultPopup.cs
@@ -126,11 +126,6 @@ namespace Nekoyume.UI
 
         public void ShowAsPractice(int bossId, long score)
         {
-            foreach (var view in runeRewardViews)
-            {
-                view.gameObject.SetActive(false);
-            }
-
             base.Show();
             AudioController.instance.PlayMusic(AudioController.MusicCode.WorldBossBattleResult);
             _practiceText.SetActive(true);
@@ -140,6 +135,11 @@ namespace Nekoyume.UI
             foreach (var view in runeRewardViews)
             {
                 view.gameObject.SetActive(false);
+            }
+
+            foreach (var item in itemRewardViews)
+            {
+                item.Hide();
             }
 
             if (Game.Game.instance.TableSheets.WorldBossCharacterSheet.TryGetValue(bossId, out var row))


### PR DESCRIPTION
월드보스에서 연습결과창에서 아이템나오는문제 수정하였습니다.
기존 아이템표현하는 프리팹을 2종류로 나누면서 발생한문제로 보입니다.