### PR TITLE
change action time out 360 to 60 sec

### DIFF
--- a/nekoyume/Assets/_Scripts/Blockchain/ActionManager.cs
+++ b/nekoyume/Assets/_Scripts/Blockchain/ActionManager.cs
@@ -42,7 +42,7 @@ namespace Nekoyume.Blockchain
     /// </summary>
     public class ActionManager : IDisposable
     {
-        private static readonly TimeSpan ActionTimeout = TimeSpan.FromSeconds(360f);
+        private static readonly TimeSpan ActionTimeout = TimeSpan.FromSeconds(60f);
 
         private readonly IAgent _agent;
 


### PR DESCRIPTION
https://planetariumhq.slack.com/archives/CBU2JFAF3/p1734678311600799
 클라이언트 액션 타임 아웃 시간이 너무 길어서(6분) 장애 발생 시 로딩이 멈춘 것 처럼 보일 수 있는 여지가 있어 해당 시간을 1분으로 조정합니다.