### PR TITLE
fix local agent rpc call func

### DIFF
--- a/nekoyume/Assets/_Scripts/Blockchain/Agent.cs
+++ b/nekoyume/Assets/_Scripts/Blockchain/Agent.cs
@@ -432,22 +432,26 @@ namespace Nekoyume.Blockchain
 
         public async Task<Integer> GetUnbondClaimableHeightByStateRootHashAsync(HashDigest<SHA256> stateRootHash, Address address)
         {
-            throw new NotImplementedException();
+            // TODO: Implement
+            return new Integer();
         }
 
         public async Task<List> GetClaimableRewardsByStateRootHashAsync(HashDigest<SHA256> stateRootHash, Address address)
         {
-            throw new NotImplementedException();
+            // TODO: Implement
+            return new List();
         }
 
         public async Task<List> GetDelegationInfoByStateRootHashAsync(HashDigest<SHA256> stateRootHash, Address address)
         {
-            throw new NotImplementedException();
+            // TODO: Implement
+            return new List();
         }
 
         public async Task<FungibleAssetValue> GetStakedByStateRootHashAsync(HashDigest<SHA256> stateRootHash, Address address)
         {
-            throw new NotImplementedException();
+            // TODO: Implement
+            return new FungibleAssetValue();
         }
 
         // TODO: Below `GetInitState` codes have to be removed with Libplanet changes,


### PR DESCRIPTION
This pull request makes changes to the `nekoyume/Assets/_Scripts/Blockchain/Agent.cs` file. Specifically, it replaces `NotImplementedException` with placeholder return statements for several methods related to blockchain operations.

Changes to method implementations:

* [`GetUnbondClaimableHeightByStateRootHashAsync`](diffhunk://#diff-cff46460fbcaac73136d987df4ea3882b837d8217b9c988d4d41bce3d61c7f86L435-R454): Replaced `throw new NotImplementedException()` with a placeholder return statement (`return new Integer()`).
* [`GetClaimableRewardsByStateRootHashAsync`](diffhunk://#diff-cff46460fbcaac73136d987df4ea3882b837d8217b9c988d4d41bce3d61c7f86L435-R454): Replaced `throw new NotImplementedException()` with a placeholder return statement (`return new List()`).
* [`GetDelegationInfoByStateRootHashAsync`](diffhunk://#diff-cff46460fbcaac73136d987df4ea3882b837d8217b9c988d4d41bce3d61c7f86L435-R454): Replaced `throw new NotImplementedException()` with a placeholder return statement (`return new List()`).
* [`GetStakedByStateRootHashAsync`](diffhunk://#diff-cff46460fbcaac73136d987df4ea3882b837d8217b9c988d4d41bce3d61c7f86L435-R454): Replaced `throw new NotImplementedException()` with a placeholder return statement (`return new FungibleAssetValue()`).