### PR TITLE
updaer init services

### DIFF
--- a/nekoyume/Assets/_Scripts/Multiplanetary/PlanetSelector.cs
+++ b/nekoyume/Assets/_Scripts/Multiplanetary/PlanetSelector.cs
@@ -355,23 +355,23 @@ namespace Nekoyume.Multiplanetary
             clo.RpcServerPort = uri.Port;
 
             // FIXME: Other hosts are selected randomly for now.
-            clo.ApiServerHost = rpcEndpoints.DataProviderGql.Count > 0
+            clo.ApiServerHost = rpcEndpoints.DataProviderGql?.Count > 0
                 ? rpcEndpoints.DataProviderGql[Random.Range(0, rpcEndpoints.DataProviderGql.Count)]
                 : null;
-            clo.MarketServiceHost = rpcEndpoints.MarketRest.Count > 0
+            clo.MarketServiceHost = rpcEndpoints.MarketRest?.Count > 0
                 ? rpcEndpoints.MarketRest[Random.Range(0, rpcEndpoints.MarketRest.Count)]
                 : null;
-            clo.OnBoardingHost = rpcEndpoints.WorldBossRest.Count > 0
+            clo.OnBoardingHost = rpcEndpoints.WorldBossRest?.Count > 0
                 ? rpcEndpoints.WorldBossRest[Random.Range(0, rpcEndpoints.WorldBossRest.Count)]
                 : null;
-            clo.ArenaServiceHost = rpcEndpoints.ArenaRest.Count > 0
+            clo.ArenaServiceHost = rpcEndpoints.ArenaRest?.Count > 0
                 ? rpcEndpoints.ArenaRest[Random.Range(0, rpcEndpoints.ArenaRest.Count)]
                 : null;
-            clo.MimirServiceHost = rpcEndpoints.MimirGql.Count > 0
+            clo.MimirServiceHost = rpcEndpoints.MimirGql?.Count > 0
                 ? rpcEndpoints.MimirGql[Random.Range(0, rpcEndpoints.MimirGql.Count)]
                 : null;
 
-            clo.GuildServiceUrl = rpcEndpoints.GuildRest.Any()
+            clo.GuildServiceUrl = rpcEndpoints.GuildRest?.Any() ?? false
                 ? rpcEndpoints.GuildRest.First()
                 : clo.GuildServiceUrl;
 


### PR DESCRIPTION
This pull request includes changes to the `UpdateCommandLineOptions` method in the `PlanetSelector.cs` file to improve null safety. The changes ensure that the code does not throw a `NullReferenceException` when accessing properties of `rpcEndpoints`.

Improvements to null safety:

* [`nekoyume/Assets/_Scripts/Multiplanetary/PlanetSelector.cs`](diffhunk://#diff-d3dbcd944b7797a9393f644f9cb8148382ee15bcc00eaa890f851f807fe60578L358-R374): Modified the conditions to use the null-conditional operator (`?.`) and the null-coalescing operator (`??`) to safely check for null values before accessing the properties of `rpcEndpoints`.