### PR TITLE
add updateAssets log

### DIFF
--- a/nekoyume/Assets/_Scripts/Debugger/NcDebug.cs
+++ b/nekoyume/Assets/_Scripts/Debugger/NcDebug.cs
@@ -5,6 +5,8 @@ namespace Nekoyume
 {
     public static class NcDebug
     {
+        public const string ChannelWidget = "Widget";
+
         // used for build with 'DEBUG_USE' symbol.
         [UsedImplicitly]
         public static string InsertTimestamp(string message)

--- a/nekoyume/Assets/_Scripts/UI/Widget/Base/Widget.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Base/Widget.cs
@@ -275,7 +275,7 @@ namespace Nekoyume.UI
 
         public virtual void Show(bool ignoreShowAnimation = false)
         {
-            NcDebug.Log($"[Widget][{GetType().Name}] Show({ignoreShowAnimation}) invoked.", "Widget");
+            NcDebug.Log($"[Widget][{GetType().Name}] Show({ignoreShowAnimation}) invoked.", NcDebug.ChannelWidget);
             if (_coClose is not null)
             {
                 StopCoroutine(_coClose);
@@ -314,7 +314,7 @@ namespace Nekoyume.UI
 
         public virtual void Close(bool ignoreCloseAnimation = false)
         {
-            NcDebug.Log($"[Widget][{GetType().Name}] Close({ignoreCloseAnimation}) invoked.", "Widget");
+            NcDebug.Log($"[Widget][{GetType().Name}] Close({ignoreCloseAnimation}) invoked.", NcDebug.ChannelWidget);
             if (WidgetStack.Count > 0 &&
                 WidgetStack.Peek() == gameObject)
             {

--- a/nekoyume/Assets/_Scripts/UI/Widget/Static/HeaderMenuStatic.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Static/HeaderMenuStatic.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using Nekoyume.Action;
 using Nekoyume.Game.Battle;
 using Nekoyume.Game.LiveAsset;
@@ -493,8 +494,10 @@ namespace Nekoyume.UI.Module
             return toggleTransform ? toggleTransform : null;
         }
 
-        public void UpdateAssets(AssetVisibleState state)
+        public void UpdateAssets(AssetVisibleState state, [CallerMemberName] string caller = "")
         {
+            NcDebug.Log($"[{nameof(HeaderMenuStatic)}] UpdateAssets: {state} from {caller}", NcDebug.ChannelWidget);
+
             switch (state)
             {
                 case AssetVisibleState.Main:


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/a69efa62-aed1-44be-89d4-6224827ebe51)

This pull request includes several changes to improve debugging and logging in the `nekoyume` project. The most important changes involve adding a new debug channel constant and updating logging statements to use this constant for better consistency and clarity.

### Debugging and Logging Improvements:

* [`nekoyume/Assets/_Scripts/Debugger/NcDebug.cs`](diffhunk://#diff-ef736f9dd0a4fda6c8d7a9202ec11979e52c13d7cbf3423019503022648c9ddaR8-R9): Added a new constant `ChannelWidget` to the `NcDebug` class for consistent logging related to widgets.
* [`nekoyume/Assets/_Scripts/UI/Widget/Base/Widget.cs`](diffhunk://#diff-0c360ad6d529f44edc57c42388189618342bbb2e258516541be0928df9f831abL278-R278): Updated the `Show` and `Close` methods to use the new `NcDebug.ChannelWidget` constant in their logging statements. [[1]](diffhunk://#diff-0c360ad6d529f44edc57c42388189618342bbb2e258516541be0928df9f831abL278-R278) [[2]](diffhunk://#diff-0c360ad6d529f44edc57c42388189618342bbb2e258516541be0928df9f831abL317-R317)
* [`nekoyume/Assets/_Scripts/UI/Widget/Static/HeaderMenuStatic.cs`](diffhunk://#diff-9995c7bdce1b4e0fd13946de5d388b833a27f2558178b93135604a9b9c9c1a17R4): Added the `System.Runtime.CompilerServices` namespace and updated the `UpdateAssets` method to include the caller's name in the log message using the `CallerMemberName` attribute. [[1]](diffhunk://#diff-9995c7bdce1b4e0fd13946de5d388b833a27f2558178b93135604a9b9c9c1a17R4) [[2]](diffhunk://#diff-9995c7bdce1b4e0fd13946de5d388b833a27f2558178b93135604a9b9c9c1a17L496-R500)