### PR TITLE
build ubuntu version update

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -157,7 +157,7 @@ jobs:
       || github.ref == 'refs/heads/preview'
       || startsWith(github.event.ref, 'refs/tags/')
       )
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         targetPlatform:
@@ -207,7 +207,7 @@ jobs:
       || github.ref == 'refs/heads/preview'
       || startsWith(github.event.ref, 'refs/tags/')
       )
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: [ extract, release ]
     environment:
       name: ${{ needs.extract.outputs.network }}


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflow configuration to use a newer version of the Ubuntu runner.

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L160-R160): Updated the `runs-on` parameter from `ubuntu-20.04` to `ubuntu-24.04` in two places to ensure the workflow uses the latest Ubuntu version. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L160-R160) [[2]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L210-R210)