### PR TITLE
sort costume items in synthesis popup

### DIFF
--- a/nekoyume/Assets/Resources/SpriteAtlases/UI/Atlas_Item.spriteatlas
+++ b/nekoyume/Assets/Resources/SpriteAtlases/UI/Atlas_Item.spriteatlas
@@ -313,6 +313,7 @@ SpriteAtlas:
   - {fileID: 21300000, guid: 17133cf37cb5ff04ea262c59cdfd0479, type: 3}
   - {fileID: 21300000, guid: c849ccf3198834a1ead33cb8d2da30e3, type: 3}
   - {fileID: 21300000, guid: fe87dcf3164337743b441c0be76761b8, type: 3}
+  - {fileID: 21300000, guid: fad25df32d4969a409faf1dc692d44b5, type: 3}
   - {fileID: 21300000, guid: 4c3dd004ece024d4e93354e938be7211, type: 3}
   - {fileID: 21300000, guid: 399e82043f2bbd24992560c8d54c6cb0, type: 3}
   - {fileID: 21300000, guid: 11984304d66d5264892c51fcb6689247, type: 3}
@@ -347,6 +348,7 @@ SpriteAtlas:
   - {fileID: 21300000, guid: d28e529463cd3c9449b5e45aaf641530, type: 3}
   - {fileID: 21300000, guid: ad4114941543a944591b1ce976bc255e, type: 3}
   - {fileID: 21300000, guid: f4aa7694dfe714148878b647776ad9c8, type: 3}
+  - {fileID: 21300000, guid: 5968079428a5cfd42874db8338c68955, type: 3}
   - {fileID: 21300000, guid: 65d1b9942a0309d4f940e0cdc9274103, type: 3}
   - {fileID: 21300000, guid: 1a393a94c9ffe984a8165098e037c8b5, type: 3}
   - {fileID: 21300000, guid: e1c40c94c526a4cae91b4662d0938ba9, type: 3}
@@ -517,6 +519,7 @@ SpriteAtlas:
   - {fileID: 21300000, guid: ba0fb91777de3bd4fb4d0268b256cfe7, type: 3}
   - {fileID: 21300000, guid: ae083b17ccb784d458c0514045970a0b, type: 3}
   - {fileID: 21300000, guid: f6de9d17e9d8f994881cc6c2a49da379, type: 3}
+  - {fileID: 21300000, guid: 97a4ee1775f360242967af7eff6ca693, type: 3}
   - {fileID: 21300000, guid: 2c70e427d2bb2fc4d92ce14baf44d677, type: 3}
   - {fileID: 21300000, guid: e4a5e42773f5d4568bb6c37f7ca28d1e, type: 3}
   - {fileID: 21300000, guid: d44c47278aef440cea963dd4d2092b0c, type: 3}
@@ -663,6 +666,7 @@ SpriteAtlas:
   - {fileID: 21300000, guid: a304fb69801e1414083e1afb1224deb9, type: 3}
   - {fileID: 21300000, guid: 8b965c69bc712ce45a20564cc2c47495, type: 3}
   - {fileID: 21300000, guid: edcc6f6974a039b48b5cb06a73debe06, type: 3}
+  - {fileID: 21300000, guid: 7c1eaf699a979cb47aabbf5e2bbdf601, type: 3}
   - {fileID: 21300000, guid: c966827919ec548ee9659ba5991c9143, type: 3}
   - {fileID: 21300000, guid: 84142379f9d134cbf8b57d8ef8f7bfb1, type: 3}
   - {fileID: 21300000, guid: be271779330bf794380457da15ef3fbb, type: 3}
@@ -672,6 +676,7 @@ SpriteAtlas:
   - {fileID: 21300000, guid: 83fd08892fcf14d29bea8bfa1e59b3f1, type: 3}
   - {fileID: 21300000, guid: 046228890c8cd491c85081ad55989f21, type: 3}
   - {fileID: 21300000, guid: 38ffba897373312479556b57721a2762, type: 3}
+  - {fileID: 21300000, guid: ee3b5099e08e6604b9d695e3b8546dc4, type: 3}
   - {fileID: 21300000, guid: 1f66449989e1ea644b06ada7fc3e0a94, type: 3}
   - {fileID: 21300000, guid: fcccb799999275f478c50aaadda70d3b, type: 3}
   - {fileID: 21300000, guid: 962cc79965747eb4ebd33c331c5b30c3, type: 3}
@@ -817,6 +822,7 @@ SpriteAtlas:
   - {fileID: 21300000, guid: 0600a3db0a29b9a4a81df6db750b3acd, type: 3}
   - {fileID: 21300000, guid: f896d4dbe12628f479200767d74093d9, type: 3}
   - {fileID: 21300000, guid: a9cc71ebd896ffb478d5ababcd30767b, type: 3}
+  - {fileID: 21300000, guid: f6dd64eb1603e1b4980e85a5ef872a05, type: 3}
   - {fileID: 21300000, guid: 59e398eb15f28d04d893582a31456b68, type: 3}
   - {fileID: 21300000, guid: 9f86a2fb6655341caaf3eca597c09e41, type: 3}
   - {fileID: 21300000, guid: 741b44fbc5b584f03b876fedc1d03c16, type: 3}
@@ -851,6 +857,7 @@ SpriteAtlas:
   - {fileID: 21300000, guid: 5c804a6c4a18845af937c66cf6be4407, type: 3}
   - {fileID: 21300000, guid: 24490b6c71497ef4ea6d60cc1184d38a, type: 3}
   - {fileID: 21300000, guid: 4f55ab6c7f0f78b48ac479111dc39b72, type: 3}
+  - {fileID: 21300000, guid: 209beb6c95851a94baafbfff05902ed7, type: 3}
   - {fileID: 21300000, guid: 7dd69e6c69c0fc14c8dae82f82b26901, type: 3}
   - {fileID: 21300000, guid: 3577a37cc13ca2049b5ab14167bba308, type: 3}
   - {fileID: 21300000, guid: b9d7f57cf0e8c421ebbffb060205cd1c, type: 3}
@@ -1042,6 +1049,7 @@ SpriteAtlas:
   - {fileID: 21300000, guid: fab26f3f532d745d0b2b7d3a54d88986, type: 3}
   - {fileID: 21300000, guid: c21bd54f6836c4242a05c06162470bc7, type: 3}
   - {fileID: 21300000, guid: 6b7bf54f6a4f84479a69b3ebfd133ad2, type: 3}
+  - {fileID: 21300000, guid: e8e1174f21555bd4ba58a6edd9146d6e, type: 3}
   - {fileID: 21300000, guid: 7be4e94ff509d4b5295fc49ec4aef9b4, type: 3}
   - {fileID: 21300000, guid: a211f25fb181c504d8dcf53345a582b3, type: 3}
   - {fileID: 21300000, guid: ebf2595f8003f7d478a56a8fd03f8854, type: 3}
@@ -1055,6 +1063,7 @@ SpriteAtlas:
   - {fileID: 21300000, guid: cae2ca7f362fd4299a357346c00374f7, type: 3}
   - {fileID: 21300000, guid: f4e41d7fb5acbd84caeff16b2525d9ad, type: 3}
   - {fileID: 21300000, guid: 2168478f22fdf4618a0ff5aeb6dc8a4e, type: 3}
+  - {fileID: 21300000, guid: 51d9229f48f4c8c4bb081edfbdfa144a, type: 3}
   - {fileID: 21300000, guid: c156fd9f430684bf395c003575437b18, type: 3}
   - {fileID: 21300000, guid: ef6371afc4f007d418409fc717eadd3a, type: 3}
   - {fileID: 21300000, guid: 6014e1af0e5c0394c8a612971f9581e6, type: 3}
@@ -1341,6 +1350,7 @@ SpriteAtlas:
   - 10551001
   - 10250001
   - 201020
+  - 49900038
   - 302019
   - 10124000
   - 20161001
@@ -1375,6 +1385,7 @@ SpriteAtlas:
   - 700011
   - 40100038
   - 10650002
+  - 49900039
   - 10352002
   - 201035
   - 202005
@@ -1545,6 +1556,7 @@ SpriteAtlas:
   - 207005
   - 201007
   - 306003
+  - 49900035
   - 10620002
   - 10252000
   - 202003
@@ -1691,6 +1703,7 @@ SpriteAtlas:
   - 302030
   - 701802
   - 10112000
+  - 49900034
   - 10231001
   - 700504
   - 302015
@@ -1700,6 +1713,7 @@ SpriteAtlas:
   - 40500008
   - 40500006
   - 10230001
+  - 49900036
   - 40100037
   - 204024
   - 600305
@@ -1845,6 +1859,7 @@ SpriteAtlas:
   - 10351002
   - 306024
   - 40500018
+  - 49900031
   - 10243000
   - icon_mail_worldBoss
   - 204003
@@ -1879,6 +1894,7 @@ SpriteAtlas:
   - 40100006
   - 10122000
   - 10210000
+  - 49900032
   - 10452002
   - 10750007
   - 100000
@@ -2070,6 +2086,7 @@ SpriteAtlas:
   - 40400001
   - 306058
   - 700804
+  - 49900033
   - icon_Navigation_002
   - 700002
   - 10242000
@@ -2083,6 +2100,7 @@ SpriteAtlas:
   - 40200007
   - 306072
   - 10150001
+  - 49900037
   - 800104
   - 900113
   - 40300015

--- a/nekoyume/Assets/_Scripts/UI/Module/SynthesisInventory.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/SynthesisInventory.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Nekoyume.Action;
 using Nekoyume.Battle;
+using Nekoyume.Game;
 using Nekoyume.Helper;
 using Nekoyume.Model.EnumType;
 using Nekoyume.Model.Item;
@@ -224,7 +225,9 @@ namespace Nekoyume.UI.Module
                     UpdateEquipmentEquipped(items);
                     break;
                 case ItemType.Costume:
+                    var costumeSheet = TableSheets.Instance.CostumeStatSheet;
                     items = items
+                        .OrderBy(item => CPHelper.GetCP(item.ItemBase as Costume, costumeSheet))
                         .ToList();
                     UpdateCostumeEquipped(items);
                     break;


### PR DESCRIPTION
This pull request includes several changes to the `SpriteAtlas` in the `nekoyume/Assets/Resources/SpriteAtlases/UI/Atlas_Item.spriteatlas` file and a small update to the `SynthesisInventory` script. The most important changes are the addition of new sprite references and the ordering of costume items based on their CP value.

Changes to `SynthesisInventory`:

* Added `using Nekoyume.Game;` to the imports in `SynthesisInventory.cs`
* Updated the `GetModels` method to order costume items by their CP value using the `CostumeStatSheet` from `TableSheets.Instance`.