### PR TITLE
fix unity slider nan value setting bug

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Module/Slider/SweepSlider.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/Slider/SweepSlider.cs
@@ -1,5 +1,6 @@
 using System;
 using TMPro;
+using Unity.Mathematics;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -96,6 +97,10 @@ namespace Nekoyume
             var each = max / multiplier;
             var interval = sliderMaxWidth / each;
             var width = Mathf.Max(sliderMinWidth, interval * sliderMaxValue);
+            if (math.isnan(width))
+            {
+                width = sliderMinWidth;
+            }
             _rectTransform.sizeDelta = new Vector2(width, _rectTransform.sizeDelta.y);
         }
 


### PR DESCRIPTION
슬라이더 최대 숫자가 0으로 세팅되는경우 숫자가 깨져서 슬라이더컴포넌트를 더 이상 사용하지 못하는 문제 수정.