### PR TITLE
fix worldboss reddot

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Widget/WorldBoss.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/WorldBoss.cs
@@ -165,7 +165,7 @@ namespace Nekoyume.UI
 
             if (preRaiderState is null)
             {
-                notification.SetActive(false);
+                notification.SetActive(_hasGradeRewards);
                 return;
             }
 


### PR DESCRIPTION
This pull request includes a small change to the `SetRedDot` method in the `WorldBoss` widget. The change ensures that the notification is activated based on the `_hasGradeRewards` condition instead of being deactivated when `preRaiderState` is null.

* [`nekoyume/Assets/_Scripts/UI/Widget/WorldBoss.cs`](diffhunk://#diff-1bbeabcbc8597da73ad8a9d4766cf6dacd1a234e584ce9fcf807f099e2646560L168-R168): Modified the `SetRedDot` method to activate the notification based on `_hasGradeRewards` when `preRaiderState` is null.


pre raid state가 없는 경우에도 red-dot이 정상적으로 출력되도록 수정 