### PR TITLE
change-stage-page-dynamic

### DIFF
--- a/nekoyume/Assets/Resources/UI/Prefabs/WorldMapWorld.prefab
+++ b/nekoyume/Assets/Resources/UI/Prefabs/WorldMapWorld.prefab
@@ -126,7 +126,7 @@ MonoBehaviour:
       m_Calls: []
 --- !u!95 &7506905123389718038
 Animator:
-  serializedVersion: 4
+  serializedVersion: 5
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -143,7 +143,8 @@ Animator:
   m_WarningMessage: 
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
-  m_KeepAnimatorControllerStateOnDisable: 0
+  m_KeepAnimatorStateOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 0
 --- !u!114 &5394987453795588399
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -233,103 +234,6 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
---- !u!1 &287098340490229479
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 5538965599936049871}
-  - component: {fileID: 1386934892773198945}
-  m_Layer: 5
-  m_Name: Toggle_2
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &5538965599936049871
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 287098340490229479}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 935775654647491397}
-  - {fileID: 2591271467597141221}
-  m_Father: {fileID: 4636111770855141660}
-  m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 20, y: 20}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &1386934892773198945
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 287098340490229479}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 090a3247e50b4ac2929c086464b5cfbb, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Navigation:
-    m_Mode: 3
-    m_WrapAround: 0
-    m_SelectOnUp: {fileID: 0}
-    m_SelectOnDown: {fileID: 0}
-    m_SelectOnLeft: {fileID: 0}
-    m_SelectOnRight: {fileID: 0}
-  m_Transition: 0
-  m_Colors:
-    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
-    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
-    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
-    m_ColorMultiplier: 1
-    m_FadeDuration: 0.1
-  m_SpriteState:
-    m_HighlightedSprite: {fileID: 0}
-    m_PressedSprite: {fileID: 0}
-    m_SelectedSprite: {fileID: 0}
-    m_DisabledSprite: {fileID: 0}
-  m_AnimationTriggers:
-    m_NormalTrigger: Normal
-    m_HighlightedTrigger: Highlighted
-    m_PressedTrigger: Pressed
-    m_SelectedTrigger: Selected
-    m_DisabledTrigger: Disabled
-  m_Interactable: 1
-  m_TargetGraphic: {fileID: 0}
-  toggleTransition: 1
-  graphic: {fileID: 0}
-  m_Group: {fileID: 5057743806923120894}
-  onValueChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_IsOn: 0
-  offObject: {fileID: 8424517765836357533}
-  onObject: {fileID: 6163583598112947295}
-  onClickToggle:
-    m_PersistentCalls:
-      m_Calls: []
-  allowSwitchOffWhenIsOn: 1
-  obsolete: 0
-  onClickObsoletedToggle:
-    m_PersistentCalls:
-      m_Calls: []
 --- !u!1 &685346340200097826
 GameObject:
   m_ObjectHideFlags: 0
@@ -397,6 +301,82 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls: []
   m_Sprite: {fileID: 21300000, guid: 808104c7483594cdb8dcfbd83cf135d3, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &1229975619185760025
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1921000551275504750}
+  - component: {fileID: 5735217143203974894}
+  - component: {fileID: 3354536462203538632}
+  m_Layer: 5
+  m_Name: On
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &1921000551275504750
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1229975619185760025}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5349110917511879490}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 20, y: 20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &5735217143203974894
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1229975619185760025}
+  m_CullTransparentMesh: 1
+--- !u!114 &3354536462203538632
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1229975619185760025}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 85e011bc4905b47798ea91e720b5cb09, type: 3}
   m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -701,6 +681,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   horizontalScrollSnap: {fileID: 1410491497850455100}
+  pagePrefab: {fileID: 987965780484511754}
+  togglePrefab: {fileID: 2721243195874376102}
   pages:
   - {fileID: 8073103411037408489}
   - {fileID: 7817409677114042399}
@@ -708,7 +690,7 @@ MonoBehaviour:
   toggles:
   - {fileID: 5291125239276681634}
   - {fileID: 940843715218672241}
-  - {fileID: 1386934892773198945}
+  - {fileID: 2721243195874376102}
   previousButton: {fileID: 2278718630565755579}
   nextButton: {fileID: 8309135660611987716}
   content: {fileID: 3844220628838777930}
@@ -1740,6 +1722,82 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &4739243154281070715
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3511203211412980815}
+  - component: {fileID: 6823674125972303619}
+  - component: {fileID: 4010278392503090548}
+  m_Layer: 5
+  m_Name: Off
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3511203211412980815
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4739243154281070715}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5349110917511879490}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 20, y: 20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &6823674125972303619
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4739243154281070715}
+  m_CullTransparentMesh: 1
+--- !u!114 &4010278392503090548
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4739243154281070715}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 808104c7483594cdb8dcfbd83cf135d3, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &4910536303979043265
 GameObject:
   m_ObjectHideFlags: 0
@@ -1772,7 +1830,7 @@ RectTransform:
   m_Children:
   - {fileID: 9185807188950369156}
   - {fileID: 4900163458372334229}
-  - {fileID: 5538965599936049871}
+  - {fileID: 5349110917511879490}
   m_Father: {fileID: 1570046419411546279}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -1917,6 +1975,7 @@ MonoBehaviour:
   onClickObsoletedToggle:
     m_PersistentCalls:
       m_Calls: []
+  colorTransitionGraphics: []
 --- !u!1 &5021964201151666584
 GameObject:
   m_ObjectHideFlags: 0
@@ -2188,7 +2247,7 @@ MonoBehaviour:
   line: {fileID: 1060036509124944832}
   line2: {fileID: 8744597092636431191}
   background: {fileID: 6322705218894708167}
---- !u!1 &6163583598112947295
+--- !u!1 &6269730819212548178
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -2196,74 +2255,96 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 2591271467597141221}
-  - component: {fileID: 3511101131967442284}
-  - component: {fileID: 7952470978703026090}
+  - component: {fileID: 5349110917511879490}
+  - component: {fileID: 2721243195874376102}
   m_Layer: 5
-  m_Name: On
+  m_Name: Toggle_2
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!224 &2591271467597141221
+  m_IsActive: 1
+--- !u!224 &5349110917511879490
 RectTransform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6163583598112947295}
+  m_GameObject: {fileID: 6269730819212548178}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 5538965599936049871}
-  m_RootOrder: 1
+  m_Children:
+  - {fileID: 3511203211412980815}
+  - {fileID: 1921000551275504750}
+  m_Father: {fileID: 4636111770855141660}
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 20, y: 20}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &3511101131967442284
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6163583598112947295}
-  m_CullTransparentMesh: 1
---- !u!114 &7952470978703026090
+--- !u!114 &2721243195874376102
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6163583598112947295}
+  m_GameObject: {fileID: 6269730819212548178}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Script: {fileID: 11500000, guid: 090a3247e50b4ac2929c086464b5cfbb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 0
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 0}
+  toggleTransition: 1
+  graphic: {fileID: 0}
+  m_Group: {fileID: 5057743806923120894}
+  onValueChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 85e011bc4905b47798ea91e720b5cb09, type: 3}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
+  m_IsOn: 0
+  offObject: {fileID: 4739243154281070715}
+  onObject: {fileID: 1229975619185760025}
+  onClickToggle:
+    m_PersistentCalls:
+      m_Calls: []
+  allowSwitchOffWhenIsOn: 1
+  obsolete: 0
+  onClickObsoletedToggle:
+    m_PersistentCalls:
+      m_Calls: []
+  colorTransitionGraphics: []
 --- !u!1 &6280981836036877327
 GameObject:
   m_ObjectHideFlags: 0
@@ -2465,7 +2546,7 @@ MonoBehaviour:
       m_Calls: []
 --- !u!95 &102492005755684367
 Animator:
-  serializedVersion: 4
+  serializedVersion: 5
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -2482,7 +2563,8 @@ Animator:
   m_WarningMessage: 
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
-  m_KeepAnimatorControllerStateOnDisable: 0
+  m_KeepAnimatorStateOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 0
 --- !u!114 &84402949730429780
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2552,82 +2634,6 @@ RectTransform:
   m_AnchoredPosition: {x: -329.93326, y: 85.29999}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0, y: 0.5}
---- !u!1 &8424517765836357533
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 935775654647491397}
-  - component: {fileID: 5141106747125134968}
-  - component: {fileID: 7926950165885944683}
-  m_Layer: 5
-  m_Name: Off
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &935775654647491397
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8424517765836357533}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 5538965599936049871}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 20, y: 20}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &5141106747125134968
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8424517765836357533}
-  m_CullTransparentMesh: 1
---- !u!114 &7926950165885944683
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8424517765836357533}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 808104c7483594cdb8dcfbd83cf135d3, type: 3}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &8628574648842623181
 GameObject:
   m_ObjectHideFlags: 0
@@ -2801,6 +2807,7 @@ MonoBehaviour:
   onClickObsoletedToggle:
     m_PersistentCalls:
       m_Calls: []
+  colorTransitionGraphics: []
 --- !u!1 &9080506522377865273
 GameObject:
   m_ObjectHideFlags: 0

--- a/nekoyume/Assets/_Scripts/Helper/SpriteHelper.cs
+++ b/nekoyume/Assets/_Scripts/Helper/SpriteHelper.cs
@@ -174,16 +174,48 @@ namespace Nekoyume.Helper
 
         public static Sprite GetWorldMapBackground(string imageKey, int pageIndex)
         {
+            // 먼저 주어진 페이지 인덱스로 시도
             var path = string.Format(WorldmapBackgroundPathFormat, imageKey, pageIndex);
             var sprite = Resources.Load<Sprite>(path);
             if (sprite)
             {
                 return sprite;
             }
+            
+            // 리소스가 없고 페이지 인덱스가 3을 초과하는 경우
+            if (pageIndex > 3)
+            {
+                // 페이지 인덱스를 1-3 범위로 순환
+                int cyclicPageIndex = ((pageIndex - 1) % 3) + 1;
+                
+                // 순환된 인덱스로 다시 시도
+                path = string.Format(WorldmapBackgroundPathFormat, imageKey, cyclicPageIndex);
+                sprite = Resources.Load<Sprite>(path);
+                if (sprite)
+                {
+                    return sprite;
+                }
+                
+                // 기본 경로도 순환된 인덱스로 시도
+                var defaultPath = string.Format(WorldmapBackgroundDefaultPathFormat, cyclicPageIndex);
+                var defaultSprite = Resources.Load<Sprite>(defaultPath);
+                if (defaultSprite)
+                {
+                    return defaultSprite;
+                }
+            }
 
-            var defaultPath = string.Format(WorldmapBackgroundDefaultPathFormat, pageIndex);
-            var defaultSprite = Resources.Load<Sprite>(defaultPath);
-            return defaultSprite;
+            // 원래 페이지 인덱스로 기본 경로 시도
+            var originalDefaultPath = string.Format(WorldmapBackgroundDefaultPathFormat, pageIndex);
+            var originalDefaultSprite = Resources.Load<Sprite>(originalDefaultPath);
+            
+            // 그래도 없으면 첫 번째 페이지 기본 이미지로 폴백
+            if (originalDefaultSprite == null && pageIndex != 1)
+            {
+                return Resources.Load<Sprite>(string.Format(WorldmapBackgroundDefaultPathFormat, 1));
+            }
+            
+            return originalDefaultSprite;
         }
 
         public static Sprite GetDialogPortrait(string key, bool isNPC = true)

--- a/nekoyume/Assets/_Scripts/UI/Module/WorldMap/WorldMapStage.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/WorldMap/WorldMapStage.cs
@@ -98,9 +98,10 @@ namespace Nekoyume.UI.Module
 
         private void Awake()
         {
-            _normalImageScale = normalImage.transform.localScale;
-            _disabledImageScale = disabledImage.transform.localScale;
-            _selectedImageScale = selectedImage.transform.localScale;
+            // 동적 생성시 스케일이 0.7f로 줄어들어서 최소 스케일을 0.7f로 설정
+            _normalImageScale = Vector3.Max(normalImage.transform.localScale, new Vector3(0.7f, 0.7f, 1f));
+            _disabledImageScale = Vector3.Max(disabledImage.transform.localScale, new Vector3(0.7f, 0.7f, 1f));
+            _selectedImageScale = Vector3.Max(selectedImage.transform.localScale, new Vector3(0.7f, 0.7f, 1f));
 
             button.OnClickAsObservable()
                 .Subscribe(_ =>
@@ -250,9 +251,10 @@ namespace Nekoyume.UI.Module
 
         private void ResetScale()
         {
-            normalImage.transform.localScale = _normalImageScale;
-            disabledImage.transform.localScale = _disabledImageScale;
-            selectedImage.transform.localScale = _selectedImageScale;
+            // 동적 생성시 스케일이 0.7f로 줄어들어서 최소 스케일을 0.7f로 설정
+            normalImage.transform.localScale = Vector3.Max(_normalImageScale, new Vector3(0.7f, 0.7f, 1f));
+            disabledImage.transform.localScale = Vector3.Max(_disabledImageScale, new Vector3(0.7f, 0.7f, 1f));
+            selectedImage.transform.localScale = Vector3.Max(_selectedImageScale, new Vector3(0.7f, 0.7f, 1f));
         }
 
         private void SetScale(float scale)

--- a/nekoyume/Assets/_Scripts/UI/Module/WorldMap/WorldMapWorld.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/WorldMap/WorldMapWorld.cs
@@ -307,12 +307,10 @@ namespace Nekoyume.UI.Module
                         // StageInformation 위젯에 이벤트 연결
                         ConnectStageToStageInformation(stage);
                     }
-                    
-                    Debug.Log($"페이지 동적 생성: 현재 {pages.Count}개");
                 }
                 else
                 {
-                    Debug.LogError("페이지 프리팹이 설정되지 않았습니다.");
+                    NcDebug.LogError("페이지 프리팹이 설정되지 않았습니다.");
                     break;
                 }
             }
@@ -352,11 +350,10 @@ namespace Nekoyume.UI.Module
                     });
                     
                     toggles.Add(newToggle);
-                    Debug.Log($"토글 동적 생성: 현재 {toggles.Count}개");
                 }
                 else
                 {
-                    Debug.LogError("토글 프리팹이 설정되지 않았습니다.");
+                    NcDebug.LogError("토글 프리팹이 설정되지 않았습니다.");
                     break;
                 }
             }

--- a/nekoyume/Assets/_Scripts/UI/Widget/StageInformation.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/StageInformation.cs
@@ -91,11 +91,7 @@ namespace Nekoyume.UI
 
             foreach (var stage in world.Pages.SelectMany(page => page.Stages))
             {
-                stage.onClick.Subscribe(worldMapStage =>
-                {
-                    _sharedViewModel.SelectedStageId.Value =
-                        worldMapStage.SharedViewModel.stageId;
-                }).AddTo(gameObject);
+                stage.onClick.Subscribe(worldMapStage => SelectStage(worldMapStage)).AddTo(gameObject);
             }
 
             submitButton.OnSubmitSubject
@@ -448,6 +444,11 @@ namespace Nekoyume.UI
                 default:
                     throw new ArgumentOutOfRangeException();
             }
+        }
+
+        public void SelectStage(WorldMapStage worldMapStage)
+        {
+            _sharedViewModel.SelectedStageId.Value = worldMapStage.SharedViewModel.stageId;
         }
     }
 }


### PR DESCRIPTION
# 월드맵 페이지 및 토글 동적 관리 개선

## 변경 사항 요약
1. 월드맵의 페이지와 토글을 요구사항에 맞게 동적으로 생성하고 관리하는 기능을 추가했습니다.
2. 페이지 인덱스가 3을 초과할 때 배경 이미지가 1~3 범위에서 순환되도록 수정했습니다.
3. 동적으로 생성된 페이지의 스테이지 버튼에 이벤트 핸들러 연결 기능을 개선했습니다.

## 주요 변경 내용

### WorldMapWorld.cs
- `EnsureEnoughPagesAndToggles()` 메서드 추가: 요구사항에 따라 페이지와 토글을 동적으로 생성/관리합니다.
- 필요한 경우 새 페이지와 토글을 생성하고, 요구사항보다 많은 경우 비활성화 처리합니다.
- 새 페이지의 스테이지 버튼에 이벤트 핸들러를 연결하여 기존 페이지와 동일하게 동작하도록 했습니다.
- 토글 그룹을 적절히 처리하여 활성화된 페이지 토글만 포함되도록 했습니다.

### SpriteHelper.cs
- `GetWorldMapBackground()` 메서드 수정: 페이지 인덱스가 3을 초과하고 해당 리소스가 없을 때 1~3 범위 내에서 순환되도록 처리했습니다.
- 원본 리소스가 있으면 그대로 사용하고, 없을 때만 순환 처리하여 호환성을 유지했습니다.

### StageInformation.cs
- 월드맵의 스테이지 버튼과 StageInformation 위젯 간의 이벤트 연결 코드를 개선했습니다.
- 새로 추가된 페이지의 스테이지 버튼에도 이벤트 핸들러가 연결되도록 개선했습니다.

## 개선 효과
1. 페이지와 토글 수를 자동으로 관리하여 다양한 스테이지 수에 유연하게 대응할 수 있습니다.
2. 페이지가 3개를 초과해도 배경 이미지가 제대로 표시됩니다.
3. 모든 스테이지 버튼이 올바르게 동작하여 UI의 일관성이 유지됩니다.
4. 불필요한 게임 오브젝트를 비활성화하여 리소스 사용을 최적화했습니다.

이 변경으로 월드맵 UI가 더 유연하게 작동하며 확장성이 개선되었습니다.
다만 이는 10자리숫자로 끊는 것만 유효합니다.
