### PR TITLE
Feature/worldboss fe qa 3

### DIFF
--- a/nekoyume/Assets/Resources/UI/Prefabs/UI_WorldBossDetail.prefab
+++ b/nekoyume/Assets/Resources/UI/Prefabs/UI_WorldBossDetail.prefab
@@ -46107,6 +46107,82 @@ MonoBehaviour:
   m_ChildScaleWidth: 0
   m_ChildScaleHeight: 0
   m_ReverseArrangement: 0
+--- !u!1 &2875195157987123358
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8041801013852949148}
+  - component: {fileID: 2564372119246390311}
+  - component: {fileID: 2956473350942162767}
+  m_Layer: 5
+  m_Name: Dot
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &8041801013852949148
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2875195157987123358}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6821355440334364071}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -6, y: -6}
+  m_SizeDelta: {x: 22, y: 23}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2564372119246390311
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2875195157987123358}
+  m_CullTransparentMesh: 1
+--- !u!114 &2956473350942162767
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2875195157987123358}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 20cfb2802ede847b3bd7399ebb092084, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &2900332496234744059
 GameObject:
   m_ObjectHideFlags: 0
@@ -54713,6 +54789,82 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_HorizontalFit: 2
   m_VerticalFit: 0
+--- !u!1 &3350707727971670759
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7673021659828169740}
+  - component: {fileID: 9049591918762449360}
+  - component: {fileID: 5370152286534748061}
+  m_Layer: 5
+  m_Name: Dot
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &7673021659828169740
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3350707727971670759}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6902423862661285997}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -6, y: -6}
+  m_SizeDelta: {x: 22, y: 23}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &9049591918762449360
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3350707727971670759}
+  m_CullTransparentMesh: 1
+--- !u!114 &5370152286534748061
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3350707727971670759}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 20cfb2802ede847b3bd7399ebb092084, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &3352321682359022857
 GameObject:
   m_ObjectHideFlags: 0
@@ -62316,6 +62468,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 6205938777457783701}
+  - {fileID: 7673021659828169740}
   m_Father: {fileID: 3840436015864757522}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -80509,7 +80662,10 @@ MonoBehaviour:
   - Toggle: {fileID: 106864371679443036}
     Type: 2
     Item: {fileID: 8105749328263143965}
-  notifications:
+  notificationsSeasonReward:
+  - {fileID: 2875195157987123358}
+  - {fileID: 3350707727971670759}
+  notificationsBattleGrade:
   - {fileID: 265645298018831223}
   - {fileID: 8243184197034438436}
   emptyContainer: {fileID: 1068728256716572584}
@@ -134867,6 +135023,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 7663996613750810285}
+  - {fileID: 8041801013852949148}
   m_Father: {fileID: 3840436015864757522}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/nekoyume/Assets/_Scripts/UI/Module/WorldBoss/WorldBossReward.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/WorldBoss/WorldBossReward.cs
@@ -10,6 +10,7 @@ using Nekoyume.L10n;
 using Nekoyume.State;
 using TMPro;
 using UnityEngine;
+using UnityEngine.Serialization;
 
 
 namespace Nekoyume.UI.Module.WorldBoss
@@ -37,7 +38,10 @@ namespace Nekoyume.UI.Module.WorldBoss
         private List<CategoryToggle> categoryToggles = null;
 
         [SerializeField]
-        private List<GameObject> notifications;
+        private List<GameObject> notificationsSeasonReward;
+
+        [SerializeField]
+        private List<GameObject> notificationsBattleGrade;
 
         [SerializeField]
         private GameObject emptyContainer;
@@ -81,9 +85,30 @@ namespace Nekoyume.UI.Module.WorldBoss
 
             WorldBossStates.SubscribeGradeRewards((b) =>
             {
-                foreach (var notification in notifications)
+                foreach (var notification in notificationsBattleGrade)
                 {
                     notification.SetActive(b);
+                }
+            });
+
+            WorldBossStates.SubscribeWorldBossState(state =>
+            {
+                var currentState = Game.Game.instance.States.CurrentAvatarState;
+                if (currentState is null)
+                {
+                    foreach (var notification in notificationsSeasonReward)
+                    {
+                        notification.SetActive(false);
+                    }
+                    return;
+                }
+
+                var avatarAddress = currentState.address;
+                var isOnSeason = WorldBossStates.IsOnSeason;
+                var preRaiderState = WorldBossStates.GetPreRaiderState(avatarAddress);
+                foreach (var notification in notificationsSeasonReward)
+                {
+                    notification.SetActive(!isOnSeason && !preRaiderState.HasClaimedReward);
                 }
             });
         }

--- a/nekoyume/Assets/_Scripts/UI/Module/WorldBoss/WorldBossSeasonReward.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/WorldBoss/WorldBossSeasonReward.cs
@@ -106,13 +106,25 @@ namespace Nekoyume.UI.Module.WorldBoss
                 var currentItem = contributeRow.Rewards[i];
                 if (!string.IsNullOrEmpty(currentItem.Ticker))
                 {
+                    var amount = (decimal)currentItem.Count * (decimal)ratio;
+                    if (amount <= 0)
+                    {
+                        continue;
+                    }
+
                     rewardItems[i].gameObject.SetActive(true);
-                    rewardItems[i].ItemViewSetCurrencyData(currentItem.Ticker, (decimal)currentItem.Count * (decimal)ratio);
+                    rewardItems[i].ItemViewSetCurrencyData(currentItem.Ticker, amount);
                 }
                 else if (currentItem.ItemId > 0)
                 {
+                    var amount = (int)((decimal)currentItem.Count * (decimal)ratio);
+                    if (amount <= 0)
+                    {
+                        continue;
+                    }
+
                     rewardItems[i].gameObject.SetActive(true);
-                    rewardItems[i].ItemViewSetItemData(currentItem.ItemId, (int)((decimal)currentItem.Count * (decimal)ratio));
+                    rewardItems[i].ItemViewSetItemData(currentItem.ItemId, amount);
                 }
             }
         }

--- a/nekoyume/Assets/_Scripts/UI/Module/WorldBoss/WorldBossSeasonReward.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/WorldBoss/WorldBossSeasonReward.cs
@@ -50,7 +50,23 @@ namespace Nekoyume.UI.Module.WorldBoss
 
         public void Set(WorldBossState worldBossState, RaiderState raider, int raidId, bool isOnSeason)
         {
-            if (raider == null || !WorldBossFrontHelper.TryGetRaid(raidId, out var raidRow))
+            if (!WorldBossFrontHelper.TryGetRaid(raidId, out var raidRow))
+            {
+                NcDebug.LogError($"Not found WorldBossSheet for raidId: {raidId}");
+                return;
+            }
+
+            var tableSheets = Game.Game.instance.TableSheets;
+            var contributeSheet = tableSheets.WorldBossContributionRewardSheet;
+            var contributeRow = contributeSheet.Values.FirstOrDefault(r => r.BossId == raidRow.BossId);
+            if (contributeRow == null)
+            {
+                NcDebug.LogError($"Not found WorldBossContributionRewardSheet for bossId: {raidRow.BossId}");
+                return;
+            }
+            rewardItem.Set(contributeRow);
+
+            if (raider == null)
             {
                 claimButton.SetCondition(() => false);
                 claimButton.UpdateObjects();
@@ -69,7 +85,6 @@ namespace Nekoyume.UI.Module.WorldBoss
             claimButton.SetCondition(() => canClaim);
             claimButton.UpdateObjects();
 
-            var tableSheets = Game.Game.instance.TableSheets;
             var worldBossTotalDamage = worldBossState?.TotalDamage ?? 0;
             var userTotalDamage = raider?.TotalScore ?? 0;
 
@@ -81,15 +96,6 @@ namespace Nekoyume.UI.Module.WorldBoss
             }
 
             userTotalDamageText.text = $"{userTotalDamage:N0} ({ratio:0.####%})";
-
-            var contributeSheet = tableSheets.WorldBossContributionRewardSheet;
-            var contributeRow = contributeSheet.Values.FirstOrDefault(r => r.BossId == raidRow.BossId);
-            if (contributeRow == null)
-            {
-                NcDebug.LogError($"Not found WorldBossContributionRewardSheet for bossId: {raidRow.BossId}");
-                return;
-            }
-            rewardItem.Set(contributeRow);
 
             foreach (var rewardItemView in rewardItems)
             {


### PR DESCRIPTION
This pull request includes several changes to the `nekoyume/Assets/Resources/UI/Prefabs/UI_WorldBossDetail.prefab` and related scripts to improve the handling of world boss rewards and notifications. The most important changes include adding new GameObjects and modifying notification handling.

### Prefab Changes:
* Added new `GameObject` named `Dot` with associated components (`RectTransform`, `CanvasRenderer`, `MonoBehaviour`) in `UI_WorldBossDetail.prefab`. [[1]](diffhunk://#diff-3e8eb1746e1bb2d87a46c8ba033407ebe0bbbc4e643ed6b20868c09560ebf304R46110-R46185) [[2]](diffhunk://#diff-3e8eb1746e1bb2d87a46c8ba033407ebe0bbbc4e643ed6b20868c09560ebf304R54792-R54867)
* Updated `RectTransform` to include new children references. [[1]](diffhunk://#diff-3e8eb1746e1bb2d87a46c8ba033407ebe0bbbc4e643ed6b20868c09560ebf304R62471) [[2]](diffhunk://#diff-3e8eb1746e1bb2d87a46c8ba033407ebe0bbbc4e643ed6b20868c09560ebf304R135026)
* Modified `MonoBehaviour` to include new notification lists for `notificationsSeasonReward` and `notificationsBattleGrade`.

### Script Changes:
* Added `using UnityEngine.Serialization;` in `WorldBossReward.cs` for serialization purposes.
* Replaced `notifications` with `notificationsSeasonReward` and `notificationsBattleGrade` in `WorldBossReward.cs`.
* Updated `Awake` method in `WorldBossReward.cs` to handle new notification lists.
* Enhanced `Set` method in `WorldBossSeasonReward.cs` to include error handling and correct reward item setting. [[1]](diffhunk://#diff-20d09ba02a5c9bf2c10d3de6384152fce6099a89a5f4fa41ece569f74b8b0371L53-R69) [[2]](diffhunk://#diff-20d09ba02a5c9bf2c10d3de6384152fce6099a89a5f4fa41ece569f74b8b0371L72) [[3]](diffhunk://#diff-20d09ba02a5c9bf2c10d3de6384152fce6099a89a5f4fa41ece569f74b8b0371L85-L93) [[4]](diffhunk://#diff-20d09ba02a5c9bf2c10d3de6384152fce6099a89a5f4fa41ece569f74b8b0371R115-R133)