### PR TITLE
typo fix CHANGELOG.md

### DIFF
--- a/nekoyume/Assets/ExternalDependencyManager/Editor/CHANGELOG.md
+++ b/nekoyume/Assets/ExternalDependencyManager/Editor/CHANGELOG.md
@@ -171,7 +171,7 @@
 # Version 1.2.156 - June 10, 2020
 ## Bug Fixes
 * Android Resolver: Fixed that the generated local repo assets contains
-  redundent labels which are causing Version Handler to failed while
+  redundant labels which are causing Version Handler to failed while
   uninstalling packages.
 * Android Resolver: Fixed that the repo url injected into mainTemplate.gradle
   is incorrect when Unity is configured to export gradle project.


### PR DESCRIPTION
# Pull Request Title: Fix Typo in `CHANGELOG.md` - "redundent" to "redundant"

## Summary:
This pull request addresses a minor typo in the `CHANGELOG.md` file to improve readability and maintain a professional standard in the documentation:
- Corrected the spelling of **"redundent"** to **"redundant"**.

## Changes Made:
- **CHANGELOG.md**:
  - Fixed the typo in the bug fix description under **Version 1.2.156 - June 10, 2020**.

## Files Changed:
- `nekoyume/Assets/ExternalDependencyManager/Editor/CHANGELOG.md`

## Testing:
- This is a documentation-only update and does not affect the codebase or functionality.

## Additional Notes:
- Correct and polished documentation reflects positively on the project's quality and can prevent confusion for developers referencing the changelog.
- This small improvement ensures clarity in historical records for the project.

---

Thank you for considering this typo fix!
