### PR TITLE
GetSheets Use StateRootHash instead of BlockHash

### DIFF
--- a/nekoyume/Assets/_Scripts/Blockchain/RPCAgent.cs
+++ b/nekoyume/Assets/_Scripts/Blockchain/RPCAgent.cs
@@ -658,7 +658,7 @@ namespace Nekoyume.Blockchain
                 {
                     var raw =
                         await _service.GetSheets(
-                            BlockTipHash.ToByteArray(),
+                            BlockTipStateRootHash.ToByteArray(),
                             list.Select(a => a.ToByteArray()));
                     await raw.ParallelForEachAsync(async pair =>
                     {


### PR DESCRIPTION
- 노드와 통신해서 시트를 가져올때 블록해쉬대신 StateRootHash를 사용하도록 변경합니다.
- resolve #6582 
- https://github.com/planetarium/NineChronicles.Headless/pull/2658 와 함께 머지되야합니다.