### PR TITLE
fix staking level

### DIFF
--- a/nekoyume/Assets/_Scripts/Blockchain/ActionRenderHandler.cs
+++ b/nekoyume/Assets/_Scripts/Blockchain/ActionRenderHandler.cs
@@ -2865,6 +2865,8 @@ namespace Nekoyume.Blockchain
             {
                 var nullablePrevStakeState = States.Instance.StakeStateV2;
                 var prevStakeState = nullablePrevStakeState.GetValueOrDefault();
+                var stakingLevel = States.Instance.StakingLevel;
+                var stakedNcg = States.Instance.StakedBalance;
 
                 await UpdateStakeStateAsync(eval);
                 await UpdateAgentStateAsync(eval);
@@ -2892,8 +2894,6 @@ namespace Nekoyume.Blockchain
                     // Calculate rewards~
                     var stakeRegularFixedRewardSheet = States.Instance.StakeRegularFixedRewardSheet;
                     var stakeRegularRewardSheet = States.Instance.StakeRegularRewardSheet;
-                    var stakingLevel = States.Instance.StakingLevel;
-                    var stakedNcg = States.Instance.StakedBalance;
                     var itemSheet = TableSheets.Instance.ItemSheet;
                     // The first reward is given at the claimable block index.
                     var rewardSteps = stakeState.ClaimableBlockIndex == eval.BlockIndex


### PR DESCRIPTION
This pull request includes changes to the `ResponseStake` method in the `Blockchain/ActionRenderHandler.cs` file to improve the handling of staking data. The most important changes involve moving the retrieval of `stakingLevel` and `stakedNcg` variables to an earlier point in the method.

Changes to `ResponseStake` method:

* Moved the retrieval of `stakingLevel` and `stakedNcg` variables to before the `UpdateStakeStateAsync` and `UpdateAgentStateAsync` method calls.
* Removed the redundant retrieval of `stakingLevel` and `stakedNcg` variables later in the method.