### PR TITLE
fix mail reward in monster collection

### DIFF
--- a/nekoyume/Assets/_Scripts/Blockchain/ActionRenderHandler.cs
+++ b/nekoyume/Assets/_Scripts/Blockchain/ActionRenderHandler.cs
@@ -2692,7 +2692,7 @@ namespace Nekoyume.Blockchain
                 .ThenBy(pair => pair.Key.Id)
                 .Select(pair => ((ItemBase)pair.Key, pair.Value)).ToArray();
 
-            var mailRewards = new List<MailReward> { new(crystalReward, (int)crystalReward.MajorUnit) };
+            var mailRewards = new List<MailReward> { new(crystalReward, (long)crystalReward.MajorUnit), };
             mailRewards.AddRange(itemRewards.Select(pair => new MailReward(pair.Item1, pair.Item2)));
 
             Widget.Find<RewardScreen>().Show(mailRewards, "NOTIFICATION_CLAIM_GRINDING_REWARD");
@@ -2864,6 +2864,8 @@ namespace Nekoyume.Blockchain
             UniTask.RunOnThreadPool(async () =>
             {
                 var nullablePrevStakeState = States.Instance.StakeStateV2;
+                var prevStakeState = nullablePrevStakeState.GetValueOrDefault();
+
                 await UpdateStakeStateAsync(eval);
                 await UpdateAgentStateAsync(eval);
                 await UpdateCurrentAvatarStateAsync(eval);
@@ -2885,7 +2887,7 @@ namespace Nekoyume.Blockchain
                 var blockIndex = eval.BlockIndex;
                 if (nullablePrevStakeState.HasValue && nullablePrevStakeState.Value.ClaimableBlockIndex <= blockIndex)
                 {
-                    var stakeState = nullablePrevStakeState.Value;
+                    var stakeState = prevStakeState;
 
                     // Calculate rewards~
                     var stakeRegularFixedRewardSheet = States.Instance.StakeRegularFixedRewardSheet;
@@ -2921,7 +2923,7 @@ namespace Nekoyume.Blockchain
                     }
 
                     mailRewards.AddRange(rewardItems.Select(pair => new MailReward(pair.Key, pair.Value)));
-                    mailRewards.AddRange(favs.Select(fav => new MailReward(fav, (int)fav.MajorUnit)));
+                    mailRewards.AddRange(favs.Select(fav => new MailReward(fav, (long)fav.MajorUnit)));
 
                     Widget.Find<RewardScreen>().Show(mailRewards, "NOTIFICATION_CLAIM_MONSTER_COLLECTION_REWARD_COMPLETE");
                     Widget.Find<StakingPopup>().SetView();
@@ -2980,7 +2982,7 @@ namespace Nekoyume.Blockchain
                 }
 
                 mailRewards.AddRange(rewardItems.Select(pair => new MailReward(pair.Key, pair.Value)));
-                mailRewards.AddRange(favs.Select(fav => new MailReward(fav, (int)fav.MajorUnit)));
+                mailRewards.AddRange(favs.Select(fav => new MailReward(fav, (long)fav.MajorUnit)));
 
                 Widget.Find<RewardScreen>().Show(mailRewards, "NOTIFICATION_CLAIM_MONSTER_COLLECTION_REWARD_COMPLETE");
                 Widget.Find<StakingPopup>().SetView();

--- a/nekoyume/Assets/_Scripts/Blockchain/ActionRenderHandler.cs
+++ b/nekoyume/Assets/_Scripts/Blockchain/ActionRenderHandler.cs
@@ -2923,7 +2923,7 @@ namespace Nekoyume.Blockchain
                     }
 
                     mailRewards.AddRange(rewardItems.Select(pair => new MailReward(pair.Key, pair.Value)));
-                    mailRewards.AddRange(favs.Select(fav => new MailReward(fav, (long)fav.MajorUnit)));
+                    mailRewards.AddRange(favs.Select(fav => new MailReward(fav, fav.MajorUnit)));
 
                     Widget.Find<RewardScreen>().Show(mailRewards, "NOTIFICATION_CLAIM_MONSTER_COLLECTION_REWARD_COMPLETE");
                     Widget.Find<StakingPopup>().SetView();
@@ -2982,7 +2982,7 @@ namespace Nekoyume.Blockchain
                 }
 
                 mailRewards.AddRange(rewardItems.Select(pair => new MailReward(pair.Key, pair.Value)));
-                mailRewards.AddRange(favs.Select(fav => new MailReward(fav, (long)fav.MajorUnit)));
+                mailRewards.AddRange(favs.Select(fav => new MailReward(fav, fav.MajorUnit)));
 
                 Widget.Find<RewardScreen>().Show(mailRewards, "NOTIFICATION_CLAIM_MONSTER_COLLECTION_REWARD_COMPLETE");
                 Widget.Find<StakingPopup>().SetView();

--- a/nekoyume/Assets/_Scripts/UI/Module/MailReward.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/MailReward.cs
@@ -1,3 +1,4 @@
+using System.Numerics;
 using Libplanet.Types.Assets;
 using Nekoyume.Blockchain;
 using Nekoyume.Game;
@@ -11,18 +12,18 @@ namespace Nekoyume.UI.Module
     {
         public ItemBase ItemBase { get; }
         public FungibleAssetValue FavFungibleAssetValue { get; }
-        public long Count { get; }
+        public BigInteger Count { get; }
 
         public bool IsPurchased { get; }
 
-        public MailReward(ItemBase itemBase, long count, bool isPurchased = false)
+        public MailReward(ItemBase itemBase, BigInteger count, bool isPurchased = false)
         {
             ItemBase = itemBase;
             Count = count;
             IsPurchased = isPurchased;
         }
 
-        public MailReward(FungibleAssetValue fav, long count, bool isPurchased = false)
+        public MailReward(FungibleAssetValue fav, BigInteger count, bool isPurchased = false)
         {
             FavFungibleAssetValue = fav;
             Count = count;

--- a/nekoyume/Assets/_Scripts/UI/Module/MailReward.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/MailReward.cs
@@ -11,18 +11,18 @@ namespace Nekoyume.UI.Module
     {
         public ItemBase ItemBase { get; }
         public FungibleAssetValue FavFungibleAssetValue { get; }
-        public int Count { get; }
+        public long Count { get; }
 
         public bool IsPurchased { get; }
 
-        public MailReward(ItemBase itemBase, int count, bool isPurchased = false)
+        public MailReward(ItemBase itemBase, long count, bool isPurchased = false)
         {
             ItemBase = itemBase;
             Count = count;
             IsPurchased = isPurchased;
         }
 
-        public MailReward(FungibleAssetValue fav, int count, bool isPurchased = false)
+        public MailReward(FungibleAssetValue fav, long count, bool isPurchased = false)
         {
             FavFungibleAssetValue = fav;
             Count = count;


### PR DESCRIPTION
This pull request includes several changes to the `nekoyume/Assets/_Scripts/Blockchain/ActionRenderHandler.cs` and `nekoyume/Assets/_Scripts/UI/Module/MailReward.cs` files aimed at improving type consistency and handling nullable values more effectively. The most important changes include modifying the `MailReward` class to use `long` instead of `int` for the `Count` property and updating related code to accommodate this change.

Type consistency improvements:

* [`nekoyume/Assets/_Scripts/Blockchain/ActionRenderHandler.cs`](diffhunk://#diff-0f08e40ec628cdd4aa728e0b0b4cff7bf842254e3ba68679d2883d0569ac14a2L2695-R2695): Changed the type of `Count` from `int` to `long` in various methods to ensure consistency and prevent potential overflows. [[1]](diffhunk://#diff-0f08e40ec628cdd4aa728e0b0b4cff7bf842254e3ba68679d2883d0569ac14a2L2695-R2695) [[2]](diffhunk://#diff-0f08e40ec628cdd4aa728e0b0b4cff7bf842254e3ba68679d2883d0569ac14a2L2924-R2926) [[3]](diffhunk://#diff-0f08e40ec628cdd4aa728e0b0b4cff7bf842254e3ba68679d2883d0569ac14a2L2983-R2985)

Nullable value handling:

* [`nekoyume/Assets/_Scripts/Blockchain/ActionRenderHandler.cs`](diffhunk://#diff-0f08e40ec628cdd4aa728e0b0b4cff7bf842254e3ba68679d2883d0569ac14a2R2867-R2868): Added a `GetValueOrDefault` call to handle nullable `StakeStateV2` values more effectively in the `ResponseStake` method. [[1]](diffhunk://#diff-0f08e40ec628cdd4aa728e0b0b4cff7bf842254e3ba68679d2883d0569ac14a2R2867-R2868) [[2]](diffhunk://#diff-0f08e40ec628cdd4aa728e0b0b4cff7bf842254e3ba68679d2883d0569ac14a2L2888-R2890)

Class property update:

* [`nekoyume/Assets/_Scripts/UI/Module/MailReward.cs`](diffhunk://#diff-5f6118dc3f166ba33373a7ef66ae254386fd0d2a0b8f48c06b3cf1d1067a267aL14-R25): Updated the `MailReward` class to use `long` instead of `int` for the `Count` property to support larger values.