### PR TITLE
add arena round text

### DIFF
--- a/nekoyume/Assets/Resources/UI/Prefabs/UI_ArenaBoard.prefab
+++ b/nekoyume/Assets/Resources/UI/Prefabs/UI_ArenaBoard.prefab
@@ -72,6 +72,7 @@ RectTransform:
   - {fileID: 7755571292624605180}
   - {fileID: 8236222775965278247}
   - {fileID: 4175930626578347361}
+  - {fileID: 7331212348934468822}
   m_Father: {fileID: 507344875499682576}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -281,6 +282,83 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls: []
+--- !u!1 &295344111683032361
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7331212348934468822}
+  - component: {fileID: 4164248189577464871}
+  - component: {fileID: 6410829121622236242}
+  m_Layer: 5
+  m_Name: Image
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7331212348934468822
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 295344111683032361}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4775023125709711725}
+  m_Father: {fileID: 6825725279518254328}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -106.4}
+  m_SizeDelta: {x: 340, y: 33}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4164248189577464871
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 295344111683032361}
+  m_CullTransparentMesh: 1
+--- !u!114 &6410829121622236242
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 295344111683032361}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607845, g: 0.10980393, b: 0.10196079, a: 0.60784316}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 94a6712e7b2e0d741a50286be14eea0c, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &459950012766258262
 GameObject:
   m_ObjectHideFlags: 0
@@ -602,6 +680,7 @@ MonoBehaviour:
   _loadingObj: {fileID: 5330092765769706255}
   _refreshBtn: {fileID: 5284349997779810893}
   _refeshCountText: {fileID: 9030223826253727699}
+  _roundText: {fileID: 7676191557551307569}
 --- !u!95 &8027222530910038736
 Animator:
   serializedVersion: 5
@@ -5083,6 +5162,174 @@ MonoBehaviour:
   fixedMarginOption: 1
   fontMaterialType: 0
   l10nKey: UI_ID
+  fontMaterialIndexInitialized: 0
+  fontMaterialIndex: 0
+  defaultFontStylesInitialized: 0
+  defaultFontStyles: 0
+  defaultFontSizeInitialized: 0
+  defaultFontSize: 0
+  defaultCharacterSpacingInitialized: 0
+  defaultCharacterSpacing: 0
+  defaultWordSpacingInitialized: 0
+  defaultWordSpacing: 0
+  defaultLineSpacingInitialized: 0
+  defaultLineSpacing: 0
+--- !u!1 &6100192804748469903
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4775023125709711725}
+  - component: {fileID: 5181046498484472186}
+  - component: {fileID: 7676191557551307569}
+  - component: {fileID: 6203451127064870735}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4775023125709711725
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6100192804748469903}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7331212348934468822}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 260, y: 30}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &5181046498484472186
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6100192804748469903}
+  m_CullTransparentMesh: 1
+--- !u!114 &7676191557551307569
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6100192804748469903}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Round 1 / 10
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8a682b7747d4a664089b7b1065aa0035, type: 2}
+  m_sharedMaterial: {fileID: -2364689171920820918, guid: 8a682b7747d4a664089b7b1065aa0035,
+    type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 18
+  m_fontSizeBase: 18
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 8
+  m_fontSizeMax: 32
+  m_fontStyle: 1
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!114 &6203451127064870735
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6100192804748469903}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6d668203cf6645c0bb09a4991d4bbe06, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  fixedFontAsset: 0
+  fixedFontStyle: 0
+  fixedFontSizeOffset: 0
+  fixedSpacingOption: 0
+  fixedMarginOption: 0
+  fontMaterialType: 0
+  l10nKey: UI_ARENABOARD_RATING
   fontMaterialIndexInitialized: 0
   fontMaterialIndex: 0
   defaultFontStylesInitialized: 0

--- a/nekoyume/Assets/_Scripts/UI/Widget/ArenaBoard.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/ArenaBoard.cs
@@ -85,6 +85,8 @@ namespace Nekoyume.UI
         private ConditionalButton _refreshBtn;
         [SerializeField]
         private TextMeshProUGUI _refeshCountText;
+        [SerializeField]
+        private TextMeshProUGUI _roundText;
 
         private SeasonResponse _seasonData;
         private List<AvailableOpponentResponse> _boundedData;
@@ -264,6 +266,9 @@ namespace Nekoyume.UI
             Find<HeaderMenuStatic>().Show(HeaderMenuStatic.AssetVisibleState.Arena);
             UpdateBillboard();
             UpdateScrolls();
+
+            var currentRoundIndex = _seasonData.Rounds.FindIndex(r => r.StartBlockIndex <= blockIndex && blockIndex <= r.EndBlockIndex);
+            _roundText.text = L10nManager.Localize("UI_ARENA_ROUND_TEXT", currentRoundIndex + 1, _seasonData.Rounds.Count);
 
             // 리스트 갱신요청 풀링하는동안에는 버튼갱신하지않도록 예외처리
             if (!_loadingObj.activeSelf)

--- a/nekoyume/Assets/_Scripts/UI/Widget/ArenaBoard.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/ArenaBoard.cs
@@ -267,20 +267,25 @@ namespace Nekoyume.UI
             UpdateBillboard();
             UpdateScrolls();
 
-            if (_seasonData != null)
+            if (_seasonData != null && _seasonData.Rounds != null)
             {
                 int currentRoundIndex = _seasonData.Rounds.FindIndex(r => r.StartBlockIndex <= blockIndex && blockIndex <= r.EndBlockIndex);
                 if (currentRoundIndex < 0)
                 {
-                    NcDebug.LogError($"블록 인덱스: {blockIndex}에 대한 현재 라운드를 찾을 수 없습니다. " +
-                                    $"시즌 ID: {_seasonData.Id}, 라운드 수: {_seasonData.Rounds.Count}. " +
-                                    "시즌 데이터와 블록 인덱스의 유효성을 확인하세요.");
+                    NcDebug.LogError($"Cannot find the current round for block index: {blockIndex}. " +
+                                    $"Season ID: {_seasonData.Id}, Number of Rounds: {_seasonData.Rounds.Count}. " +
+                                    "Please verify the validity of the season data and block index.");
                     _roundText.text = string.Empty;
                 }
                 else
                 {
                     _roundText.text = L10nManager.Localize("UI_ARENA_ROUND_TEXT", currentRoundIndex + 1, _seasonData.Rounds.Count);
                 }
+            }
+            else
+            {
+                _roundText.text = string.Empty;
+                NcDebug.LogError("No season data available.");
             }
 
             // 리스트 갱신요청 풀링하는동안에는 버튼갱신하지않도록 예외처리

--- a/nekoyume/Assets/_Scripts/UI/Widget/ArenaBoard.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/ArenaBoard.cs
@@ -267,8 +267,21 @@ namespace Nekoyume.UI
             UpdateBillboard();
             UpdateScrolls();
 
-            var currentRoundIndex = _seasonData.Rounds.FindIndex(r => r.StartBlockIndex <= blockIndex && blockIndex <= r.EndBlockIndex);
-            _roundText.text = L10nManager.Localize("UI_ARENA_ROUND_TEXT", currentRoundIndex + 1, _seasonData.Rounds.Count);
+            if (_seasonData != null)
+            {
+                int currentRoundIndex = _seasonData.Rounds.FindIndex(r => r.StartBlockIndex <= blockIndex && blockIndex <= r.EndBlockIndex);
+                if (currentRoundIndex < 0)
+                {
+                    NcDebug.LogError($"블록 인덱스: {blockIndex}에 대한 현재 라운드를 찾을 수 없습니다. " +
+                                    $"시즌 ID: {_seasonData.Id}, 라운드 수: {_seasonData.Rounds.Count}. " +
+                                    "시즌 데이터와 블록 인덱스의 유효성을 확인하세요.");
+                    _roundText.text = string.Empty;
+                }
+                else
+                {
+                    _roundText.text = L10nManager.Localize("UI_ARENA_ROUND_TEXT", currentRoundIndex + 1, _seasonData.Rounds.Count);
+                }
+            }
 
             // 리스트 갱신요청 풀링하는동안에는 버튼갱신하지않도록 예외처리
             if (!_loadingObj.activeSelf)


### PR DESCRIPTION
# Arena 라운드 텍스트 표시 기능 추가

## 변경사항
1. Arena 라운드 정보 표시 기능 추가
   - 현재 라운드와 전체 라운드 수를 표시하는 텍스트 UI 추가
   - `UI_ARENA_ROUND_TEXT` L10n 키를 사용하여 다국어 지원

## 구현 상세
- 현재 라운드 인덱스와 전체 라운드 수를 계산하여 표시
- 블록 인덱스를 기반으로 현재 진행 중인 라운드 계산
