### PR TITLE
implement patrol reward mail

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Widget/Popup/MailPopup.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Popup/MailPopup.cs
@@ -964,7 +964,58 @@ namespace Nekoyume.UI
 
         public void Read(PatrolRewardMail patrolRewardMail)
         {
-            throw new NotImplementedException();
+            var game = Game.Game.instance;
+            patrolRewardMail.New = false;
+            LocalLayerModifier.RemoveNewMail(
+                game.States.CurrentAvatarState.address,
+                patrolRewardMail.id);
+            ReactiveAvatarState.UpdateMailBox(game.States.CurrentAvatarState.mailBox);
+            NcDebug.Log($"[MailRead] MailPopupRead PatrolRewardMail mailid : {patrolRewardMail.id}");
+
+            var rewards = new List<MailReward>();
+            if (patrolRewardMail.FungibleAssetValues is not null)
+            {
+                rewards.AddRange(
+                    patrolRewardMail.FungibleAssetValues.Select(fav =>
+                        new MailReward(fav, (int)fav.MajorUnit)));
+            }
+
+            if (patrolRewardMail.Items is not null)
+            {
+                var materialSheet = Game.Game.instance.TableSheets.MaterialItemSheet;
+                var itemSheet = Game.Game.instance.TableSheets.ItemSheet;
+                foreach (var (fungibleId, count) in
+                    patrolRewardMail.Items)
+                {
+                    var row = materialSheet.OrderedList!
+                        .FirstOrDefault(row => row.Id.Equals(fungibleId));
+                    if (row != null)
+                    {
+                        var material = ItemFactory.CreateMaterial(row);
+                        rewards.Add(new MailReward(material, count));
+                        continue;
+                    }
+
+                    row = materialSheet.OrderedList!.FirstOrDefault(row => row.ItemId.Equals(fungibleId));
+                    if (row != null)
+                    {
+                        var material = ItemFactory.CreateMaterial(row);
+                        rewards.Add(new MailReward(material, count));
+                        continue;
+                    }
+
+                    if (itemSheet.TryGetValue(fungibleId, out var itemSheetRow))
+                    {
+                        var item = ItemFactory.CreateItem(itemSheetRow, new ActionRenderHandler.LocalRandom(0));
+                        rewards.Add(new MailReward(item, 1));
+                        continue;
+                    }
+
+                    NcDebug.LogWarning($"Not found material sheet row. {fungibleId}");
+                }
+            }
+
+            Find<MailRewardScreen>().Show(rewards, "UI_IAP_PURCHASE_DELIVERY_COMPLETE_POPUP_TITLE");
         }
 
         [Obsolete]


### PR DESCRIPTION
This pull request includes significant changes to the `Read` method in the `MailPopup` class to handle `PatrolRewardMail` objects. The changes involve implementing the previously unimplemented method to properly process and display rewards from patrol reward mails.

Key changes include:

* [`nekoyume/Assets/_Scripts/UI/Widget/Popup/MailPopup.cs`](diffhunk://#diff-7250c9b4338dfeac7f3eb05262cba0280ceffb634d2707fc71aafd3fcde3b4cfL967-R1018): Implemented the `Read` method for `PatrolRewardMail` to mark the mail as read, update the mailbox state, and log the mail read action.
* Added logic to extract and convert fungible asset values and items from `PatrolRewardMail` into `MailReward` objects, including handling material and item sheets to create the appropriate reward objects.
* Updated the `MailRewardScreen` to display the collected rewards with a specific title.