### PR TITLE
fix staking share local key

### DIFF
--- a/nekoyume/Assets/StreamingAssets/Localization/common.csv
+++ b/nekoyume/Assets/StreamingAssets/Localization/common.csv
@@ -2056,7 +2056,7 @@ UI_STAKING_UNBOND_BLOCK_TIP_FORMAT,The refunded NCG will be available for claim 
 UI_UNBOND,Unbond,언본드,Desvincular,アンボンド,Desvincular,ยกเลิกการผูก,Unbond,Разблокировать,解绑,解綁,Unbond,Unbond
 UI_CLAIM_UNBONDED_REWARD_SUCCESS,The refunded NCG has been successfully claimed.,환불된 NCG가 성공적으로 청구되었습니다.,O NCG reembolsado foi reivindicado com sucesso.,返金されたNCGが正常に請求されました。,El NCG reembolsado ha sido reclamado con éxito.,NCG ที่คืนได้รับการเรียกร้องเรียบร้อยแล้ว.,Refund NCG telah berhasil diklaim.,Возвращенные NCG успешно запросили.,退款的NCG已成功索取。,退款的NCG已成功索取。,Ang ibinalik na NCG ay matagumpay na na-claim.,NCG hoàn trả đã được yêu cầu thành công.
 UI_CLAIM_NCG_REWARD_SUCCESS,The NCG reward has been successfully claimed.,NCG 보상이 성공적으로 청구되었습니다.,A recompensa NCG foi reivindicada com sucesso.,NCG報酬が正常に請求されました。,La recompensa NCG ha sido reclamada con éxito.,รางวัล NCG ได้รับการเรียกร้องเรียบร้อยแล้ว.,Hadiah NCG telah berhasil diklaim.,Награда NCG успешно запросили.,NCG奖励已成功索取。,NCG獎勵已成功索取。,Ang gantimpala ng NCG ay matagumpay na na-claim.,Phần thưởng NCG đã được yêu cầu thành công.
-UI_STAKING_SHARE_POWER_FORMAT,STAKING Share {0}%,STAKING {0}%,STAKING Compartilhar {0}%,STAKING {0}%,STAKING Compartir {0}%,STAKING แบ่งปัน {0}%,STAKING Bagikan {0}%,STAKING Доля {0}%,STAKING 分享 {0}%,STAKING 分享 {0}%,STAKING Bahagi {0}%,STAKING Chia sẻ {0}%
+UI_STAKING_SHARE_POWER_FORMAT,STAKING Share {0}%,STAKING Share {0}%,STAKING Compartilhar {0}%,STAKING Share {0}%,STAKING Compartir {0}%,STAKING แบ่งปัน {0}%,STAKING Bagikan {0}%,STAKING Доля {0}%,STAKING 分享 {0}%,STAKING 分享 {0}%,STAKING Bahagi {0}%,STAKING Chia sẻ {0}%
 UI_KEY_BACKUP,Key backup,키 백업,,,,,,,,,,
 UI_RUNE_LEVEL_BONUS,Rune Level Bonus,룬 레벨 보너스,,,,,,,,,,
 UI_RUNE_STAT_REWARD,Rune Stat Reward,룬 스텟 보상,,,,,,,,,,


### PR DESCRIPTION
This pull request includes a minor localization update to the `common.csv` file. The change corrects the translation for the `UI_STAKING_SHARE_POWER_FORMAT` key in the Korean language.

Localization update:

* [`nekoyume/Assets/StreamingAssets/Localization/common.csv`](diffhunk://#diff-98d1566ff25314daa2b2a12f07f1c2f68f26b3466b72020b9be70b7059bd1748L2059-R2059): Corrected the translation for `UI_STAKING_SHARE_POWER_FORMAT` from "STAKING {0}%" to "STAKING Share {0}%".