### PR TITLE
Stake 관련 시트 하위호환 처리

### DIFF
--- a/nekoyume/Assets/_Scripts/Game/Game.cs
+++ b/nekoyume/Assets/_Scripts/Game/Game.cs
@@ -771,7 +771,7 @@ namespace Nekoyume.Game
             var csvAssets = addressableAssetsContainer.tableCsvAssets;
             IDictionary<string, string> csvDict;
             // TODO delete GetSheetsAsync backward compatibility
-            if (string.IsNullOrEmpty(_commandLineOptions.SheetBuckUrl))
+            if (string.IsNullOrEmpty(_commandLineOptions.SheetBucketUrl))
             {
                 var map = csvAssets.ToDictionary(
                     asset => Addresses.TableSheet.Derive(asset.name),
@@ -798,7 +798,7 @@ namespace Nekoyume.Game
                 var planetId = CurrentPlanetId!.Value;
 
                 // Download and save sheets for the current planet
-                csvDict = await DownloadSheet(planetId, _commandLineOptions.SheetBuckUrl, sheetNames);
+                csvDict = await DownloadSheet(planetId, _commandLineOptions.SheetBucketUrl, sheetNames);
 
                 NcDebug.Log($"[{nameof(SyncTableSheetsAsync)}] download sheet: {sw.Elapsed}");
 

--- a/nekoyume/Assets/_Scripts/Game/Game.cs
+++ b/nekoyume/Assets/_Scripts/Game/Game.cs
@@ -845,7 +845,21 @@ namespace Nekoyume.Game
                         stakeStateV2.Contract.StakeRegularRewardSheetTableName,
                     };
                 }
-                var sheets = await DownloadSheet(CurrentPlanetId!.Value, CommandLineOptions.SheetBuckUrl, sheetNames);
+
+                IDictionary<string, string> sheets;
+                if (string.IsNullOrEmpty(CommandLineOptions.SheetBucketUrl))
+                {
+                    var map = sheetNames.ToDictionary(i => Addresses.TableSheet.Derive(i), i => i);
+                    var dict = await Agent.GetSheetsAsync(map.Keys);
+                    sheets = dict.ToDictionary(
+                        pair => map[pair.Key],
+                        // NOTE: `pair.Value` is `null` when the chain not contains the `pair.Key`.
+                        pair => pair.Value is Text ? pair.Value.ToDotnetString() : null);
+                }
+                else
+                {
+                    sheets = await DownloadSheet(CurrentPlanetId!.Value, CommandLineOptions.SheetBucketUrl, sheetNames);
+                }
                 stakeRegularFixedRewardSheet.Set(sheets[sheetNames[0]]);
                 stakeRegularRewardSheet.Set(sheets[sheetNames[1]]);
             }

--- a/nekoyume/Assets/_Scripts/Helper/CommandLineOptions.cs
+++ b/nekoyume/Assets/_Scripts/Helper/CommandLineOptions.cs
@@ -645,7 +645,7 @@ namespace Nekoyume.Helper
         }
 
         [Option("sheet-bucket-url", Required = false, HelpText = "table sheets bucket url")]
-        public string SheetBuckUrl
+        public string SheetBucketUrl
         {
             get => _sheetBucketUrl;
             set


### PR DESCRIPTION
- SheetBuckUrl을 SheetBucketUrl로 이름 수정
- SheetBucketUrl이 설정되있는 경우에만 DownloadSheet를 호출하도록 하위호환 처리
- resolve #6920