### PR TITLE
Feature/monster collection issues

### DIFF
--- a/nekoyume/Assets/Resources/UI/Prefabs/UI_StakingPopup.prefab
+++ b/nekoyume/Assets/Resources/UI/Prefabs/UI_StakingPopup.prefab
@@ -6526,14 +6526,14 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Padding:
     m_Left: 5
-    m_Right: 5
+    m_Right: 20
     m_Top: 5
     m_Bottom: 5
   m_ChildAlignment: 0
   m_Spacing: 5
   m_ChildForceExpandWidth: 0
   m_ChildForceExpandHeight: 0
-  m_ChildControlWidth: 0
+  m_ChildControlWidth: 1
   m_ChildControlHeight: 0
   m_ChildScaleWidth: 0
   m_ChildScaleHeight: 0
@@ -26991,7 +26991,7 @@ PrefabInstance:
     - target: {fileID: 7094565395026477004, guid: 0e587670461d74fb6b45d6a1bf627459,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 500
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7094565395026477004, guid: 0e587670461d74fb6b45d6a1bf627459,
         type: 3}
@@ -29789,7 +29789,7 @@ PrefabInstance:
     - target: {fileID: 7094565395026477004, guid: 0e587670461d74fb6b45d6a1bf627459,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 500
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7094565395026477004, guid: 0e587670461d74fb6b45d6a1bf627459,
         type: 3}
@@ -30561,7 +30561,7 @@ PrefabInstance:
     - target: {fileID: 7094565395026477004, guid: 0e587670461d74fb6b45d6a1bf627459,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 500
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7094565395026477004, guid: 0e587670461d74fb6b45d6a1bf627459,
         type: 3}

--- a/nekoyume/Assets/_Scripts/UI/Widget/Popup/StakingPopup.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Popup/StakingPopup.cs
@@ -250,7 +250,7 @@ namespace Nekoyume.UI
                 States.Instance.GoldBalanceState.Gold.Currency).TargetFAV;
             NcDebug.Log($"[{nameof(StakingPopup)}] DelegationInfoByBlockHash: {userShared}, {allShared}, {delegatedNcg}");
             allShared /= 1000000000000000000;
-            userShared /= 1000000000000000000;
+            userShared /= 10000000000000000; // 백분율 표기를 위해 allShared보다 100배 작게 나눔
 
             var sharePower = allShared == 0 ? 0 : (double)userShared / (long)allShared;
             var sharePowerString = sharePower.ToString("F4");

--- a/nekoyume/Assets/_Scripts/UI/Widget/Popup/StakingPopup.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Popup/StakingPopup.cs
@@ -231,7 +231,7 @@ namespace Nekoyume.UI
 
             unbondBlockText.gameObject.SetActive(value > blockIndex);
             unbondBlockText.text =
-                L10nManager.Localize("UI_STAKING_UNBOND_BLOCK_TIP_FORMAT", value);
+                L10nManager.Localize("UI_STAKING_UNBOND_BLOCK_TIP_FORMAT", value.Value);
 
             _getUnbondClaimableHeight = value;
         }

--- a/nekoyume/Assets/_Scripts/UI/Widget/Popup/StakingPopup.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Popup/StakingPopup.cs
@@ -479,6 +479,16 @@ namespace Nekoyume.UI
             var nullableStakeState = States.Instance.StakeStateV2;
             if (nullableStakeState.HasValue && inputBigInt < States.Instance.StakedBalance.MajorUnit)
             {
+                var blockIndex = Game.Game.instance.Agent.BlockIndex;
+                if (_getUnbondClaimableHeight != -1 && blockIndex < _getUnbondClaimableHeight)
+                {
+                    OneLineSystem.Push(MailType.System,
+                        L10nManager.Localize("UI_STAKING_LOCK_BLOCK_TIP_FORMAT",
+                            _getUnbondClaimableHeight),
+                        NotificationCell.NotificationType.UnlockCondition);
+                    return;
+                }
+
                 confirmTitle = "UI_CAUTION";
                 confirmContent = "UI_WARNING_STAKING_REDUCE";
                 confirmIcon = IconAndButtonSystem.SystemType.Error;


### PR DESCRIPTION
This pull request includes several changes to the `StakingPopup.cs` file to improve the handling of staking and unbonding logic. The changes ensure more accurate calculations and add a new condition to prevent staking actions during a lock period.

### Key Changes:

Improvements to unbond block handling:

* [`private async UniTask CheckUnbondBlock()`](diffhunk://#diff-a70936507caa2abe09369bcc28e19289dbba0a92d9812a33bea641c5bacbdd48L234-R234): Updated the localization method to use `value.Value` instead of `value` for more precise unbond block text.

Enhancements to share power calculation:

* [`public async UniTask CheckSharePower()`](diffhunk://#diff-a70936507caa2abe09369bcc28e19289dbba0a92d9812a33bea641c5bacbdd48L253-R253): Adjusted the division factor for `userShared` to correctly reflect a percentage, making it 100 times smaller than `allShared`.

New condition for staking actions:

* [`private void OnClickSaveButton()`](diffhunk://#diff-a70936507caa2abe09369bcc28e19289dbba0a92d9812a33bea641c5bacbdd48R482-R491): Added a check to prevent staking actions if the current block index is less than `_getUnbondClaimableHeight`, and provided a localized notification to inform the user about the lock condition.