### PR TITLE
Feature/world boss fe qa2

### DIFF
--- a/nekoyume/Assets/Resources/UI/Prefabs/UI_WorldBossDetail.prefab
+++ b/nekoyume/Assets/Resources/UI/Prefabs/UI_WorldBossDetail.prefab
@@ -9767,6 +9767,7 @@ RectTransform:
   - {fileID: 7644466086119102246}
   - {fileID: 8517378932449840340}
   - {fileID: 7439634360647800081}
+  - {fileID: 9150990823094070913}
   m_Father: {fileID: 6622272727240834826}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -14617,6 +14618,7 @@ MonoBehaviour:
   - {fileID: 245066099996370167}
   - {fileID: 1463323137200925030}
   claimButton: {fileID: 2845927084220769327}
+  loadingIndicator: {fileID: 4732326752874114235}
 --- !u!1 &1558876350121021388
 GameObject:
   m_ObjectHideFlags: 0
@@ -154618,6 +154620,142 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 8953210588604891776, guid: fd7a738610a297e41bd57e2eebf6fe64,
     type: 3}
   m_PrefabInstance: {fileID: 7663093498983080199}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &7944574180012577957
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 6223522880479349195}
+    m_Modifications:
+    - target: {fileID: 1206425615335586340, guid: 79ca869aa9be842b09fd026333ae8bf7,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1206425615335586340, guid: 79ca869aa9be842b09fd026333ae8bf7,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1206425615335586340, guid: 79ca869aa9be842b09fd026333ae8bf7,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 1206425615335586340, guid: 79ca869aa9be842b09fd026333ae8bf7,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1206425615335586340, guid: 79ca869aa9be842b09fd026333ae8bf7,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1206425615335586340, guid: 79ca869aa9be842b09fd026333ae8bf7,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1206425615335586340, guid: 79ca869aa9be842b09fd026333ae8bf7,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1206425615335586340, guid: 79ca869aa9be842b09fd026333ae8bf7,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 54
+      objectReference: {fileID: 0}
+    - target: {fileID: 1206425615335586340, guid: 79ca869aa9be842b09fd026333ae8bf7,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 18
+      objectReference: {fileID: 0}
+    - target: {fileID: 1206425615335586340, guid: 79ca869aa9be842b09fd026333ae8bf7,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1206425615335586340, guid: 79ca869aa9be842b09fd026333ae8bf7,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1206425615335586340, guid: 79ca869aa9be842b09fd026333ae8bf7,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1206425615335586340, guid: 79ca869aa9be842b09fd026333ae8bf7,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1206425615335586340, guid: 79ca869aa9be842b09fd026333ae8bf7,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1206425615335586340, guid: 79ca869aa9be842b09fd026333ae8bf7,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1206425615335586340, guid: 79ca869aa9be842b09fd026333ae8bf7,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1206425615335586340, guid: 79ca869aa9be842b09fd026333ae8bf7,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 150
+      objectReference: {fileID: 0}
+    - target: {fileID: 1206425615335586340, guid: 79ca869aa9be842b09fd026333ae8bf7,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -22
+      objectReference: {fileID: 0}
+    - target: {fileID: 1206425615335586340, guid: 79ca869aa9be842b09fd026333ae8bf7,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1206425615335586340, guid: 79ca869aa9be842b09fd026333ae8bf7,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1206425615335586340, guid: 79ca869aa9be842b09fd026333ae8bf7,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3453229590426712094, guid: 79ca869aa9be842b09fd026333ae8bf7,
+        type: 3}
+      propertyPath: m_Name
+      value: IndicatorAnimation
+      objectReference: {fileID: 0}
+    - target: {fileID: 3453229590426712094, guid: 79ca869aa9be842b09fd026333ae8bf7,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 79ca869aa9be842b09fd026333ae8bf7, type: 3}
+--- !u!1 &4732326752874114235 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3453229590426712094, guid: 79ca869aa9be842b09fd026333ae8bf7,
+    type: 3}
+  m_PrefabInstance: {fileID: 7944574180012577957}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &9150990823094070913 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 1206425615335586340, guid: 79ca869aa9be842b09fd026333ae8bf7,
+    type: 3}
+  m_PrefabInstance: {fileID: 7944574180012577957}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &8288301857607568860
 PrefabInstance:

--- a/nekoyume/Assets/_Scripts/Blockchain/ActionRenderHandler.cs
+++ b/nekoyume/Assets/_Scripts/Blockchain/ActionRenderHandler.cs
@@ -3477,6 +3477,9 @@ namespace Nekoyume.Blockchain
             var avatarAddress = Game.Game.instance.States.CurrentAvatarState.address;
             WorldBossStates.Set(eval.OutputState, eval.BlockIndex, avatarAddress).Forget();
 
+            var worldBossReward = Widget.Find<WorldBossDetail>();
+            worldBossReward.OnRenderSeasonReward();
+
             if (eval.Exception is not null)
             {
                 NcDebug.Log(eval.Exception.Message);

--- a/nekoyume/Assets/_Scripts/UI/Module/Item/BaseItemView.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/Item/BaseItemView.cs
@@ -238,9 +238,16 @@ namespace Nekoyume
             _disposables.DisposeAllAndClear();
             gameObject.SetActive(true);
             ClearItem();
+
             ItemImage.overrideSprite = SpriteHelper.GetFavIcon(ticker);
             CountText.text = ((BigInteger)amount).ToCurrencyNotation();
             GradeImage.sprite = SpriteHelper.GetItemBackground(Util.GetTickerGrade(ticker));
+
+            touchHandler.OnClick.Subscribe(_ =>
+            {
+                var tooltip = Widget.Find<FungibleAssetTooltip>();
+                tooltip.Show(ticker, CountText.text, null);
+            }).AddTo(_disposables);
         }
 
         public bool ItemViewSetCurrencyData(int favId, decimal amount)

--- a/nekoyume/Assets/_Scripts/UI/Module/WorldBoss/WorldBossReward.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/WorldBoss/WorldBossReward.cs
@@ -2,16 +2,12 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
-using Libplanet.Action.State;
+using JetBrains.Annotations;
 using Libplanet.Crypto;
-using Nekoyume.Extensions;
 using Nekoyume.Game.Controller;
 using Nekoyume.Helper;
 using Nekoyume.L10n;
-using Nekoyume.Model.State;
 using Nekoyume.State;
-using Nekoyume.TableData;
 using TMPro;
 using UnityEngine;
 
@@ -26,7 +22,7 @@ namespace Nekoyume.UI.Module.WorldBoss
         {
             SeasonRanking,
             BossBattle,
-            BattleGrade
+            BattleGrade,
         }
 
         [Serializable]
@@ -51,6 +47,8 @@ namespace Nekoyume.UI.Module.WorldBoss
 
         private readonly ReactiveProperty<ToggleType> _selectedItemSubType = new();
         private Address _cachedAvatarAddress;
+
+        private WorldBossSeasonReward SeasonReward => categoryToggles.First(t => t.Type == ToggleType.SeasonRanking).Item as WorldBossSeasonReward;
 
         protected void Awake()
         {
@@ -169,6 +167,16 @@ namespace Nekoyume.UI.Module.WorldBoss
             title.text = status == WorldBossStatus.Season
                 ? L10nManager.Localize("UI_REWARDS")
                 : $"{L10nManager.Localize("UI_PREVIOUS")} {L10nManager.Localize("UI_REWARDS")}";
+        }
+
+        public void OnRenderSeasonReward()
+        {
+            if (SeasonReward == null)
+            {
+                return;
+            }
+
+            SeasonReward.OnRender();
         }
     }
 }

--- a/nekoyume/Assets/_Scripts/UI/Module/WorldBoss/WorldBossSeasonReward.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/WorldBoss/WorldBossSeasonReward.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Linq;
+﻿using System.Linq;
 using Nekoyume.Blockchain;
 using Nekoyume.Helper;
 using Nekoyume.L10n;
@@ -29,6 +28,9 @@ namespace Nekoyume.UI.Module.WorldBoss
 
         [SerializeField]
         private ConditionalButton claimButton;
+
+        [SerializeField]
+        private GameObject loadingIndicator;
 
         private void Awake()
         {
@@ -119,6 +121,8 @@ namespace Nekoyume.UI.Module.WorldBoss
             ActionManager.Instance.ClaimWorldBossReward().Subscribe();
             claimButton.SetCondition(() => false);
             claimButton.UpdateObjects();
+
+            loadingIndicator.SetActive(true);
         }
 
         private void OnClickDisableClaimButton()
@@ -127,6 +131,11 @@ namespace Nekoyume.UI.Module.WorldBoss
                 MailType.System,
                 L10nManager.Localize("UI_BOSS_SEASON_REWARD_CANNOT_CLAIM_INFO"),
                 NotificationCell.NotificationType.Information);
+        }
+
+        public void OnRender()
+        {
+            loadingIndicator.SetActive(false);
         }
     }
 }

--- a/nekoyume/Assets/_Scripts/UI/Module/WorldBoss/WorldBossSeasonReward.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/WorldBoss/WorldBossSeasonReward.cs
@@ -38,7 +38,8 @@ namespace Nekoyume.UI.Module.WorldBoss
                 .Subscribe(_ => OnClickClaimButton())
                 .AddTo(gameObject);
 
-            claimButton.OnClickDisabledSubject
+            claimButton.OnClickSubject
+                .Where(_ => !claimButton.IsSubmittable)
                 .Subscribe(_ => OnClickDisableClaimButton())
                 .AddTo(gameObject);
         }

--- a/nekoyume/Assets/_Scripts/UI/Widget/WorldBossDetail.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/WorldBossDetail.cs
@@ -143,6 +143,17 @@ namespace Nekoyume.UI
             }
         }
 
+        public void OnRenderSeasonReward()
+        {
+            var worldBossReward = categoryToggles.FirstOrDefault(x => x.Type == ToggleType.Reward).Item as WorldBossReward;
+            if (worldBossReward == null)
+            {
+                return;
+            }
+
+            worldBossReward.OnRenderSeasonReward();
+        }
+
         // Invoke from TutorialController.PlayAction() by TutorialTargetType
         public void TutorialActionClickWorldBossRewardsButton()
         {


### PR DESCRIPTION
This pull request includes several changes to the `nekoyume` project, primarily focused on the `UI_WorldBossDetail.prefab`, `ActionRenderHandler.cs`, `BaseItemView.cs`, `WorldBossReward.cs`, and `WorldBossSeasonReward.cs` files. The changes introduce new features and improve the user interface for handling world boss rewards.

### UI Enhancements:
* Added a `loadingIndicator` to the `UI_WorldBossDetail.prefab` to provide visual feedback during loading.
* Introduced a new `PrefabInstance` and `RectTransform` for the loading indicator in the `UI_WorldBossDetail.prefab`.

### New Features:
* Implemented the `OnRenderSeasonReward` method in `WorldBossReward` to update the season reward display.
* Added a subscription to display a tooltip with currency details in `ItemViewSetCurrencyData` method in `BaseItemView.cs`.

### Code Improvements:
* Removed unused `using` directives from `WorldBossReward.cs` to clean up the code.
* Added a `loadingIndicator` and related logic to `WorldBossSeasonReward.cs` to show and hide the loading indicator appropriately. [[1]](diffhunk://#diff-20d09ba02a5c9bf2c10d3de6384152fce6099a89a5f4fa41ece569f74b8b0371R32-R42) [[2]](diffhunk://#diff-20d09ba02a5c9bf2c10d3de6384152fce6099a89a5f4fa41ece569f74b8b0371R136-R140)

These changes collectively improve the user experience by providing better feedback and clearer information when interacting with world boss rewards.