### PR TITLE
Feature/resources exception handling

### DIFF
--- a/nekoyume/Assets/_Scripts/Game/Character/Actor.cs
+++ b/nekoyume/Assets/_Scripts/Game/Character/Actor.cs
@@ -401,8 +401,8 @@ namespace Nekoyume.Game.Character
             var source = GetAnimatorHitPointBoxCollider();
             if (!source)
             {
-                throw new NullReferenceException(
-                    $"{nameof(GetAnimatorHitPointBoxCollider)}() returns null.");
+                NcDebug.LogError("GetAnimatorHitPointBoxCollider() returns null.");
+                return;
             }
 
             var scale = Animator.Target.transform.localScale;

--- a/nekoyume/Assets/_Scripts/Game/Character/Actor.cs
+++ b/nekoyume/Assets/_Scripts/Game/Character/Actor.cs
@@ -615,6 +615,11 @@ namespace Nekoyume.Game.Character
 
             var buff = info.Buff;
             var effect = BattleRenderer.Instance.BuffController.Get<BuffVFX>(target.gameObject, buff, tableSheets);
+            if (effect is null)
+            {
+                NcDebug.LogError($"[ProcessBuff] [Buff] {info.Buff.BuffInfo.Id}");
+                return;
+            }
             effect.Target = target;
             effect.Buff = buff;
 

--- a/nekoyume/Assets/_Scripts/Game/Character/ArenaCharacter.cs
+++ b/nekoyume/Assets/_Scripts/Game/Character/ArenaCharacter.cs
@@ -379,6 +379,10 @@ namespace Nekoyume.Game.Character
 
             var buff = info.Buff;
             var effect = BattleRenderer.Instance.BuffController.Get<BuffVFX>(target.gameObject, buff, TableSheets.Instance);
+            if (effect is null)
+            {
+                return;
+            }
             effect.Target = target;
             effect.Buff = buff;
 

--- a/nekoyume/Assets/_Scripts/Game/Character/Player.cs
+++ b/nekoyume/Assets/_Scripts/Game/Character/Player.cs
@@ -212,8 +212,15 @@ namespace Nekoyume.Game.Character
         protected override void UpdateHitPoint()
         {
             var scale = Vector3.one;
-            var center = GetAnimatorHitPointBoxCollider().center;
-            var size = GetAnimatorHitPointBoxCollider().size;
+            var source = GetAnimatorHitPointBoxCollider();
+            if (!source)
+            {
+                NcDebug.LogError("GetAnimatorHitPointBoxCollider() returns null.");
+                return;
+            }
+
+            var center = source.center;
+            var size = source.size;
             HitPointBoxCollider.center =
                 new Vector3(center.x * scale.x, center.y * scale.y, center.z * scale.z);
             HitPointBoxCollider.size =

--- a/nekoyume/Assets/_Scripts/Game/Character/PrologueCharacter.cs
+++ b/nekoyume/Assets/_Scripts/Game/Character/PrologueCharacter.cs
@@ -226,6 +226,10 @@ namespace Nekoyume.Game.Character
             Animator.CastAttack();
             AudioController.instance.PlaySfx(AudioController.SfxCode.FenrirGrowlCastingAttack);
             var effect = BattleRenderer.Instance.BuffController.Get<BuffVFX>(_target.gameObject, buff, TableSheets.Instance);
+            if (effect == null)
+            {
+                yield break;
+            }
             effect.Play();
             yield return new WaitForSeconds(Game.DefaultSkillDelay);
         }

--- a/nekoyume/Assets/_Scripts/Game/Character/RaidCharacter.cs
+++ b/nekoyume/Assets/_Scripts/Game/Character/RaidCharacter.cs
@@ -767,6 +767,10 @@ namespace Nekoyume.Game.Character
 
             var buff = info.Buff;
             var effect = BattleRenderer.Instance.BuffController.Get<BuffVFX>(target.gameObject, buff, TableSheets.Instance);
+            if (effect == null)
+            {
+                return;
+            }
             effect.Target = target;
             effect.Buff = buff;
 

--- a/nekoyume/Assets/_Scripts/Game/Character/StageMonster.cs
+++ b/nekoyume/Assets/_Scripts/Game/Character/StageMonster.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using Cysharp.Threading.Tasks;
+using JetBrains.Annotations;
 using UnityEngine;
 
 namespace Nekoyume.Game.Character
@@ -125,7 +126,7 @@ namespace Nekoyume.Game.Character
 
         protected override BoxCollider GetAnimatorHitPointBoxCollider()
         {
-            return SpineController.BoxCollider;
+            return SpineController == null ? null : SpineController.BoxCollider;
         }
 
 #region AttackPoint & HitPoint

--- a/nekoyume/Assets/_Scripts/Game/Controller/AudioController.cs
+++ b/nekoyume/Assets/_Scripts/Game/Controller/AudioController.cs
@@ -26,7 +26,7 @@ namespace Nekoyume.Game.Controller
             public AudioInfo(AudioSource source)
             {
                 this.source = source;
-                volume = source.volume;
+                volume = source ? source.volume : 0f;
             }
         }
 
@@ -281,7 +281,7 @@ namespace Nekoyume.Game.Controller
             {
                 foreach (var audioInfo in pair.Value)
                 {
-                    if (audioInfo.source.isPlaying)
+                    if (audioInfo.source == null || audioInfo.source.isPlaying)
                     {
                         continue;
                     }
@@ -434,6 +434,11 @@ namespace Nekoyume.Game.Controller
             }
 
             var audioInfo = PopFromSfxPool(audioName);
+            if (audioInfo.source == null)
+            {
+                NcDebug.LogError($"Failed to load AudioSource `{audioName}`.");
+                return;
+            }
             Push(_sfxPlaylist, audioName, audioInfo);
             audioInfo.source.volume = audioInfo.volume * volume * Settings.Instance.volumeSfx;
             audioInfo.source.Play();

--- a/nekoyume/Assets/_Scripts/Game/Prologue.cs
+++ b/nekoyume/Assets/_Scripts/Game/Prologue.cs
@@ -234,6 +234,10 @@ namespace Nekoyume.Game
             castingEffect.Play();
             yield return new WaitForSeconds(Game.DefaultSkillDelay);
             var effect = BattleRenderer.Instance.BuffController.Get<BuffVFX>(_player.gameObject, buff, TableSheets.Instance);
+            if (effect == null)
+            {
+                yield break;
+            }
             effect.Play();
             var position = _player.transform.TransformPoint(0f, 1.7f, 0f);
             var force = new Vector3(-0.1f, 0.5f);

--- a/nekoyume/Assets/_Scripts/Game/Util/ObjectPool.cs
+++ b/nekoyume/Assets/_Scripts/Game/Util/ObjectPool.cs
@@ -190,7 +190,8 @@ namespace Nekoyume.Game.Util
 
                 if (!go)
                 {
-                    throw new NullReferenceException($"Set `{objName}` first in ObjectPool.");
+                    NcDebug.LogError($"Set `{objName}` first in ObjectPool.");
+                    return null;
                 }
 
                 go.transform.position = position;

--- a/nekoyume/Assets/_Scripts/Game/VFX/Skill/BuffController.cs
+++ b/nekoyume/Assets/_Scripts/Game/VFX/Skill/BuffController.cs
@@ -3,6 +3,7 @@ using Nekoyume.Helper;
 using Nekoyume.Model.Buff;
 using System.Collections;
 using Cysharp.Threading.Tasks;
+using JetBrains.Annotations;
 using Nekoyume.Model.Skill;
 using UnityEngine;
 
@@ -33,6 +34,7 @@ namespace Nekoyume.Game.VFX.Skill
             });
         }
 
+        [CanBeNull]
         public T Get<T>(GameObject target, Buff buff, TableSheets tableSheets) where T : BuffVFX
         {
             if (target == null)
@@ -43,13 +45,10 @@ namespace Nekoyume.Game.VFX.Skill
             var position = target.transform.position + BuffHelper.GetBuffPosition(buff.BuffInfo.Id, tableSheets);
 
             var resourceName = BuffHelper.GetBuffVFXPrefab(buff, tableSheets).name;
-            var go = _pool.Get(resourceName, false, position);
-            if (go == null)
-            {
-                go = _pool.Get(resourceName, true, position);
-            }
+            var go = _pool.Get(resourceName, false, position) ??
+                _pool.Get(resourceName, true, position);
 
-            return GetEffect<T>(go);
+            return go == null ? null : GetEffect<T>(go);
         }
 
         public BuffCastingVFX Get(Vector3 position, Buff buff, TableSheets tableSheets)

--- a/nekoyume/Assets/_Scripts/Game/VFX/Skill/SkillController.cs
+++ b/nekoyume/Assets/_Scripts/Game/VFX/Skill/SkillController.cs
@@ -1,4 +1,5 @@
 using Cysharp.Threading.Tasks;
+using JetBrains.Annotations;
 using Nekoyume.Game.Battle;
 using Nekoyume.Game.Util;
 using Nekoyume.Model.BattleStatus.Arena;
@@ -34,6 +35,7 @@ namespace Nekoyume.Game.VFX.Skill
             });
         }
 
+        [CanBeNull]
         public T Get<T>(Character.Character target, Model.BattleStatus.Skill.SkillInfo skillInfo)
             where T : SkillVFX
         {
@@ -75,7 +77,7 @@ namespace Nekoyume.Game.VFX.Skill
             var go = _pool.Get(skillName, false, position) ??
                 _pool.Get(skillName, true, position);
 
-            return GetEffect<T>(go, target);
+            return go == null ? null : GetEffect<T>(go, target);
         }
 
         public T Get<T>(Character.Character target, ArenaSkill.ArenaSkillInfo skillInfo)
@@ -153,7 +155,7 @@ namespace Nekoyume.Game.VFX.Skill
                 throw new NotFoundComponentException<T>(go.name);
             }
 
-            if (!(target is null))
+            if (target is not null)
             {
                 effect.target = target;
             }


### PR DESCRIPTION
This pull request includes several changes aimed at improving error handling and null checking within the game's codebase. The primary focus is on preventing null reference exceptions and ensuring that appropriate error messages are logged when issues arise.

### Error Handling Improvements:

* [`nekoyume/Assets/_Scripts/Game/Character/Actor.cs`](diffhunk://#diff-a5b5e126b5a93158e9d12f5971c2286750a9b68e327d9bc355fb54f2b2b876cfL404-R405): Replaced exceptions with error logs and added null checks in `UpdateHitPoint` and `ProcessBuff` methods to prevent crashes when certain objects are not found. [[1]](diffhunk://#diff-a5b5e126b5a93158e9d12f5971c2286750a9b68e327d9bc355fb54f2b2b876cfL404-R405) [[2]](diffhunk://#diff-a5b5e126b5a93158e9d12f5971c2286750a9b68e327d9bc355fb54f2b2b876cfR618-R622)
* [`nekoyume/Assets/_Scripts/Game/Character/Player.cs`](diffhunk://#diff-d0f8b3abd57ce4efc1ac412054c556074a4894fb078a41aa14aa96d4cb776e86L215-R223): Added null checks and error logging in `UpdateHitPoint` to handle cases where `GetAnimatorHitPointBoxCollider` returns null.
* [`nekoyume/Assets/_Scripts/Game/Controller/AudioController.cs`](diffhunk://#diff-79854855ca147724acb54ba24570e48d3842a78e6391503613ec218be4268d5eL29-R29): Enhanced null checking and error logging in `AudioInfo` constructor, `CheckPlaying`, and `PlaySfx` methods to handle missing audio sources gracefully. [[1]](diffhunk://#diff-79854855ca147724acb54ba24570e48d3842a78e6391503613ec218be4268d5eL29-R29) [[2]](diffhunk://#diff-79854855ca147724acb54ba24570e48d3842a78e6391503613ec218be4268d5eL284-R284) [[3]](diffhunk://#diff-79854855ca147724acb54ba24570e48d3842a78e6391503613ec218be4268d5eR437-R441)
* [`nekoyume/Assets/_Scripts/Game/Util/ObjectPool.cs`](diffhunk://#diff-12557ac3ecd4d802a6a7f70a7a827f7abb067f7cfffe1c570189778ee7faed06L193-R194): Replaced exception with an error log and null return when an object is not set in the pool.

### Null Checking Enhancements:

* `nekoyume/Assets/_Scripts/Game/Character/PrologueCharacter.cs` and `nekoyume/Assets/_Scripts/Game/Prologue.cs`: Added null checks before using effects to prevent potential crashes. [[1]](diffhunk://#diff-4b0c7c76f7006f9750659fb29b7c6c6f3a2fec1f2418c68badd783596d19cf1fR229-R232) [[2]](diffhunk://#diff-c861477f5db3b976c79c00d1623f30101fa6a951ea09880be76a0dc7cf4fa0adR237-R240)
* `nekoyume/Assets/_Scripts/Game/VFX/Skill/BuffController.cs` and `nekoyume/Assets/_Scripts/Game/VFX/Skill/SkillController.cs`: Introduced `[CanBeNull]` annotation and improved null checking in `Get` methods to handle cases where effects are not found. [[1]](diffhunk://#diff-780d0b9b0f4db6ae874bf9b0de0da1cd3f5e8fbb34da488af6ba70a4d7fcf94cR6) [[2]](diffhunk://#diff-780d0b9b0f4db6ae874bf9b0de0da1cd3f5e8fbb34da488af6ba70a4d7fcf94cR37) [[3]](diffhunk://#diff-780d0b9b0f4db6ae874bf9b0de0da1cd3f5e8fbb34da488af6ba70a4d7fcf94cL46-R51) [[4]](diffhunk://#diff-bbd095d1e8af70cdbbafa78920d972c0d557f883577dca552b0ed02db3001a73R2) [[5]](diffhunk://#diff-bbd095d1e8af70cdbbafa78920d972c0d557f883577dca552b0ed02db3001a73R38) [[6]](diffhunk://#diff-bbd095d1e8af70cdbbafa78920d972c0d557f883577dca552b0ed02db3001a73L78-R80) [[7]](diffhunk://#diff-bbd095d1e8af70cdbbafa78920d972c0d557f883577dca552b0ed02db3001a73L156-R158)

### Minor Code Improvements:

* [`nekoyume/Assets/_Scripts/Game/Character/StageMonster.cs`](diffhunk://#diff-d24fbb0d3c7f57fb46219da85e10180b72d1f4c74a495b53b6aa59ba8357e4e4L128-R129): Added a null check in `GetAnimatorHitPointBoxCollider` to handle cases where `SpineController` is null.
* Added missing `JetBrains.Annotations` imports in several files to support `[CanBeNull]` annotations. [[1]](diffhunk://#diff-d24fbb0d3c7f57fb46219da85e10180b72d1f4c74a495b53b6aa59ba8357e4e4R6) [[2]](diffhunk://#diff-780d0b9b0f4db6ae874bf9b0de0da1cd3f5e8fbb34da488af6ba70a4d7fcf94cR6) [[3]](diffhunk://#diff-bbd095d1e8af70cdbbafa78920d972c0d557f883577dca552b0ed02db3001a73R2)