### PR TITLE
fix item view hide

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Module/Stat/StatView.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/Stat/StatView.cs
@@ -39,6 +39,7 @@ namespace Nekoyume.UI.Module
         {
             statTypeText.enabled = false;
             valueText.enabled = false;
+            gameObject.SetActive(false);
         }
     }
 }


### PR DESCRIPTION
This pull request includes a minor change to the `StatView` class in the `nekoyume/Assets/_Scripts/UI/Module/Stat/StatView.cs` file. The change ensures that the game object is deactivated when the `Hide` method is called.

* [`nekoyume/Assets/_Scripts/UI/Module/Stat/StatView.cs`](diffhunk://#diff-b9573291e9050c89573a4efa9f398bdabf68c4c60e437943d741ce6d4845df04R42): Added `gameObject.SetActive(false);` to the `Hide` method to deactivate the game object.