### PR TITLE
Remove build_lib9c job

### DIFF
--- a/.github/bin/check-libplanet-version.sh
+++ b/.github/bin/check-libplanet-version.sh
@@ -8,10 +8,16 @@ ci-out() {
 
 root="$(dirname "$0")/../.."
 packages="$root/nekoyume/Assets/Packages"
-submodule="$root/nekoyume/Assets/_Scripts/Lib9c/lib9c/.Libplanet"
+lib9c_props_path="$root/nekoyume/Assets/_Scripts/Lib9c/lib9c/Directory.Build.props"
+version_pattern="<LibplanetVersion>(.*)<\/LibplanetVersion>"
 
-git -C "$submodule" fetch --tags --depth=2147483647
-submodule_version="$(git -C "$submodule" describe --tags --abbrev=0)"
+if grep -qE "$version_pattern" "$lib9c_props_path"; then
+  sed_pattern="s/.*$version_pattern.*/\\1/p"
+  submodule_version="$(cat $lib9c_props_path | sed -nE $sed_pattern)"
+else
+  echo >&2 "The version of Libplanet is not specified in $lib9c_props_path."
+  exit 1
+fi
 
 echo >&2 "The version of Libplanet submodule vendored by Lib9c is:"
 echo "$submodule_version"

--- a/.github/workflows/build-misc.yml
+++ b/.github/workflows/build-misc.yml
@@ -15,51 +15,6 @@ on:
 name: Build-misc
 
 jobs:
-  build_9c:
-    name: build_lib9c
-    runs-on: ubuntu-20.04
-    if: github.event_name == 'push' || github.event_name == 'pull_request'
-    steps:
-    - uses: actions/checkout@master
-      with:
-        submodules: recursive
-    - run: hooks/pre-commit
-    - uses: unsplash/comment-on-pr@master
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        msg: >
-          @${{ github.actor }} Your pull request does not pass lint checks.
-          You probably haven't configured hooks in your local Git repository.
-          Please configure Git hooks in your local repository using the below
-          command:
-
-
-              git config core.hooksPath hooks
-      if: failure() && github.event_name == 'pull_request'
-    - run: sudo apt install libimage-exiftool-perl
-    - id: clv
-      run: .github/bin/check-libplanet-version.sh
-    - uses: unsplash/comment-on-pr@master
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      if: failure() && github.event_name == 'pull_request'
-      with:
-        msg: >
-          @${{ github.actor }} The versions of bundled Libplanet assemblies and
-          Libplanet submodule vendored by Lib9c apparently do not match:
-
-          - Libplanet submdoule: ${{ steps.clv.outputs.submodule_version }}
-
-          ${{ join(fromJSON(steps.clv.outputs.unmatches), fromJSON('"\n"')) }}
-
-
-          Leave a comment in this pull_request with the following command to
-          let the bot upgrade bundled Libplanet assemblies:
-
-          > /update-libplanet-dlls
-      # The action for command /update-libplanet-dlls is implemented below.
-
   update-libplanet-dlls:
     runs-on: ubuntu-20.04
     name: Update bundled Libplanet assemblies


### PR DESCRIPTION
- resolve #6692 
- lib9c가 libplanet을 서브모듈로 사용하지 않게 되면서 필요없어진 해당 job을 제거합니다.