### PR TITLE
fix staking popup for unbond button

### DIFF
--- a/nekoyume/Assets/Resources/UI/Prefabs/UI_StakingPopup.prefab
+++ b/nekoyume/Assets/Resources/UI/Prefabs/UI_StakingPopup.prefab
@@ -12586,7 +12586,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_IgnoreLayout: 0
-  m_MinWidth: 90
+  m_MinWidth: 160
   m_MinHeight: -1
   m_PreferredWidth: -1
   m_PreferredHeight: -1
@@ -13589,7 +13589,7 @@ RectTransform:
   m_AnchorMin: {x: 1, y: 0.5}
   m_AnchorMax: {x: 1, y: 0.5}
   m_AnchoredPosition: {x: -57, y: -5.1821}
-  m_SizeDelta: {x: 248.5751, y: 51.6359}
+  m_SizeDelta: {x: 473.404, y: 51.6359}
   m_Pivot: {x: 1, y: 0.5}
 --- !u!114 &6452005920902409544
 MonoBehaviour:
@@ -13610,7 +13610,7 @@ MonoBehaviour:
     m_Bottom: 0
   m_ChildAlignment: 2
   m_Spacing: 8
-  m_ChildForceExpandWidth: 1
+  m_ChildForceExpandWidth: 0
   m_ChildForceExpandHeight: 1
   m_ChildControlWidth: 1
   m_ChildControlHeight: 1
@@ -23671,7 +23671,7 @@ PrefabInstance:
     - target: {fileID: 1498349374040689898, guid: 45eb7886920094eeca085daf783730b5,
         type: 3}
       propertyPath: m_fontSize
-      value: 13.45
+      value: 18
       objectReference: {fileID: 0}
     - target: {fileID: 1498349374040689898, guid: 45eb7886920094eeca085daf783730b5,
         type: 3}
@@ -23752,7 +23752,7 @@ PrefabInstance:
     - target: {fileID: 5476809316646564014, guid: 45eb7886920094eeca085daf783730b5,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 80
+      value: 120
       objectReference: {fileID: 0}
     - target: {fileID: 5476809316646564014, guid: 45eb7886920094eeca085daf783730b5,
         type: 3}
@@ -23797,7 +23797,7 @@ PrefabInstance:
     - target: {fileID: 5476809316646564014, guid: 45eb7886920094eeca085daf783730b5,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 178
+      value: 345.404
       objectReference: {fileID: 0}
     - target: {fileID: 5476809316646564014, guid: 45eb7886920094eeca085daf783730b5,
         type: 3}
@@ -23907,7 +23907,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_IgnoreLayout: 0
-  m_MinWidth: 80
+  m_MinWidth: 120
   m_MinHeight: -1
   m_PreferredWidth: -1
   m_PreferredHeight: -1
@@ -26711,7 +26711,7 @@ PrefabInstance:
     - target: {fileID: 1498349374040689898, guid: 45eb7886920094eeca085daf783730b5,
         type: 3}
       propertyPath: m_fontSize
-      value: 12.85
+      value: 18
       objectReference: {fileID: 0}
     - target: {fileID: 1498349374040689898, guid: 45eb7886920094eeca085daf783730b5,
         type: 3}
@@ -26807,7 +26807,7 @@ PrefabInstance:
     - target: {fileID: 5476809316646564014, guid: 45eb7886920094eeca085daf783730b5,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 80
+      value: 120
       objectReference: {fileID: 0}
     - target: {fileID: 5476809316646564014, guid: 45eb7886920094eeca085daf783730b5,
         type: 3}
@@ -26852,7 +26852,7 @@ PrefabInstance:
     - target: {fileID: 5476809316646564014, guid: 45eb7886920094eeca085daf783730b5,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 266
+      value: 473.404
       objectReference: {fileID: 0}
     - target: {fileID: 5476809316646564014, guid: 45eb7886920094eeca085daf783730b5,
         type: 3}
@@ -26984,7 +26984,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_IgnoreLayout: 0
-  m_MinWidth: 80
+  m_MinWidth: 120
   m_MinHeight: -1
   m_PreferredWidth: -1
   m_PreferredHeight: -1
@@ -28918,7 +28918,7 @@ PrefabInstance:
     - target: {fileID: 1498349374040689898, guid: 45eb7886920094eeca085daf783730b5,
         type: 3}
       propertyPath: m_fontSize
-      value: 16
+      value: 18
       objectReference: {fileID: 0}
     - target: {fileID: 1498349374040689898, guid: 45eb7886920094eeca085daf783730b5,
         type: 3}
@@ -28999,7 +28999,7 @@ PrefabInstance:
     - target: {fileID: 5476809316646564014, guid: 45eb7886920094eeca085daf783730b5,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 100
+      value: 120
       objectReference: {fileID: 0}
     - target: {fileID: 5476809316646564014, guid: 45eb7886920094eeca085daf783730b5,
         type: 3}
@@ -29044,7 +29044,7 @@ PrefabInstance:
     - target: {fileID: 5476809316646564014, guid: 45eb7886920094eeca085daf783730b5,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 316
+      value: 544
       objectReference: {fileID: 0}
     - target: {fileID: 5476809316646564014, guid: 45eb7886920094eeca085daf783730b5,
         type: 3}
@@ -29160,7 +29160,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_IgnoreLayout: 0
-  m_MinWidth: 60
+  m_MinWidth: 120
   m_MinHeight: -1
   m_PreferredWidth: -1
   m_PreferredHeight: -1

--- a/nekoyume/Assets/Resources/UI/Prefabs/UI_StakingPopup.prefab
+++ b/nekoyume/Assets/Resources/UI/Prefabs/UI_StakingPopup.prefab
@@ -104,10 +104,10 @@ MonoBehaviour:
   defaultUIParent: {fileID: 1311743436452887614}
   stakingNcgInputField: {fileID: 2076805992604655026}
   unbondBlockText: {fileID: 3717971297094907357}
+  unbondButton: {fileID: 3543773056911489820}
   ncgEditButton: {fileID: 2951633833249351142}
   editCancelButton: {fileID: 1144331684316804122}
   editSaveButton: {fileID: 2508074699277713052}
-  unbondButton: {fileID: 3543773056911489820}
   buffBenefitsViews:
   - {fileID: 3823265623034877818}
   - {fileID: 8445137412660312501}
@@ -470,7 +470,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -4.43, y: -5.88}
+  m_AnchoredPosition: {x: -4.4299927, y: -5.88}
   m_SizeDelta: {x: 26, y: 26}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &5614078444077708507
@@ -3348,9 +3348,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 7741461049349654985}
-  - {fileID: 5502583187181224521}
-  - {fileID: 5308008981479148836}
-  - {fileID: 130567709964835609}
+  - {fileID: 6534262848753482017}
   m_Father: {fileID: 3587857532151392750}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -10955,7 +10953,6 @@ RectTransform:
   m_Children:
   - {fileID: 7980064921332391128}
   - {fileID: 8584531984938221165}
-  - {fileID: 7260392130162473965}
   m_Father: {fileID: 1106206927664342278}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -12402,6 +12399,7 @@ GameObject:
   - component: {fileID: 7033953087654154781}
   - component: {fileID: 3467176480340285917}
   - component: {fileID: 8610658427175866693}
+  - component: {fileID: 4933544298327634808}
   m_Layer: 5
   m_Name: StakingStartButton
   m_TagString: Untagged
@@ -12425,14 +12423,14 @@ RectTransform:
   - {fileID: 1252833231685044018}
   - {fileID: 2422329960069692769}
   - {fileID: 9173366815705877028}
-  m_Father: {fileID: 5092414723803118987}
-  m_RootOrder: 1
+  m_Father: {fileID: 6534262848753482017}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 1, y: 0.5}
-  m_AnchorMax: {x: 1, y: 0.5}
-  m_AnchoredPosition: {x: -156.5, y: 0}
-  m_SizeDelta: {x: 180, y: 60}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 1, y: 1}
 --- !u!222 &8412422668037418989
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -12575,6 +12573,26 @@ Animator:
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorStateOnDisable: 0
   m_WriteDefaultValuesOnDisable: 0
+--- !u!114 &4933544298327634808
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5422364491087802129}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreLayout: 0
+  m_MinWidth: 90
+  m_MinHeight: -1
+  m_PreferredWidth: -1
+  m_PreferredHeight: -1
+  m_FlexibleWidth: -1
+  m_FlexibleHeight: -1
+  m_LayoutPriority: 1
 --- !u!1 &5514073130726928471
 GameObject:
   m_ObjectHideFlags: 0
@@ -13532,6 +13550,73 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   iconImage: {fileID: 1829580183685242851}
   countText: {fileID: 4046234338795328108}
+--- !u!1 &5723728510526173880
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6534262848753482017}
+  - component: {fileID: 6452005920902409544}
+  m_Layer: 5
+  m_Name: CancelOrSaveButtonParent
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6534262848753482017
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5723728510526173880}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5502583187181224521}
+  - {fileID: 5308008981479148836}
+  - {fileID: 7260392130162473965}
+  - {fileID: 130567709964835609}
+  m_Father: {fileID: 5092414723803118987}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 0.5}
+  m_AnchorMax: {x: 1, y: 0.5}
+  m_AnchoredPosition: {x: -57, y: -5.1821}
+  m_SizeDelta: {x: 248.5751, y: 51.6359}
+  m_Pivot: {x: 1, y: 0.5}
+--- !u!114 &6452005920902409544
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5723728510526173880}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 30649d3a9faa99c48a7b1166b86bf2a0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Padding:
+    m_Left: 0
+    m_Right: 0
+    m_Top: 0
+    m_Bottom: 0
+  m_ChildAlignment: 2
+  m_Spacing: 8
+  m_ChildForceExpandWidth: 1
+  m_ChildForceExpandHeight: 1
+  m_ChildControlWidth: 1
+  m_ChildControlHeight: 1
+  m_ChildScaleWidth: 0
+  m_ChildScaleHeight: 0
+  m_ReverseArrangement: 0
 --- !u!1 &5734906265938109342
 GameObject:
   m_ObjectHideFlags: 0
@@ -23545,7 +23630,7 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 5092414723803118987}
+    m_TransformParent: {fileID: 6534262848753482017}
     m_Modifications:
     - target: {fileID: 333440615415594262, guid: 45eb7886920094eeca085daf783730b5,
         type: 3}
@@ -23586,7 +23671,7 @@ PrefabInstance:
     - target: {fileID: 1498349374040689898, guid: 45eb7886920094eeca085daf783730b5,
         type: 3}
       propertyPath: m_fontSize
-      value: 18
+      value: 13.45
       objectReference: {fileID: 0}
     - target: {fileID: 1498349374040689898, guid: 45eb7886920094eeca085daf783730b5,
         type: 3}
@@ -23632,47 +23717,47 @@ PrefabInstance:
     - target: {fileID: 5476809316646564014, guid: 45eb7886920094eeca085daf783730b5,
         type: 3}
       propertyPath: m_Pivot.x
-      value: 0.5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5476809316646564014, guid: 45eb7886920094eeca085daf783730b5,
         type: 3}
       propertyPath: m_Pivot.y
-      value: 0.5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5476809316646564014, guid: 45eb7886920094eeca085daf783730b5,
         type: 3}
       propertyPath: m_RootOrder
-      value: 2
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5476809316646564014, guid: 45eb7886920094eeca085daf783730b5,
         type: 3}
       propertyPath: m_AnchorMax.x
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5476809316646564014, guid: 45eb7886920094eeca085daf783730b5,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5476809316646564014, guid: 45eb7886920094eeca085daf783730b5,
-        type: 3}
-      propertyPath: m_AnchorMin.x
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5476809316646564014, guid: 45eb7886920094eeca085daf783730b5,
         type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5476809316646564014, guid: 45eb7886920094eeca085daf783730b5,
+        type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0.5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5476809316646564014, guid: 45eb7886920094eeca085daf783730b5,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 143
+      value: 80
       objectReference: {fileID: 0}
     - target: {fileID: 5476809316646564014, guid: 45eb7886920094eeca085daf783730b5,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: 46
+      value: 51.6359
       objectReference: {fileID: 0}
     - target: {fileID: 5476809316646564014, guid: 45eb7886920094eeca085daf783730b5,
         type: 3}
@@ -23712,12 +23797,12 @@ PrefabInstance:
     - target: {fileID: 5476809316646564014, guid: 45eb7886920094eeca085daf783730b5,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: -143
+      value: 178
       objectReference: {fileID: 0}
     - target: {fileID: 5476809316646564014, guid: 45eb7886920094eeca085daf783730b5,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 5476809316646564014, guid: 45eb7886920094eeca085daf783730b5,
         type: 3}
@@ -23803,13 +23888,39 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &2037259766476754388 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1868312093538365534, guid: 45eb7886920094eeca085daf783730b5,
+    type: 3}
+  m_PrefabInstance: {fileID: 407680245397814666}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &8175096402351228182
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2037259766476754388}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreLayout: 0
+  m_MinWidth: 80
+  m_MinHeight: -1
+  m_PreferredWidth: -1
+  m_PreferredHeight: -1
+  m_FlexibleWidth: -1
+  m_FlexibleHeight: -1
+  m_LayoutPriority: 1
 --- !u!114 &2951633833249351142 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 3269068318677096556, guid: 45eb7886920094eeca085daf783730b5,
     type: 3}
   m_PrefabInstance: {fileID: 407680245397814666}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
+  m_GameObject: {fileID: 2037259766476754388}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
@@ -26554,7 +26665,7 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 8424543187190836175}
+    m_TransformParent: {fileID: 6534262848753482017}
     m_Modifications:
     - target: {fileID: 333440615415594262, guid: 45eb7886920094eeca085daf783730b5,
         type: 3}
@@ -26600,7 +26711,7 @@ PrefabInstance:
     - target: {fileID: 1498349374040689898, guid: 45eb7886920094eeca085daf783730b5,
         type: 3}
       propertyPath: m_fontSize
-      value: 16.8
+      value: 12.85
       objectReference: {fileID: 0}
     - target: {fileID: 1498349374040689898, guid: 45eb7886920094eeca085daf783730b5,
         type: 3}
@@ -26630,7 +26741,7 @@ PrefabInstance:
     - target: {fileID: 1868312093538365534, guid: 45eb7886920094eeca085daf783730b5,
         type: 3}
       propertyPath: m_IsActive
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3746725619262994438, guid: 45eb7886920094eeca085daf783730b5,
         type: 3}
@@ -26661,12 +26772,12 @@ PrefabInstance:
     - target: {fileID: 5476809316646564014, guid: 45eb7886920094eeca085daf783730b5,
         type: 3}
       propertyPath: m_Pivot.x
-      value: 0.5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5476809316646564014, guid: 45eb7886920094eeca085daf783730b5,
         type: 3}
       propertyPath: m_Pivot.y
-      value: 0.5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5476809316646564014, guid: 45eb7886920094eeca085daf783730b5,
         type: 3}
@@ -26696,12 +26807,12 @@ PrefabInstance:
     - target: {fileID: 5476809316646564014, guid: 45eb7886920094eeca085daf783730b5,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 104.666664
+      value: 80
       objectReference: {fileID: 0}
     - target: {fileID: 5476809316646564014, guid: 45eb7886920094eeca085daf783730b5,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: 46
+      value: 51.6359
       objectReference: {fileID: 0}
     - target: {fileID: 5476809316646564014, guid: 45eb7886920094eeca085daf783730b5,
         type: 3}
@@ -26741,12 +26852,12 @@ PrefabInstance:
     - target: {fileID: 5476809316646564014, guid: 45eb7886920094eeca085daf783730b5,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 277.66666
+      value: 266
       objectReference: {fileID: 0}
     - target: {fileID: 5476809316646564014, guid: 45eb7886920094eeca085daf783730b5,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -23
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5476809316646564014, guid: 45eb7886920094eeca085daf783730b5,
         type: 3}
@@ -26848,12 +26959,38 @@ MonoBehaviour:
     type: 3}
   m_PrefabInstance: {fileID: 2937350959424375619}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
+  m_GameObject: {fileID: 3543773056911489821}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: dd36e9ecf7775ae45bc40a208c43fc92, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &3543773056911489821 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1868312093538365534, guid: 45eb7886920094eeca085daf783730b5,
+    type: 3}
+  m_PrefabInstance: {fileID: 2937350959424375619}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &2252019226264894867
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3543773056911489821}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreLayout: 0
+  m_MinWidth: 80
+  m_MinHeight: -1
+  m_PreferredWidth: -1
+  m_PreferredHeight: -1
+  m_FlexibleWidth: -1
+  m_FlexibleHeight: -1
+  m_LayoutPriority: 1
 --- !u!224 &3633733426451048621 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 1922487757674341358, guid: 45eb7886920094eeca085daf783730b5,
@@ -28740,7 +28877,7 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 5092414723803118987}
+    m_TransformParent: {fileID: 6534262848753482017}
     m_Modifications:
     - target: {fileID: 333440615415594262, guid: 45eb7886920094eeca085daf783730b5,
         type: 3}
@@ -28781,7 +28918,7 @@ PrefabInstance:
     - target: {fileID: 1498349374040689898, guid: 45eb7886920094eeca085daf783730b5,
         type: 3}
       propertyPath: m_fontSize
-      value: 18
+      value: 16
       objectReference: {fileID: 0}
     - target: {fileID: 1498349374040689898, guid: 45eb7886920094eeca085daf783730b5,
         type: 3}
@@ -28827,12 +28964,12 @@ PrefabInstance:
     - target: {fileID: 5476809316646564014, guid: 45eb7886920094eeca085daf783730b5,
         type: 3}
       propertyPath: m_Pivot.x
-      value: 0.5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5476809316646564014, guid: 45eb7886920094eeca085daf783730b5,
         type: 3}
       propertyPath: m_Pivot.y
-      value: 0.5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5476809316646564014, guid: 45eb7886920094eeca085daf783730b5,
         type: 3}
@@ -28842,32 +28979,32 @@ PrefabInstance:
     - target: {fileID: 5476809316646564014, guid: 45eb7886920094eeca085daf783730b5,
         type: 3}
       propertyPath: m_AnchorMax.x
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5476809316646564014, guid: 45eb7886920094eeca085daf783730b5,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5476809316646564014, guid: 45eb7886920094eeca085daf783730b5,
-        type: 3}
-      propertyPath: m_AnchorMin.x
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5476809316646564014, guid: 45eb7886920094eeca085daf783730b5,
         type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5476809316646564014, guid: 45eb7886920094eeca085daf783730b5,
+        type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0.5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5476809316646564014, guid: 45eb7886920094eeca085daf783730b5,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 143
+      value: 100
       objectReference: {fileID: 0}
     - target: {fileID: 5476809316646564014, guid: 45eb7886920094eeca085daf783730b5,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: 46
+      value: 51.6359
       objectReference: {fileID: 0}
     - target: {fileID: 5476809316646564014, guid: 45eb7886920094eeca085daf783730b5,
         type: 3}
@@ -28907,7 +29044,7 @@ PrefabInstance:
     - target: {fileID: 5476809316646564014, guid: 45eb7886920094eeca085daf783730b5,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: -294
+      value: 316
       objectReference: {fileID: 0}
     - target: {fileID: 5476809316646564014, guid: 45eb7886920094eeca085daf783730b5,
         type: 3}
@@ -29004,13 +29141,39 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &6062905435239226345 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1868312093538365534, guid: 45eb7886920094eeca085daf783730b5,
+    type: 3}
+  m_PrefabInstance: {fileID: 5606514989596912567}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &3887715263078872730
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6062905435239226345}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreLayout: 0
+  m_MinWidth: 60
+  m_MinHeight: -1
+  m_PreferredWidth: -1
+  m_PreferredHeight: -1
+  m_FlexibleWidth: -1
+  m_FlexibleHeight: -1
+  m_LayoutPriority: 1
 --- !u!114 &6958140577983034331 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 3269068318677096556, guid: 45eb7886920094eeca085daf783730b5,
     type: 3}
   m_PrefabInstance: {fileID: 5606514989596912567}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
+  m_GameObject: {fileID: 6062905435239226345}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}

--- a/nekoyume/Assets/_Scripts/UI/Widget/Popup/StakingPopup.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Popup/StakingPopup.cs
@@ -247,6 +247,14 @@ namespace Nekoyume.UI
             var agentAddress = States.Instance.AgentState.address;
             var blockTipStateRootHash = Game.Game.instance.Agent.BlockTipStateRootHash;
             var rawValue = await agent.GetDelegationInfoByStateRootHashAsync(blockTipStateRootHash, agentAddress);
+            // rawValue: [userShared, allShared, delegateGuildGold]
+            if (rawValue.Count < 3)
+            {
+                sharePowerText.text = L10nManager.Localize("UI_STAKING_SHARE_POWER_FORMAT", 0);
+                sharePowerText.gameObject.SetActive(true);
+                return;
+            }
+
             var userShared = rawValue[0].ToBigInteger();
             var allShared = rawValue[1].ToBigInteger();
             var delegateGuildGold = rawValue[2].ToFungibleAssetValue();
@@ -288,6 +296,13 @@ namespace Nekoyume.UI
             var agentAddress = States.Instance.AgentState.address;
             var blockTipStateRootHash = Game.Game.instance.Agent.BlockTipStateRootHash;
             var claimableRewards = await agent.GetClaimableRewardsByStateRootHashAsync(blockTipStateRootHash, agentAddress);
+            if (claimableRewards.Count < 0)
+            {
+                rewardNcgText.text = "+0";
+                rewardNcgText.gameObject.SetActive(true);
+                ncgLoadingIndicator.SetActive(false);
+                return;
+            }
             var fungibleAssetValue = new FungibleAssetValue(claimableRewards[0]);
             var claimableQuantity = fungibleAssetValue.RawValue;
 

--- a/nekoyume/Assets/_Scripts/UI/Widget/Popup/StakingPopup.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Popup/StakingPopup.cs
@@ -49,12 +49,12 @@ namespace Nekoyume.UI
         [SerializeField] private GameObject defaultUIParent;
         [SerializeField] private TMP_InputField stakingNcgInputField;
         [SerializeField] private TMP_Text unbondBlockText;
+        [SerializeField] private ConditionalButton unbondButton;
 
         [Header("Editing")]
         [SerializeField] private Button ncgEditButton;
         [SerializeField] private Button editCancelButton;
         [SerializeField] private ConditionalButton editSaveButton;
-        [SerializeField] private ConditionalButton unbondButton;
 
         [Header("Center")]
         [SerializeField] private StakingBuffBenefitsView[] buffBenefitsViews;
@@ -394,8 +394,6 @@ namespace Nekoyume.UI
             currentBenefitsTabButton.SetToggledOff();
             levelBenefitsTabButton.OnClick.OnNext(levelBenefitsTabButton);
             levelBenefitsTabButton.SetToggledOn();
-
-            CheckUnbondBlock().Forget();
         }
 
         private void OnClickMigrateButton()
@@ -672,6 +670,8 @@ namespace Nekoyume.UI
             editingUIParent.SetActive(isEdit);
             defaultUIParent.SetActive(!isEdit);
             stakingNcgInputField.interactable = isEdit;
+
+            CheckUnbondBlock().Forget();
         }
     }
 }


### PR DESCRIPTION
This pull request includes multiple changes to the `UI_StakingPopup.prefab` file in the `nekoyume/Assets/Resources/UI/Prefabs` directory. The changes involve adjustments to various UI elements, including modifications to `RectTransform`, `MonoBehaviour`, and `PrefabInstance` components. Below are the most important changes grouped by theme:

### UI Element Adjustments

* Added a new `unbondButton` element to the `MonoBehaviour` section.
* Adjusted the `m_AnchoredPosition` of a `RectTransform` element for more precise positioning.

### Hierarchy and Parent-Child Relationships

* Updated the `m_Father` property of a `RectTransform` element to change its parent, and adjusted its `m_RootOrder`.
* Modified the `m_TransformParent` of multiple `PrefabInstance` elements to change their parent in the hierarchy. [[1]](diffhunk://#diff-90bcb6d299d520d5abcc79a6aab36ec75e062ec9e2925fb7b06ad4d1309124ceL23548-R23633) [[2]](diffhunk://#diff-90bcb6d299d520d5abcc79a6aab36ec75e062ec9e2925fb7b06ad4d1309124ceL26557-R26668)

### Component Additions and Removals

* Added a new `MonoBehaviour` component with specific layout properties.
* Added a new `GameObject` element named `CancelOrSaveButtonParent` with associated `RectTransform` and `MonoBehaviour` components.

These changes are aimed at refining the UI structure and layout of the staking popup, ensuring better organization and visual consistency.