### PR TITLE
add shop sort condition

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Module/Inventory.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/Inventory.cs
@@ -1109,6 +1109,7 @@ namespace Nekoyume.UI.Module
                 data = data
                     .OrderByDescending(x => x.ItemBase is ITradableItem)
                     .ThenByDescending(x => x.ItemBase.Grade)
+                    .ThenBy(x => x.ItemBase.ItemSubType)
                     .ThenByDescending(x => CPHelper.GetCP(x.ItemBase as Equipment))
                     .ToList();
             }
@@ -1135,6 +1136,7 @@ namespace Nekoyume.UI.Module
                 data = data
                     .OrderByDescending(x => x.ItemBase is ITradableItem)
                     .ThenByDescending(x => x.ItemBase.Grade)
+                    .ThenBy(x => x.ItemBase.ItemSubType)
                     .ThenByDescending(x => CPHelper.GetCP(x.ItemBase as Costume, costumeSheet))
                     .ToList();
             }


### PR DESCRIPTION
This pull request includes changes to the sorting logic in the `SortInventoryInShop` method in the `Inventory.cs` file. The modifications ensure that items are now additionally sorted by their `ItemSubType`.

Improvements to inventory sorting:

* [`nekoyume/Assets/_Scripts/UI/Module/Inventory.cs`](diffhunk://#diff-7ccd62049e45fec5dc5fd35188609a0043e467fe8f376d0841cc184e06d390cfR1112): Added sorting by `ItemBase.ItemSubType` to the `SortInventoryInShop` method for both general and costume items. [[1]](diffhunk://#diff-7ccd62049e45fec5dc5fd35188609a0043e467fe8f376d0841cc184e06d390cfR1112) [[2]](diffhunk://#diff-7ccd62049e45fec5dc5fd35188609a0043e467fe8f376d0841cc184e06d390cfR1139)