### PR TITLE
add try catch for patrol reward sheet

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Model/PatrolReward.cs
+++ b/nekoyume/Assets/_Scripts/UI/Model/PatrolReward.cs
@@ -73,25 +73,32 @@ namespace Nekoyume.ApiClient
         public static void LoadPolicyInfo(int level, long blockIndex)
         {
             var patrolRewardSheet = Game.Game.instance.TableSheets.PatrolRewardSheet;
-            var row = patrolRewardSheet.FindByLevel(level, blockIndex);
-            var rewards = new List<PatrolRewardModel>();
-            foreach (var rewardModel in row.Rewards)
+            try
             {
-                rewards.Add(new PatrolRewardModel
+                var row = patrolRewardSheet.FindByLevel(level, blockIndex);
+                var rewards = new List<PatrolRewardModel>();
+                foreach (var rewardModel in row.Rewards)
                 {
-                    Currency = rewardModel.Ticker,
-                    ItemId = rewardModel.ItemId,
-                    PerInterval = rewardModel.Count,
-                });
+                    rewards.Add(new PatrolRewardModel
+                    {
+                        Currency = rewardModel.Ticker,
+                        ItemId = rewardModel.ItemId,
+                        PerInterval = rewardModel.Count,
+                    });
+                }
+                var policy = new PolicyModel
+                {
+                    MinimumLevel = row.MinimumLevel,
+                    MaxLevel = row.MaxLevel,
+                    RequiredBlockInterval = row.Interval,
+                    Rewards = rewards,
+                };
+                SetPolicyModel(policy);
             }
-            var policy = new PolicyModel
+            catch (InvalidOperationException)
             {
-                MinimumLevel = row.MinimumLevel,
-                MaxLevel = row.MaxLevel,
-                RequiredBlockInterval = row.Interval,
-                Rewards = rewards,
-            };
-            SetPolicyModel(policy);
+                Debug.LogError("No activated policy matches the criteria.");
+            }
         }
 
         public static void ClaimReward(System.Action onSuccess)


### PR DESCRIPTION
This pull request includes changes to enhance error handling in the `LoadPolicyInfo` method within the `PatrolReward` model. The most important changes are:

Error handling improvements:

* [`nekoyume/Assets/_Scripts/UI/Model/PatrolReward.cs`](diffhunk://#diff-6cc13713b2ef0880cb12c9056ebee94cb9939359e6f96901395b158a7ffedbe2R76-R77): Added a try-catch block to handle potential `InvalidOperationException` when no activated policy matches the criteria, logging an error message in such cases. [[1]](diffhunk://#diff-6cc13713b2ef0880cb12c9056ebee94cb9939359e6f96901395b158a7ffedbe2R76-R77) [[2]](diffhunk://#diff-6cc13713b2ef0880cb12c9056ebee94cb9939359e6f96901395b158a7ffedbe2R98-R102)