### PR TITLE
Feature/auto select grind20

### DIFF
--- a/nekoyume/Assets/AddressableAssets/UI/Module/GrindModule.prefab
+++ b/nekoyume/Assets/AddressableAssets/UI/Module/GrindModule.prefab
@@ -5321,7 +5321,7 @@ RectTransform:
   - {fileID: 432175986752076012}
   - {fileID: 583005504372585191}
   m_Father: {fileID: 2752236434775052170}
-  m_RootOrder: 4
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -16062,7 +16062,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2752236434775052170}
-  m_RootOrder: 7
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -21208,7 +21208,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2752236434775052170}
-  m_RootOrder: 6
+  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -21245,7 +21245,7 @@ RectTransform:
   m_Children:
   - {fileID: 2112723451167118444}
   m_Father: {fileID: 2752236434775052170}
-  m_RootOrder: 3
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
@@ -21451,6 +21451,7 @@ RectTransform:
   - {fileID: 148424149703485761}
   - {fileID: 7523634157966004335}
   - {fileID: 1961020151052205462}
+  - {fileID: 5489864739948933406}
   - {fileID: 4181481049905423138}
   - {fileID: 7371766099224163054}
   - {fileID: 4185166660565687830}
@@ -21626,6 +21627,7 @@ MonoBehaviour:
   - {fileID: 6012264179647788454}
   canvasGroup: {fileID: 8257705394460708354}
   removeAllButton: {fileID: 5682112896095911271}
+  autoSelectButton: {fileID: 0}
   animator: {fileID: 709826153028242293}
   animationData:
     maximum: 10
@@ -21860,7 +21862,7 @@ PrefabInstance:
     - target: {fileID: 4578447937534175230, guid: 6bc3f6b9639a1c74b9979cefcbe061f9,
         type: 3}
       propertyPath: m_RootOrder
-      value: 5
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 4578447937534175230, guid: 6bc3f6b9639a1c74b9979cefcbe061f9,
         type: 3}
@@ -22881,7 +22883,7 @@ PrefabInstance:
     - target: {fileID: 2418683638863790235, guid: 543ea58faa96c47bea69a87c29ba0ce7,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 107
+      value: 93.800026
       objectReference: {fileID: 0}
     - target: {fileID: 2418683638863790235, guid: 543ea58faa96c47bea69a87c29ba0ce7,
         type: 3}
@@ -22982,7 +22984,7 @@ PrefabInstance:
     - target: {fileID: 8393857624628101227, guid: 543ea58faa96c47bea69a87c29ba0ce7,
         type: 3}
       propertyPath: m_Name
-      value: ConditionalButton_Type5
+      value: RemoveAllButton
       objectReference: {fileID: 0}
     - target: {fileID: 8393857624628101227, guid: 543ea58faa96c47bea69a87c29ba0ce7,
         type: 3}
@@ -23932,6 +23934,267 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 3909500369725347631, guid: 9067b4811aa0241b7a96a2cc09536ced,
     type: 3}
   m_PrefabInstance: {fileID: 6988435027472687365}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &7908049437545443717
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 2752236434775052170}
+    m_Modifications:
+    - target: {fileID: 411511002073010539, guid: 543ea58faa96c47bea69a87c29ba0ce7,
+        type: 3}
+      propertyPath: m_text
+      value: Auto Select 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 411511002073010539, guid: 543ea58faa96c47bea69a87c29ba0ce7,
+        type: 3}
+      propertyPath: m_fontSize
+      value: 15.4
+      objectReference: {fileID: 0}
+    - target: {fileID: 411511002073010539, guid: 543ea58faa96c47bea69a87c29ba0ce7,
+        type: 3}
+      propertyPath: m_fontStyle
+      value: 17
+      objectReference: {fileID: 0}
+    - target: {fileID: 411511002073010539, guid: 543ea58faa96c47bea69a87c29ba0ce7,
+        type: 3}
+      propertyPath: m_fontSizeMax
+      value: 16
+      objectReference: {fileID: 0}
+    - target: {fileID: 2418683638863790235, guid: 543ea58faa96c47bea69a87c29ba0ce7,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2418683638863790235, guid: 543ea58faa96c47bea69a87c29ba0ce7,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2418683638863790235, guid: 543ea58faa96c47bea69a87c29ba0ce7,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 2418683638863790235, guid: 543ea58faa96c47bea69a87c29ba0ce7,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2418683638863790235, guid: 543ea58faa96c47bea69a87c29ba0ce7,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2418683638863790235, guid: 543ea58faa96c47bea69a87c29ba0ce7,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2418683638863790235, guid: 543ea58faa96c47bea69a87c29ba0ce7,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2418683638863790235, guid: 543ea58faa96c47bea69a87c29ba0ce7,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 150
+      objectReference: {fileID: 0}
+    - target: {fileID: 2418683638863790235, guid: 543ea58faa96c47bea69a87c29ba0ce7,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 36
+      objectReference: {fileID: 0}
+    - target: {fileID: 2418683638863790235, guid: 543ea58faa96c47bea69a87c29ba0ce7,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2418683638863790235, guid: 543ea58faa96c47bea69a87c29ba0ce7,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2418683638863790235, guid: 543ea58faa96c47bea69a87c29ba0ce7,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2418683638863790235, guid: 543ea58faa96c47bea69a87c29ba0ce7,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2418683638863790235, guid: 543ea58faa96c47bea69a87c29ba0ce7,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2418683638863790235, guid: 543ea58faa96c47bea69a87c29ba0ce7,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2418683638863790235, guid: 543ea58faa96c47bea69a87c29ba0ce7,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2418683638863790235, guid: 543ea58faa96c47bea69a87c29ba0ce7,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 250.4
+      objectReference: {fileID: 0}
+    - target: {fileID: 2418683638863790235, guid: 543ea58faa96c47bea69a87c29ba0ce7,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -47.999992
+      objectReference: {fileID: 0}
+    - target: {fileID: 2418683638863790235, guid: 543ea58faa96c47bea69a87c29ba0ce7,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2418683638863790235, guid: 543ea58faa96c47bea69a87c29ba0ce7,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2418683638863790235, guid: 543ea58faa96c47bea69a87c29ba0ce7,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2885806143486015812, guid: 543ea58faa96c47bea69a87c29ba0ce7,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: -20
+      objectReference: {fileID: 0}
+    - target: {fileID: 2885806143486015812, guid: 543ea58faa96c47bea69a87c29ba0ce7,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2885806143486015812, guid: 543ea58faa96c47bea69a87c29ba0ce7,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2885806143486015812, guid: 543ea58faa96c47bea69a87c29ba0ce7,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 3458498375167141336, guid: 543ea58faa96c47bea69a87c29ba0ce7,
+        type: 3}
+      propertyPath: l10nKey
+      value: UI_SELECT_AUTO
+      objectReference: {fileID: 0}
+    - target: {fileID: 4596416969279276279, guid: 543ea58faa96c47bea69a87c29ba0ce7,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5020062428710556598, guid: 543ea58faa96c47bea69a87c29ba0ce7,
+        type: 3}
+      propertyPath: l10nKey
+      value: UI_SELECT_AUTO
+      objectReference: {fileID: 0}
+    - target: {fileID: 7057353643760748405, guid: 543ea58faa96c47bea69a87c29ba0ce7,
+        type: 3}
+      propertyPath: m_Controller
+      value: 
+      objectReference: {fileID: 22100000, guid: 2db93b3f45b9c144f9d5d985f2a95adf,
+        type: 2}
+    - target: {fileID: 7170817156671662161, guid: 543ea58faa96c47bea69a87c29ba0ce7,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7505806445016242676, guid: 543ea58faa96c47bea69a87c29ba0ce7,
+        type: 3}
+      propertyPath: l10nKey
+      value: UI_SELECT_AUTO
+      objectReference: {fileID: 0}
+    - target: {fileID: 7545097809271751591, guid: 543ea58faa96c47bea69a87c29ba0ce7,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7562037863879786557, guid: 543ea58faa96c47bea69a87c29ba0ce7,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: -20
+      objectReference: {fileID: 0}
+    - target: {fileID: 7562037863879786557, guid: 543ea58faa96c47bea69a87c29ba0ce7,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7562037863879786557, guid: 543ea58faa96c47bea69a87c29ba0ce7,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7562037863879786557, guid: 543ea58faa96c47bea69a87c29ba0ce7,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 7580108491995122979, guid: 543ea58faa96c47bea69a87c29ba0ce7,
+        type: 3}
+      propertyPath: m_text
+      value: Auto Select 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 7580108491995122979, guid: 543ea58faa96c47bea69a87c29ba0ce7,
+        type: 3}
+      propertyPath: m_fontStyle
+      value: 17
+      objectReference: {fileID: 0}
+    - target: {fileID: 8393857624628101227, guid: 543ea58faa96c47bea69a87c29ba0ce7,
+        type: 3}
+      propertyPath: m_Name
+      value: AutoSelectButton
+      objectReference: {fileID: 0}
+    - target: {fileID: 8393857624628101227, guid: 543ea58faa96c47bea69a87c29ba0ce7,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8744405165787708639, guid: 543ea58faa96c47bea69a87c29ba0ce7,
+        type: 3}
+      propertyPath: m_text
+      value: Auto Select 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 8744405165787708639, guid: 543ea58faa96c47bea69a87c29ba0ce7,
+        type: 3}
+      propertyPath: m_fontSize
+      value: 15.4
+      objectReference: {fileID: 0}
+    - target: {fileID: 8744405165787708639, guid: 543ea58faa96c47bea69a87c29ba0ce7,
+        type: 3}
+      propertyPath: m_fontStyle
+      value: 17
+      objectReference: {fileID: 0}
+    - target: {fileID: 8744405165787708639, guid: 543ea58faa96c47bea69a87c29ba0ce7,
+        type: 3}
+      propertyPath: m_fontSizeMax
+      value: 16
+      objectReference: {fileID: 0}
+    - target: {fileID: 8928001901855831812, guid: 543ea58faa96c47bea69a87c29ba0ce7,
+        type: 3}
+      propertyPath: m_fontSize
+      value: 20.5
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 543ea58faa96c47bea69a87c29ba0ce7, type: 3}
+--- !u!224 &5489864739948933406 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 2418683638863790235, guid: 543ea58faa96c47bea69a87c29ba0ce7,
+    type: 3}
+  m_PrefabInstance: {fileID: 7908049437545443717}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &8258431621500585179
 PrefabInstance:

--- a/nekoyume/Assets/AddressableAssets/UI/Module/GrindModule.prefab
+++ b/nekoyume/Assets/AddressableAssets/UI/Module/GrindModule.prefab
@@ -21627,7 +21627,7 @@ MonoBehaviour:
   - {fileID: 6012264179647788454}
   canvasGroup: {fileID: 8257705394460708354}
   removeAllButton: {fileID: 5682112896095911271}
-  autoSelectButton: {fileID: 0}
+  autoSelectButton: {fileID: 1856591465534599663}
   animator: {fileID: 709826153028242293}
   animationData:
     maximum: 10
@@ -21712,7 +21712,7 @@ PrefabInstance:
     - target: {fileID: 241701247471134299, guid: 6bc3f6b9639a1c74b9979cefcbe061f9,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 0
+      value: 120
       objectReference: {fileID: 0}
     - target: {fileID: 241701247471134299, guid: 6bc3f6b9639a1c74b9979cefcbe061f9,
         type: 3}
@@ -24190,6 +24190,18 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 543ea58faa96c47bea69a87c29ba0ce7, type: 3}
+--- !u!114 &1856591465534599663 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8393857624628101226, guid: 543ea58faa96c47bea69a87c29ba0ce7,
+    type: 3}
+  m_PrefabInstance: {fileID: 7908049437545443717}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dd36e9ecf7775ae45bc40a208c43fc92, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!224 &5489864739948933406 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 2418683638863790235, guid: 543ea58faa96c47bea69a87c29ba0ce7,

--- a/nekoyume/Assets/_Scripts/UI/Module/GrindModule.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/GrindModule.cs
@@ -496,12 +496,20 @@ namespace Nekoyume.UI.Module
 
             var isFirst = _selectedItemsForGrind.Count == 0;
             var inventoryData = States.Instance.CurrentAvatarState.inventory;
-            var equipmentItems = inventoryData.Equipments
-                .OrderBy(equipment => equipment.Grade)
-                .ThenBy(CPHelper.GetCP)
-                .Select(equipment => grindInventory.TryGetModel(equipment, out var inventoryItem)
-                    ? inventoryItem
-                    : null)
+
+            var equipmentWithCpList = new List<(Equipment Equip, int CP)>();
+            foreach (var eq in inventoryData.Equipments) {
+                var cp = CPHelper.GetCP(eq);
+                equipmentWithCpList.Add((eq, cp));
+            }
+
+            equipmentWithCpList.Sort((a, b) => {
+                var gradeCompare = a.Equip.Grade.CompareTo(b.Equip.Grade);
+                return gradeCompare != 0 ? gradeCompare : a.CP.CompareTo(b.CP);
+            });
+
+            var equipmentItems = equipmentWithCpList
+                .Select(x => grindInventory.TryGetModel(x.Equip, out var inventoryItem) ? inventoryItem : null)
                 .Where(CanAutoSelect)
                 .ToList();
 

--- a/nekoyume/Assets/_Scripts/UI/Module/GrindModule.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/GrindModule.cs
@@ -230,10 +230,11 @@ namespace Nekoyume.UI.Module
         {
             var selectedItems = _selectedItemsForGrind.ToList();
             _selectedItemsForGrind.Clear();
+            var cachedList = grindInventory.GetModels(ItemType.Equipment);
             foreach (var selectedItem in selectedItems)
             {
                 // Check if the item is still in the inventory.
-                if (inventory.TryGetModel(selectedItem.ItemBase, out var item))
+                if (inventory.TryGetModel(selectedItem.ItemBase, cachedList, out var item))
                 {
                     _selectedItemsForGrind.Add(item);
                 }
@@ -508,8 +509,9 @@ namespace Nekoyume.UI.Module
                 return gradeCompare != 0 ? gradeCompare : a.CP.CompareTo(b.CP);
             });
 
+            var cachedList = grindInventory.GetModels(ItemType.Equipment);
             var equipmentItems = equipmentWithCpList
-                .Select(x => grindInventory.TryGetModel(x.Equip, out var inventoryItem) ? inventoryItem : null)
+                .Select(x => grindInventory.TryGetModel(x.Equip, cachedList, out var inventoryItem) ? inventoryItem : null)
                 .Where(CanAutoSelect)
                 .ToList();
 

--- a/nekoyume/Assets/_Scripts/UI/Module/GrindModule.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/GrindModule.cs
@@ -515,16 +515,16 @@ namespace Nekoyume.UI.Module
                 .Where(CanAutoSelect)
                 .ToList();
 
-            var itemCount = equipmentItems.Count;
             var selectedCount = _selectedItemsForGrind.Count;
-            var remainder = selectedCount % selectCount;
-            // 이미 선택된 아이템을 제외하고 필요 수량만큼 선택할 여분이 없으면 아이템 추가 선택 안함
-            if (itemCount - (selectedCount - remainder) < selectCount)
+            if (selectedCount >= LimitGrindingCount)
             {
+                OneLineSystem.Push(MailType.System,
+                    L10nManager.Localize("ERROR_NOT_GRINDING_OVER", LimitGrindingCount),
+                    NotificationCell.NotificationType.Alert);
                 return;
             }
 
-            var i = selectedCount % selectCount;
+            var i = 0;
             foreach (var cachedItem in equipmentItems)
             {
                 if (cachedItem.SelectCountEnabled.Value)
@@ -535,7 +535,7 @@ namespace Nekoyume.UI.Module
                 _selectedItemsForGrind.Add(cachedItem);
                 i++;
 
-                if (i >= selectCount)
+                if (i >= selectCount || i + selectedCount >= LimitGrindingCount)
                 {
                     break;
                 }

--- a/nekoyume/Assets/_Scripts/UI/Module/GrindModule.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/GrindModule.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Numerics;
 using Libplanet.Types.Assets;
 using Nekoyume.Action;
+using Nekoyume.Battle;
 using Nekoyume.Blockchain;
 using Nekoyume.Game;
 using Nekoyume.Helper;
@@ -210,6 +211,7 @@ namespace Nekoyume.UI.Module
             }
 
             grindInventory.ClearSelectedItem();
+            return;
 
             void RegisterForGrind()
             {
@@ -478,18 +480,21 @@ namespace Nekoyume.UI.Module
             if (_selectedItemsForGrind.Count > 0)
             {
                 ClearSelectedItems();
-                return;
             }
 
             var inventoryData = States.Instance.CurrentAvatarState.inventory;
             inventoryData.Equipments
-                .OrderByDescending(equipment => equipment.Grade)
-                .ThenBy(equipment => equipment.Id)
+                .OrderBy(equipment => equipment.Grade)
+                .ThenBy(CPHelper.GetCP)
                 .Take(20)
                 .ToList()
                 .ForEach(equipment =>
                 {
+                    grindInventory.TryGetModel(equipment, out var inventoryItem);
+                    _selectedItemsForGrind.Add(inventoryItem);
                 });
+
+            animator.SetTrigger(FirstRegister);
         }
 
         private void ClearSelectedItems()

--- a/nekoyume/Assets/_Scripts/UI/Module/Inventory.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/Inventory.cs
@@ -32,7 +32,7 @@ namespace Nekoyume.UI.Module
             Rune,
             Material,
             Costume,
-            FungibleAsset
+            FungibleAsset,
         }
 
         [SerializeField]

--- a/nekoyume/Assets/_Scripts/UI/Module/Inventory.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/Inventory.cs
@@ -389,7 +389,7 @@ namespace Nekoyume.UI.Module
             };
         }
 
-        private List<InventoryItem> GetModels(ItemType itemType)
+        public List<InventoryItem> GetModels(ItemType itemType)
         {
             return itemType switch
             {
@@ -431,7 +431,7 @@ namespace Nekoyume.UI.Module
                 result.AddRange(pair.Value);
             }
 
-            var cpMap = new Dictionary<Equipment, int>();
+            var cpMap = new Dictionary<Guid, int>();
             result = result
                 .OrderByDescending(x => x.Equipped.Value)
                 .ThenByDescending(x => bestItemSet.Contains(x))
@@ -451,13 +451,13 @@ namespace Nekoyume.UI.Module
                         return 0;
                     }
 
-                    if (cpMap.TryGetValue(eq, out var cpValue))
+                    if (cpMap.TryGetValue(eq.ItemId, out var cpValue))
                     {
                         return cpValue;
                     }
 
                     cpValue = CPHelper.GetCP(eq);
-                    cpMap[eq] = cpValue;
+                    cpMap[eq.ItemId] = cpValue;
                     return cpValue;
                 })
                 .ToList();
@@ -1086,6 +1086,43 @@ namespace Nekoyume.UI.Module
                         return true;
                     }
                 }
+            }
+
+            return false;
+        }
+
+        public bool TryGetModel(ItemBase itemBase, List<InventoryItem> cachedList, out InventoryItem result)
+        {
+            result = null;
+            if (itemBase is null || cachedList is null)
+            {
+                return false;
+            }
+
+            if (itemBase.ItemType == ItemType.Consumable)
+            {
+                return TryGetConsumable(itemBase.Id, out result);
+            }
+
+            if (itemBase is not INonFungibleItem item)
+            {
+                return false;
+            }
+
+            foreach (var model in cachedList)
+            {
+                if (model.ItemBase is not INonFungibleItem nonFungibleItem)
+                {
+                    continue;
+                }
+
+                if (!nonFungibleItem.NonFungibleId.Equals(item.NonFungibleId))
+                {
+                    continue;
+                }
+
+                result = model;
+                return true;
             }
 
             return false;


### PR DESCRIPTION
This pull request includes several modifications to the `GrindModule.prefab` and `GrindModule.cs` files in the `nekoyume` project. The primary changes involve adjustments to the UI elements and the addition of a new button, as well as refactoring the `Awake` method to improve code organization.

### UI Changes:
* Updated the `m_RootOrder` values for various `RectTransform` components to adjust the rendering order. [[1]](diffhunk://#diff-412e38d483bb5b42b6ff3c57199bb2b311af61e4b60353300ebdfd1ad3c57c88L5324-R5324) [[2]](diffhunk://#diff-412e38d483bb5b42b6ff3c57199bb2b311af61e4b60353300ebdfd1ad3c57c88L16065-R16065) [[3]](diffhunk://#diff-412e38d483bb5b42b6ff3c57199bb2b311af61e4b60353300ebdfd1ad3c57c88L21211-R21211) [[4]](diffhunk://#diff-412e38d483bb5b42b6ff3c57199bb2b311af61e4b60353300ebdfd1ad3c57c88L21248-R21248)
* Added a new `autoSelectButton` to the `MonoBehaviour` component.
* Modified the `PrefabInstance` properties to adjust the size, position, and other attributes of UI elements. [[1]](diffhunk://#diff-412e38d483bb5b42b6ff3c57199bb2b311af61e4b60353300ebdfd1ad3c57c88L21713-R21715) [[2]](diffhunk://#diff-412e38d483bb5b42b6ff3c57199bb2b311af61e4b60353300ebdfd1ad3c57c88L21863-R21865) [[3]](diffhunk://#diff-412e38d483bb5b42b6ff3c57199bb2b311af61e4b60353300ebdfd1ad3c57c88L22884-R22886) [[4]](diffhunk://#diff-412e38d483bb5b42b6ff3c57199bb2b311af61e4b60353300ebdfd1ad3c57c88L22985-R22987) [[5]](diffhunk://#diff-412e38d483bb5b42b6ff3c57199bb2b311af61e4b60353300ebdfd1ad3c57c88R23938-R24210)

### Code Changes:
* Added a new `using` directive for `Nekoyume.Battle` in `GrindModule.cs`.
* Introduced a new `autoSelectButton` field in the `CrystalAnimationData` struct.
* Refactored the `Awake` method to extract button event bindings into a separate method `BindButtonEvents`.
* Added a missing `return` statement in the `OnClickItem` method to prevent further execution.
* Updated the `OnUpdateInventory` method to use a cached list for inventory models.