### PR TITLE
fix ui on userTotalDamage is 0

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Module/WorldBoss/WorldBossSeasonReward.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/WorldBoss/WorldBossSeasonReward.cs
@@ -84,27 +84,28 @@ namespace Nekoyume.UI.Module.WorldBoss
                 return;
             }
 
+            var userTotalDamage = raider.TotalScore;
+
+            if (userTotalDamage == 0 || worldBossTotalDamage == 0)
+            {
+                userTotalDamageText.text = $"{userTotalDamage:N0} (0%)";
+                return;
+            }
+
             var canClaim = !isOnSeason && !raider.HasClaimedReward;
             claimButton.SetCondition(() => canClaim);
             claimButton.UpdateObjects();
 
-            var userTotalDamage = raider.TotalScore;
             float ratio = 0;
             if (worldBossTotalDamage > 0)
             {
                 ratio = userTotalDamage / (float)worldBossTotalDamage;
             }
-
             userTotalDamageText.text = $"{userTotalDamage:N0} ({ratio:0.####%})";
 
             foreach (var rewardItemView in rewardItems)
             {
                 rewardItemView.gameObject.SetActive(false);
-            }
-
-            if (userTotalDamage == 0)
-            {
-                return;
             }
 
             for (var i = 0; i < contributeRow.Rewards.Count; ++i)


### PR DESCRIPTION
This pull request includes an update to the `WorldBossSeasonReward` class to improve the handling of user total damage calculations and display.

Changes to damage calculation and display:

* [`nekoyume/Assets/_Scripts/UI/Module/WorldBoss/WorldBossSeasonReward.cs`](diffhunk://#diff-20d09ba02a5c9bf2c10d3de6384152fce6099a89a5f4fa41ece569f74b8b0371R87-L109): Moved the `userTotalDamage` assignment earlier and added a check for zero damage to set the `userTotalDamageText` and return early if either `userTotalDamage` or `worldBossTotalDamage` is zero. This ensures the damage text is properly formatted and avoids unnecessary calculations.