### PR TITLE
remove arena info caching

### DIFF
--- a/nekoyume/Assets/_Scripts/State/RxProps.Arena.cs
+++ b/nekoyume/Assets/_Scripts/State/RxProps.Arena.cs
@@ -50,7 +50,6 @@ namespace Nekoyume.State
         public static IReadOnlyReactiveProperty<List<SeasonResponse>> ArenaSeasonResponses => _arenaSeasonResponses;
         #endregion RxPropObservable
 
-        private static long _arenaInfoTupleUpdatedBlockIndex;
         private static int _currentSeasonId = -1;
         private static int _lastBattleLogId;
 
@@ -181,8 +180,6 @@ namespace Nekoyume.State
             // 로비화면에서 티켓정보를 보여주기 위해 인포 초기화
             await ArenaInfo.UpdateAsync(_agent.BlockTipStateRootHash);
 
-            _arenaInfoTupleUpdatedBlockIndex = 0;
-
             // 중복 구독을 방지
             if (!_hasSubscribedArenaTicketProgress)
             {
@@ -268,13 +265,6 @@ namespace Nekoyume.State
             {
                 return null;
             }
-
-            if (_arenaInfoTupleUpdatedBlockIndex == _agent.BlockIndex)
-            {
-                return arenaInfo;
-            }
-
-            _arenaInfoTupleUpdatedBlockIndex = _agent.BlockIndex;
 
             try
             {

--- a/nekoyume/Assets/_Scripts/State/RxProps.Arena.cs
+++ b/nekoyume/Assets/_Scripts/State/RxProps.Arena.cs
@@ -250,6 +250,7 @@ namespace Nekoyume.State
                             Widget.Find<LobbyMenu>().Close();
                             Widget.Find<ArenaJoin>().ShowAsync().Forget();
                             Widget.Find<OneButtonSystem>().Show(L10nManager.Localize("UI_ARENA_ROUND_CHAGED"), L10nManager.Localize("UI_OK"), null);
+                            ArenaInfo.UpdateAsync(Game.Game.instance.Agent.BlockTipStateRootHash);
                         });
                     MainCanvas.instance.InitWidgetInMain();
                 }

--- a/nekoyume/Assets/_Scripts/UI/Widget/ArenaBoard.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/ArenaBoard.cs
@@ -100,15 +100,7 @@ namespace Nekoyume.UI
             {
                 AudioController.PlayClick();
 
-                //캐싱한 시즌정보들에 시즌이없는경우 다음구간 시즌리스트를 가져와야해서 비동기 실행으로 변경.
-                if (RxProps.GetSeasonResponseByBlockIndex(Game.Game.instance.Agent.BlockIndex) == null)
-                {
-                    Find<ArenaJoin>().ShowAsync().Forget();
-                }
-                else
-                {
-                    Find<ArenaJoin>().Show();
-                }
+                Find<ArenaJoin>().ShowAsync().Forget();
                 Close();
             }).AddTo(gameObject);
 


### PR DESCRIPTION
- 아레나인포 캐싱제거(블록단위로 캐싱데이터를 먼저 확인하도록되어있어서 동일블록내의 갱신처리가 안되는문제가있었음)
- 아레나 join창 진입시 메달정보 캐싱되지않도록 수정
- 인터벌종료시 아레나인포 강제 갱신되도록 수정