### PR TITLE
remove worldboss reward mail

### DIFF
--- a/nekoyume/Assets/_Scripts/Blockchain/ActionRenderHandler.cs
+++ b/nekoyume/Assets/_Scripts/Blockchain/ActionRenderHandler.cs
@@ -3489,11 +3489,6 @@ namespace Nekoyume.Blockchain
                     NotificationCell.NotificationType.Alert);
                 return;
             }
-            LocalLayerModifier.AddNewMail(prepared.avatarState, prepared.mail.id);
-            OneLineSystem.Push(
-                MailType.System,
-                L10nManager.Localize("NOTIFICATION_WORLDBOSS_REWARD_CLAIMED"),
-                NotificationCell.NotificationType.Notification);
 
             var rewards = new List<MailReward>();
             if (worldBossRewardMail.FungibleAssetValues is not null)

--- a/nekoyume/Assets/_Scripts/UI/Widget/Popup/MailPopup.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Popup/MailPopup.cs
@@ -1012,14 +1012,9 @@ namespace Nekoyume.UI
             NcDebug.Log($"[MailRead] MailPopupReadRaidRewardMail mailid : {raidRewardMail.id}");
         }
 
+        [Obsolete]
         public void Read(WorldBossRewardMail worldBossRewardMail)
         {
-            var game = Game.Game.instance;
-            worldBossRewardMail.New = false;
-            var avatarAddress = game.States.CurrentAvatarState.address;
-            LocalLayerModifier.RemoveNewMail(avatarAddress, worldBossRewardMail.id);
-            ReactiveAvatarState.UpdateMailBox(game.States.CurrentAvatarState.mailBox);
-            NcDebug.Log($"[{nameof(WorldBossRewardMail)}] ItemCount: {worldBossRewardMail.id}");
         }
 
         [Obsolete]


### PR DESCRIPTION
빌드 새로 뽑히는 경우 290에 머지, 아닌 경우 대기했다 백머지 후 dev에 머지하겠습니다

This pull request includes changes to the handling of world boss reward mails in the `ActionRenderHandler` and `MailPopup` classes. The most important changes include the removal of specific methods and the deprecation of a method.

Changes to `ActionRenderHandler`:

* Removed calls to `LocalLayerModifier.AddNewMail` and `OneLineSystem.Push` after claiming a world boss reward. (`nekoyume/Assets/_Scripts/Blockchain/ActionRenderHandler.cs`)

Changes to `MailPopup`:

* Deprecated the `Read(WorldBossRewardMail worldBossRewardMail)` method and removed its body, indicating it should no longer be used. (`nekoyume/Assets/_Scripts/UI/Widget/Popup/MailPopup.cs`)
