### PR TITLE
fix wait start button

### DIFF
--- a/nekoyume/Assets/_Scripts/Game/Scene/LoginScene.cs
+++ b/nekoyume/Assets/_Scripts/Game/Scene/LoginScene.cs
@@ -498,7 +498,7 @@ namespace Nekoyume.Game.Scene
 
             if (planetContext.HasPledgedAccount)
             {
-                await HasPledgedAccountProcess(planetContext, loginCallback).ToUniTask();
+                await HasPledgedAccountProcess(planetContext, loginCallback);
                 return;
             }
 
@@ -512,7 +512,7 @@ namespace Nekoyume.Game.Scene
                 {
                     email = outEmail;
                     agentAddrInPortal = outAddress;
-                }).ToUniTask();
+                });
             }
             else
             {
@@ -740,8 +740,7 @@ namespace Nekoyume.Game.Scene
 
                 // NOTE: Update CommandlineOptions.PrivateKey.
                 CommandLineOptions.PrivateKey = pk.ToHexWithZeroPaddings();
-                NcDebug.Log("[LoginScene] CoLogin()... CommandLineOptions.PrivateKey updated" +
-                    $" to ({pk.Address}).");
+                NcDebug.Log($"[LoginScene] CoLogin()... CommandLineOptions.PrivateKey updated to ({pk.Address}).");
 
                 // NOTE: Check PlanetContext.CanSkipPlanetSelection.
                 //       If true, then update planet account infos for IntroScreen.
@@ -781,7 +780,7 @@ namespace Nekoyume.Game.Scene
             }
         }
 
-        private IEnumerator HasPledgedAccountProcess(PlanetContext planetContext, Action<bool> loginCallback)
+        private async UniTask HasPledgedAccountProcess(PlanetContext planetContext, Action<bool> loginCallback)
         {
             var game = Game.instance;
 
@@ -792,22 +791,21 @@ namespace Nekoyume.Game.Scene
                 planetContext);
 
             NcDebug.Log("[LoginScene] CoLogin()... WaitUntil introScreen.OnClickStart.");
-            yield return introScreen.OnClickStart.AsObservable().First().StartAsCoroutine();
+            await introScreen.OnClickStart.AsObservable().First().ToUniTask();
             NcDebug.Log("[LoginScene] CoLogin()... WaitUntil introScreen.OnClickStart. Done.");
 
             // NOTE: Update CommandlineOptions.PrivateKey finally.
             CommandLineOptions.PrivateKey = pk.ToHexWithZeroPaddings();
-            NcDebug.Log("[LoginScene] CoLogin()... CommandLineOptions.PrivateKey finally updated" +
-                $" to ({pk.Address}).");
+            NcDebug.Log($"[LoginScene] CoLogin()... CommandLineOptions.PrivateKey finally updated to ({pk.Address}).");
 
-            yield return game.AgentInitialize(true, loginCallback);
+            await game.AgentInitialize(true, loginCallback).ToUniTask();
         }
 
         /// <summary>
         /// If has latest signed in social type, then return email and agent address in portal.
         /// </summary>
         /// <param name="outValueCallback">callback of (email, agentAddrInPortal)</param>
-        private IEnumerator HasLatestSignedInSocialTypeProcess(Action<string, Address?> outValueCallback)
+        private async UniTask HasLatestSignedInSocialTypeProcess(Action<string, Address?> outValueCallback)
         {
             var game = Game.instance;
             var dimmedLoadingScreen = Widget.Find<DimmedLoadingScreen>();
@@ -817,14 +815,14 @@ namespace Nekoyume.Game.Scene
             sw.Reset();
             sw.Start();
             var getTokensTask = game.PortalConnect.GetTokensSilentlyAsync();
-            yield return new WaitUntil(() => getTokensTask.IsCompleted);
+            await UniTask.WaitUntil(() => getTokensTask.IsCompleted);
             sw.Stop();
             NcDebug.Log($"[LoginScene] CoLogin()... Portal signed in in {sw.ElapsedMilliseconds}ms.(elapsed)");
             dimmedLoadingScreen.Close();
             outValueCallback?.Invoke(getTokensTask.Result.email, getTokensTask.Result.address);
 
             NcDebug.Log("[LoginScene] CoLogin()... WaitUntil introScreen.OnClickStart.");
-            yield return introScreen.OnClickStart.AsObservable().First().StartAsCoroutine();
+            await introScreen.OnClickStart.AsObservable().First().ToUniTask();
             NcDebug.Log("[LoginScene] CoLogin()... WaitUntil introScreen.OnClickStart. Done.");
         }
 

--- a/nekoyume/Assets/_Scripts/UI/Widget/Screen/DimmedLoadingScreen.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Screen/DimmedLoadingScreen.cs
@@ -15,7 +15,7 @@ namespace Nekoyume.UI
             WaitingForSocialAuthenticating,
             WaitingForPortalAuthenticating,
             WaitingForPlanetAccountInfoSyncing,
-            WaitingForConnectingToPlanet
+            WaitingForConnectingToPlanet,
         }
 
         public override WidgetType WidgetType => WidgetType.System;


### PR DESCRIPTION
This pull request includes several changes to the `LoginScene` class in `nekoyume/Assets/_Scripts/Game/Scene/LoginScene.cs` to improve the asynchronous processing and logging. The changes primarily involve converting coroutine methods to use `UniTask` for better performance and readability.

Conversion to `UniTask` for asynchronous processing:

* `private async UniTask CoLoginMobile(PlanetContext planetContext, Action<bool> loginCallback)`: Removed `.ToUniTask()` call for `HasPledgedAccountProcess` method.
* `private async UniTask HasPledgedAccountProcess(PlanetContext planetContext, Action<bool> loginCallback)`: Changed from `IEnumerator` to `UniTask` and updated the method calls within to use `await` instead of `yield return`. [[1]](diffhunk://#diff-29e19aadb2f6c1eedf49bfe71d5d2b7eb817e54692c30622a509b4f206cd83cdL784-R783) [[2]](diffhunk://#diff-29e19aadb2f6c1eedf49bfe71d5d2b7eb817e54692c30622a509b4f206cd83cdL795-R808)
* `private async UniTask HasLatestSignedInSocialTypeProcess(Action<string, Address?> outValueCallback)`: Changed from `IEnumerator` to `UniTask` and updated the method calls within to use `await` instead of `yield return`.

Logging improvements:

* Simplified logging statements by removing string concatenation and using string interpolation. [[1]](diffhunk://#diff-29e19aadb2f6c1eedf49bfe71d5d2b7eb817e54692c30622a509b4f206cd83cdL743-R743) [[2]](diffhunk://#diff-29e19aadb2f6c1eedf49bfe71d5d2b7eb817e54692c30622a509b4f206cd83cdL795-R808)

Minor change:

* Added a comma in the `ContentType` enum in `DimmedLoadingScreen.cs`.