### PR TITLE
Feature/synthesis polishing

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Model/SynthesizeModel.cs
+++ b/nekoyume/Assets/_Scripts/UI/Model/SynthesizeModel.cs
@@ -1,3 +1,4 @@
+using System;
 using Nekoyume.Model.EnumType;
 using Nekoyume.Model.Item;
 
@@ -16,6 +17,26 @@ namespace Nekoyume.UI.Model
             ItemSubType = itemSubType;
             InventoryItemCount = inventoryItemCount;
             RequiredItemCount = requiredItemCount;
+        }
+
+        public static bool operator ==(SynthesizeModel obj1, SynthesizeModel obj2)
+        {
+            if (obj1 is null)
+            {
+                return obj2 is null;
+            }
+
+            if (obj2 is null)
+            {
+                return false;
+            }
+
+            return obj1.Grade == obj2.Grade && obj1.ItemSubType == obj2.ItemSubType;
+        }
+
+        public static bool operator!= (SynthesizeModel obj1, SynthesizeModel obj2)
+        {
+            return !(obj1 == obj2);
         }
     }
 }

--- a/nekoyume/Assets/_Scripts/UI/Module/SynthesisInventory.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/SynthesisInventory.cs
@@ -28,7 +28,6 @@ namespace Nekoyume.UI.Module
         private SynthesizeModel? _selectedModel;
         private Action<InventoryItem>? _onClickItem;
 
-        private readonly List<IDisposable> _disposables = new();
         private readonly List<InventoryItem> _items = new();
 
         private List<InventoryItem>? _cachedInventoryItems;
@@ -57,21 +56,15 @@ namespace Nekoyume.UI.Module
                 .AddTo(gameObject);
         }
 
-        private void OnEnable()
+        public void UpdateInventory()
         {
-            ReactiveAvatarState.Inventory
-                .Subscribe(UpdateInventory)
-                .AddTo(_disposables);
-        }
-
-        private void OnDisable()
-        {
-            _disposables.DisposeAllAndClear();
+            ClearSelectedItems();
+            var inventory = Game.Game.instance.States.CurrentAvatarState.inventory;
+            UpdateInventory(inventory);
         }
 
         public void Show(SynthesizeModel requiredItem)
         {
-            ClearSelectedItems();
             _selectedModel = requiredItem;
             _cachedInventoryItems = GetModels(requiredItem);
             scroll.UpdateData(_cachedInventoryItems, true);

--- a/nekoyume/Assets/_Scripts/UI/Module/SynthesisModule.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/SynthesisModule.cs
@@ -140,6 +140,9 @@ namespace Nekoyume.UI.Module
 
             numberSynthesisText.text = L10nManager.Localize("UI_NUMBER_SYNTHESIS", 0);
             successRateText.text = L10nManager.Localize("UI_SYNTHESIZE_SUCCESS_RATE", 0);
+
+            var registrationPopup = Widget.Find<SynthesisRegistrationPopup>();
+            registrationPopup.Clear();
         }
 
         private void SetSynthesisButtonState(bool possibleSynthesis)

--- a/nekoyume/Assets/_Scripts/UI/Widget/Popup/SynthesisRegistrationPopup.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Popup/SynthesisRegistrationPopup.cs
@@ -210,6 +210,8 @@ namespace Nekoyume.UI
             if (isSameModel)
             {
                 base.Show(ignoreShowAnimation);
+                _registerMaterials = registerAction;
+                synthesisInventory.Show(model);
                 return;
             }
 
@@ -222,6 +224,14 @@ namespace Nekoyume.UI
             SetHeaderText(model);
 
             synthesisInventory.Show(model);
+            synthesisInventory.UpdateInventory();
+        }
+
+        public void Clear()
+        {
+            _registerMaterials = null;
+            _synthesizeModel = null;
+            synthesisInventory.UpdateInventory();
         }
 
         private void SetAutoSelectButtonText(SynthesizeModel model)
@@ -276,7 +286,11 @@ namespace Nekoyume.UI
                 return;
             }
 
-            equipmentTooltip.Show(item, string.Empty, false, null);
+            if (equipmentTooltip.gameObject.activeSelf)
+            {
+                    equipmentTooltip.Show(item, string.Empty, false, null);
+            }
+
             equipmentTooltip.OnEnterButtonArea(true);
         }
 

--- a/nekoyume/Assets/_Scripts/UI/Widget/Popup/SynthesisRegistrationPopup.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Popup/SynthesisRegistrationPopup.cs
@@ -41,6 +41,8 @@ namespace Nekoyume.UI
 
         private SynthesizeModel? _synthesizeModel;
 
+        public bool HasModel(SynthesizeModel model) => _synthesizeModel != null && _synthesizeModel == model;
+
 #region MonoBehaviour
 
         protected override void Awake()
@@ -204,6 +206,13 @@ namespace Nekoyume.UI
             Action<IList<InventoryItem>, SynthesizeModel> registerAction,
             bool ignoreShowAnimation = false)
         {
+            var isSameModel = _synthesizeModel == model;
+            if (isSameModel)
+            {
+                base.Show(ignoreShowAnimation);
+                return;
+            }
+
             _synthesizeModel = model;
             _registerMaterials = registerAction;
 

--- a/nekoyume/Assets/_Scripts/UI/Widget/Workshop/Synthesis.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Workshop/Synthesis.cs
@@ -171,9 +171,10 @@ namespace Nekoyume.UI
                 return;
             }
 
-            System.Action showRegistrationPopup = () => Find<SynthesisRegistrationPopup>().Show(model, RegisterItems);
+            var registrationPopup = Find<SynthesisRegistrationPopup>();
+            System.Action showRegistrationPopup = () => registrationPopup.Show(model, RegisterItems);
 
-            if (synthesisModule.PossibleSynthesis)
+            if (synthesisModule.PossibleSynthesis && !registrationPopup.HasModel(model))
             {
                 Find<TwoButtonSystem>().Show(
                     L10nManager.Localize("UI_SYNTHESIZE_MATERIAL_CHANGE"),


### PR DESCRIPTION
This pull request includes several changes to improve the synthesis functionality and UI interactions in the `nekoyume` project. The most important changes include adding equality operators to the `SynthesizeModel` class, refactoring the `SynthesisInventory` class, and enhancing the `SynthesisRegistrationPopup` class to handle model updates and clear actions more effectively.

### Improvements to `SynthesizeModel` class:

* Added `==` and `!=` operators to the `SynthesizeModel` class to allow for easy comparison of instances based on `Grade` and `ItemSubType`.

### Refactoring of `SynthesisInventory` class:

* Removed the `_disposables` list and refactored the `OnEnable` and `OnDisable` methods to update the inventory directly. [[1]](diffhunk://#diff-462098c691ea40c6442d42988f8d63b74d197055abf5001a565e4fb763c57c00L31) [[2]](diffhunk://#diff-462098c691ea40c6442d42988f8d63b74d197055abf5001a565e4fb763c57c00L60-L74)

### Enhancements to `SynthesisRegistrationPopup` class:

* Added a `HasModel` method to check if the popup currently holds a specific model.
* Modified the `Show` method to check for the same model and update the inventory if necessary. [[1]](diffhunk://#diff-aa822f6d803f75e83df6837a50d705afd559674562d3c57bbdf8bb58a2cb1ee7R209-R217) [[2]](diffhunk://#diff-aa822f6d803f75e83df6837a50d705afd559674562d3c57bbdf8bb58a2cb1ee7R227-R234)
* Added a `Clear` method to reset the registration state and update the inventory.
* Improved the `ShowItemTooltip` method to handle active tooltips more gracefully.

### Other UI updates:

* Updated the `Synthesis` class to use the new `HasModel` method in the `OnClickGradeItem` method to prevent redundant popup displays.
* Added a call to clear the `SynthesisRegistrationPopup` in the `ClearScrollData` method of the `SynthesisModule` class.