### PR TITLE
remove world boss mail

### DIFF
--- a/nekoyume/Assets/_Scripts/Blockchain/ActionRenderHandler.cs
+++ b/nekoyume/Assets/_Scripts/Blockchain/ActionRenderHandler.cs
@@ -3448,34 +3448,27 @@ namespace Nekoyume.Blockchain
             Widget.Find<WorldBossRewardScreen>().Show(new LocalRandom(eval.RandomSeed));
         }
 
-        private (ActionEvaluation<ClaimWorldBossReward>, WorldBossRewardMail, AvatarState) PrepareClaimWorldBossReward(
+        private (ActionEvaluation<ClaimWorldBossReward>, AvatarState) PrepareClaimWorldBossReward(
             ActionEvaluation<ClaimWorldBossReward> eval)
         {
             var gameStates = Game.Game.instance.States;
-            var agentAddr = gameStates.AgentState.address;
             var avatarAddr = gameStates.CurrentAvatarState.address;
             var states = eval.OutputState;
             var avatarState = StateGetter.GetAvatarState(states, avatarAddr);
 
-            var mailBox = avatarState.mailBox;
             UpdateCurrentAvatarStateAsync(avatarState).Forget();
-            var mail = mailBox.OfType<WorldBossRewardMail>()
-                .First(r => r.blockIndex == eval.BlockIndex);
-
             UpdateCurrentAvatarRuneStoneBalance(eval);
             UpdateCrystalBalance(eval);
             UpdateCurrentAvatarInventory(eval);
 
-            return (eval, mail, avatarState);
+            return (eval, avatarState);
         }
 
-        private static void ResponseClaimWorldBossReward((ActionEvaluation<ClaimWorldBossReward> eval, WorldBossRewardMail mail, AvatarState avatarState) prepared)
+        private static void ResponseClaimWorldBossReward((ActionEvaluation<ClaimWorldBossReward> eval, AvatarState avatarState) prepared)
         {
             var eval = prepared.eval;
-            var worldBossRewardMail = prepared.mail;
 
             var avatarAddress = Game.Game.instance.States.CurrentAvatarState.address;
-            WorldBossStates.Set(eval.OutputState, eval.BlockIndex, avatarAddress).Forget();
 
             var worldBossReward = Widget.Find<WorldBossDetail>();
             worldBossReward.OnRenderSeasonReward();
@@ -3490,48 +3483,66 @@ namespace Nekoyume.Blockchain
                 return;
             }
 
-            var rewards = new List<MailReward>();
-            if (worldBossRewardMail.FungibleAssetValues is not null)
+            UniTask.Run(async () =>
             {
-                rewards.AddRange(
-                    worldBossRewardMail.FungibleAssetValues.Select(fav =>
-                        new MailReward(fav, fav.MajorUnit)));
-            }
+                var worldBossState = WorldBossStates.GetWorldBossState();
+                await WorldBossStates.Set(eval.OutputState, eval.BlockIndex, avatarAddress);
 
-            if (worldBossRewardMail.Items is not null)
-            {
-                var materialSheet = Game.Game.instance.TableSheets.MaterialItemSheet;
-                var itemSheet = Game.Game.instance.TableSheets.ItemSheet;
-                foreach (var (fungibleId, count) in worldBossRewardMail.Items)
+                var blockIndex = eval.BlockIndex;
+                var worldBossListSheet = Game.Game.instance.TableSheets.WorldBossListSheet;
+                var worldBossContributionRewardSheet = Game.Game.instance.TableSheets.WorldBossContributionRewardSheet;
+                var previousSeasonRow = worldBossListSheet.FindPreviousRowByBlockIndex(blockIndex);
+                var bossId = previousSeasonRow.BossId;
+
+                worldBossState ??= WorldBossStates.GetWorldBossState();
+                var raiderState = WorldBossStates.GetPreRaiderState(avatarAddress);
+                var contribution =
+                    WorldBossHelper.CalculateContribution(worldBossState.TotalDamage,
+                        raiderState.TotalScore);
+
+                var (items, favs) = WorldBossHelper.CalculateContributionReward(worldBossContributionRewardSheet[bossId], contribution);
+
+                var rewards = new List<MailReward>();
+                if (favs is not null)
                 {
-                    var row = materialSheet.OrderedList!.FirstOrDefault(row => row.Id.Equals(fungibleId));
-                    if (row != null)
-                    {
-                        var material = ItemFactory.CreateMaterial(row);
-                        rewards.Add(new MailReward(material, count));
-                        continue;
-                    }
-
-                    row = materialSheet.OrderedList!.FirstOrDefault(row => row.ItemId.Equals(fungibleId));
-                    if (row != null)
-                    {
-                        var material = ItemFactory.CreateMaterial(row);
-                        rewards.Add(new MailReward(material, count));
-                        continue;
-                    }
-
-                    if (itemSheet.TryGetValue(fungibleId, out var itemSheetRow))
-                    {
-                        var item = ItemFactory.CreateItem(itemSheetRow, new ActionRenderHandler.LocalRandom(0));
-                        rewards.Add(new MailReward(item, 1));
-                        continue;
-                    }
-
-                    NcDebug.LogWarning($"Not found material sheet row. {fungibleId}");
+                    rewards.AddRange(favs.Select(fav => new MailReward(fav, fav.MajorUnit)));
                 }
-            }
 
-            Widget.Find<MailRewardScreen>().Show(rewards, "UI_IAP_PURCHASE_DELIVERY_COMPLETE_POPUP_TITLE");
+                if (items is not null)
+                {
+                    var materialSheet = Game.Game.instance.TableSheets.MaterialItemSheet;
+                    var itemSheet = Game.Game.instance.TableSheets.ItemSheet;
+                    foreach (var (fungibleId, count) in items)
+                    {
+                        var row = materialSheet.OrderedList!.FirstOrDefault(row => row.Id.Equals(fungibleId));
+                        if (row != null)
+                        {
+                            var material = ItemFactory.CreateMaterial(row);
+                            rewards.Add(new MailReward(material, count));
+                            continue;
+                        }
+
+                        row = materialSheet.OrderedList!.FirstOrDefault(row => row.ItemId.Equals(fungibleId));
+                        if (row != null)
+                        {
+                            var material = ItemFactory.CreateMaterial(row);
+                            rewards.Add(new MailReward(material, count));
+                            continue;
+                        }
+
+                        if (itemSheet.TryGetValue(fungibleId, out var itemSheetRow))
+                        {
+                            var item = ItemFactory.CreateItem(itemSheetRow, new ActionRenderHandler.LocalRandom(0));
+                            rewards.Add(new MailReward(item, 1));
+                            continue;
+                        }
+
+                        NcDebug.LogWarning($"Not found material sheet row. {fungibleId}");
+                    }
+                }
+
+                Widget.Find<MailRewardScreen>().Show(rewards, "UI_IAP_PURCHASE_DELIVERY_COMPLETE_POPUP_TITLE");
+            });
         }
 
         private (ActionEvaluation<RuneEnhancement>, FungibleAssetValue runeStone, AllRuneState previousState)


### PR DESCRIPTION
+ 아에 새로운 월드보스 시즌이 시작되기 전까지 worldBossState의 값은 바뀌지 않는 걸로 보여 새로 클라이언트에 캐싱된 worldBossState를 업데이트 하기 전에 worldBossState를 미리 가져온 다음 해당 값이 null이면 상태 업데이트 후 다시 가져오는걸로 구현해두었습니다.

This pull request includes significant changes to the `ActionRenderHandler` and `WorldBossStates` classes, focusing on refactoring and improving the handling of world boss rewards and states. The most important changes include removing the `WorldBossRewardMail` dependency, adding new methods for state retrieval, and replacing `Task` with `UniTask` for asynchronous operations.

Refactoring and dependency removal:

* [`nekoyume/Assets/_Scripts/Blockchain/ActionRenderHandler.cs`](diffhunk://#diff-0f08e40ec628cdd4aa728e0b0b4cff7bf842254e3ba68679d2883d0569ac14a2L3451-L3478): Removed the dependency on `WorldBossRewardMail` in the `PrepareClaimWorldBossReward` and `ResponseClaimWorldBossReward` methods. [[1]](diffhunk://#diff-0f08e40ec628cdd4aa728e0b0b4cff7bf842254e3ba68679d2883d0569ac14a2L3451-L3478) [[2]](diffhunk://#diff-0f08e40ec628cdd4aa728e0b0b4cff7bf842254e3ba68679d2883d0569ac14a2R3486-R3515) [[3]](diffhunk://#diff-0f08e40ec628cdd4aa728e0b0b4cff7bf842254e3ba68679d2883d0569ac14a2R3545)

New methods for state retrieval:

* [`nekoyume/Assets/_Scripts/UI/Module/WorldBoss/WorldBossStates.cs`](diffhunk://#diff-0a7c0fd6da4a74c76011d88a7baf7280dd01fbdeab4969e07c5667c021fe9a2bR72-R76): Added `GetWorldBossState` method to retrieve the current world boss state.

Asynchronous operations improvement:

* [`nekoyume/Assets/_Scripts/UI/Module/WorldBoss/WorldBossStates.cs`](diffhunk://#diff-0a7c0fd6da4a74c76011d88a7baf7280dd01fbdeab4969e07c5667c021fe9a2bL217-R222): Replaced `Task` with `UniTask` for better performance and consistency in asynchronous methods, including `IsExistGradeReward` and `GetDataAsync`. [[1]](diffhunk://#diff-0a7c0fd6da4a74c76011d88a7baf7280dd01fbdeab4969e07c5667c021fe9a2bL217-R222) [[2]](diffhunk://#diff-0a7c0fd6da4a74c76011d88a7baf7280dd01fbdeab4969e07c5667c021fe9a2bL227-L228) [[3]](diffhunk://#diff-0a7c0fd6da4a74c76011d88a7baf7280dd01fbdeab4969e07c5667c021fe9a2bR251) [[4]](diffhunk://#diff-0a7c0fd6da4a74c76011d88a7baf7280dd01fbdeab4969e07c5667c021fe9a2bR275-L285) [[5]](diffhunk://#diff-0a7c0fd6da4a74c76011d88a7baf7280dd01fbdeab4969e07c5667c021fe9a2bR305) [[6]](diffhunk://#diff-0a7c0fd6da4a74c76011d88a7baf7280dd01fbdeab4969e07c5667c021fe9a2bL321-R323)

Submodule update:

* [`nekoyume/Assets/_Scripts/Lib9c/lib9c`](diffhunk://#diff-69e7ba47b0c3c67ae4b931d5d0adad68ba8e4d6c4ed90ae1c52e246f9c5fbf71L1-R1): Updated the submodule commit to the latest version.