### PR TITLE
코스튬 장착 실패시 장비 장착 로직을 타도록 처리

### DIFF
--- a/nekoyume/Assets/_Scripts/Game/Avatar/AvatarSpineController.cs
+++ b/nekoyume/Assets/_Scripts/Game/Avatar/AvatarSpineController.cs
@@ -288,23 +288,42 @@ namespace Nekoyume.Game.Avatar
             _cachedAuraVFX = vfx;
         }
 
-        public void UpdateFullCostume(int index, bool isDcc)
+        /// <summary>
+        /// Updates the avatar's full costume by loading the specified SkeletonDataAsset
+        /// and refreshing the visual elements accordingly.
+        /// </summary>
+        /// <param name="index">The index of the full costume to load.</param>
+        /// <param name="isDcc">Flag indicating if Dynamic Character Customization (DCC) mode is active.</param>
+        /// <returns>True if the costume was updated successfully, otherwise false.</returns>
+        public bool UpdateFullCostume(int index, bool isDcc)
         {
+            // Activate full costume mode
             _isActiveFullCostume = true;
+
+            // Construct the resource key for the SkeletonDataAsset
             var key = $"{index}_SkeletonData";
+
+            // Load the SkeletonDataAsset using the resource key
             var asset = ResourceManager.Instance.Load<SkeletonDataAsset>(key);
 
+            // If the asset couldn't be loaded, log an error and return false
             if (asset == null)
             {
                 NcDebug.LogError($"Failed to load SkeletonDataAsset: {key}");
-                return;
+                return false;
             }
 
+            // Update the SkeletonDataAsset for the full costume part
             var isChange = UpdateSkeletonDataAsset(AvatarPartsType.full_costume, asset);
+
+            // If the asset was updated successfully, refresh the character's appearance
             if (isChange)
             {
                 Refresh(isDcc);
             }
+
+            // Return true to indicate the update was successful
+            return true;
         }
 
         public void UnequipFullCostume(bool isDcc)

--- a/nekoyume/Assets/_Scripts/Game/Character/CharacterAppearance.cs
+++ b/nekoyume/Assets/_Scripts/Game/Character/CharacterAppearance.cs
@@ -200,12 +200,13 @@ namespace Nekoyume.Game.Character
             {
                 var fullCostume =
                     costumes.FirstOrDefault(x => x.ItemSubType == ItemSubType.FullCostume);
+                var useEquipment = true;
                 if (fullCostume is not null)
                 {
-                    UpdateFullCostume(fullCostume);
-                    UpdateAura(aura);
+                    useEquipment = !UpdateFullCostume(fullCostume);
                 }
-                else
+
+                if (useEquipment)
                 {
                     SpineController.UnequipFullCostume(false);
                     UpdateEar(earIndex, false, costumeItemSheet);
@@ -217,9 +218,9 @@ namespace Nekoyume.Game.Character
                     UpdateAcHead(0, false);
                     UpdateArmor(armor, 0, false);
                     UpdateWeapon(weapon);
-                    UpdateAura(aura);
                 }
 
+                UpdateAura(aura);
                 if (!isFriendCharacter && pet)
                 {
                     pet.SetPosition(SpineController.GetBodySkeletonAnimation(), fullCostume is not null);
@@ -235,11 +236,31 @@ namespace Nekoyume.Game.Character
             onFinish?.Invoke();
         }
 
-        private void UpdateFullCostume(Costume fullCostume)
+        /// <summary>
+        /// Updates the full costume for the character by setting the corresponding costume ID.
+        /// If the costume exists, updates the target and hit points.
+        /// Note: If <c>UpdateHitPoint</c> is called conditionally on <c>costumeExist</c>,
+        /// fallback behavior (when the costume does not exist) may not execute as intended.
+        /// </summary>
+        /// <param name="fullCostume">The costume object containing the ID to be applied.</param>
+        /// <returns>True if the costume exists and was successfully updated; otherwise, false.</returns>
+        private bool UpdateFullCostume(Costume fullCostume)
         {
-            SpineController.UpdateFullCostume(fullCostume.Id, false);
-            UpdateTarget();
-            UpdateHitPoint();
+            // Attempt to update the full costume using the SpineController and check if it exists.
+            var costumeExist = SpineController.UpdateFullCostume(fullCostume.Id, false);
+
+            // If the costume exists, update the character's target and hit points.
+            if (costumeExist)
+            {
+                UpdateTarget(); // Update the target object for the character's animations.
+
+                // Warning: If the costume does not exist, fallback logic (e.g., resetting hit points)
+                // will not execute as intended because UpdateHitPoint is conditionally called here.
+                UpdateHitPoint(); // Update the character's collider and hit point dimensions.
+            }
+
+            // Return whether the costume exists.
+            return costumeExist;
         }
 
         private void UpdateAcFace(int index, bool isDcc)


### PR DESCRIPTION
- resolve #6668 
- 코스튬 장착시 에셋 로드에 실패하면 장비 장착 로직으로 폴백되도록 처리합니다.
- 장비 장착로직에선 기본적인 폴백(기본값)이 설정되있기 때문에 추가 처리는 하지 않았습니다.