### PR TITLE
Download remote bucket sheet instead of GetSheets from node

### DIFF
--- a/nekoyume/Assets/_Scripts/Helper/CommandLineOptions.cs
+++ b/nekoyume/Assets/_Scripts/Helper/CommandLineOptions.cs
@@ -120,6 +120,8 @@ namespace Nekoyume.Helper
 
         private bool _mixpanelDebugWarning;
 
+        private string _sheetBucketUrl;
+
         public bool Empty { get; private set; } = true;
 
         public string genesisBlockPath;
@@ -641,6 +643,16 @@ namespace Nekoyume.Helper
             }
         }
 
+        [Option("sheet-bucket-url", Required = false, HelpText = "table sheets bucket url")]
+        public string SheetBuckUrl
+        {
+            get => _sheetBucketUrl;
+            set
+            {
+                _sheetBucketUrl = value;
+                Empty = false;
+            }
+        }
 
         public override string ToString()
         {

--- a/nekoyume/Assets/_Scripts/Helper/FileHelper.cs
+++ b/nekoyume/Assets/_Scripts/Helper/FileHelper.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.Threading.Tasks;
 using UnityEngine;
 
 namespace Nekoyume.Helper
@@ -15,6 +16,24 @@ namespace Nekoyume.Helper
         {
             var path = Platform.GetPersistentDataPath(fileName);
             File.AppendAllText(path, text);
+        }
+        public static void WriteAllText(string directoryName, string fileName, string text)
+        {
+            var dirPath = Platform.GetPersistentDataDirectoryPath(directoryName);
+            if (!Directory.Exists(dirPath))
+            {
+                Directory.CreateDirectory(dirPath);
+            }
+
+            var path = Path.Join(dirPath, fileName);
+            File.WriteAllText(path, text);
+        }
+
+        public static async Task<string> ReadAllTextAsync(string directoryName, string fileName)
+        {
+            var dirPath = Platform.GetPersistentDataDirectoryPath(directoryName);
+            var path = Path.Join(dirPath, fileName);
+            return await File.ReadAllTextAsync(path);
         }
     }
 }

--- a/nekoyume/Assets/_Scripts/PlatformUtility/Platform.cs
+++ b/nekoyume/Assets/_Scripts/PlatformUtility/Platform.cs
@@ -25,6 +25,11 @@ namespace Nekoyume
             return Path.Combine(PersistentDataPath, fileName);
         }
 
+        public static string GetPersistentDataDirectoryPath(string directoryName)
+        {
+            return Path.Combine(PersistentDataPath, directoryName);
+        }
+
         [RuntimeInitializeOnLoadMethod]
         private static void OnRuntimeMethodLoad()
         {


### PR DESCRIPTION
- resolve #6902 
- 이 코드가 동작하기위해선 PlanetId별로 시트 데이터를 직접 서빙해야합니다.
- 지정된 버킷/PlanetId 경로에 있는 시트 데이터를 다운 받아서 저장시키고 노드에서 GetSheets를 호출하는대신 해당 시트를 사용하도록 처리합니다.