### PR TITLE
fix enhancement inventory filter size delta

### DIFF
--- a/nekoyume/Assets/AddressableAssets/UI/Module/EnhancementInventory.prefab
+++ b/nekoyume/Assets/AddressableAssets/UI/Module/EnhancementInventory.prefab
@@ -11613,7 +11613,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 5}
-  m_SizeDelta: {x: 0, y: 300}
+  m_SizeDelta: {x: 0, y: 350}
   m_Pivot: {x: 0.5, y: 0}
 --- !u!114 &4049058945997509844
 MonoBehaviour:


### PR DESCRIPTION
This pull request includes a minor adjustment to the `EnhancementInventory.prefab` file in the `RectTransform` configuration. The `m_SizeDelta` property was updated to increase the height of the UI element.

* [`nekoyume/Assets/AddressableAssets/UI/Module/EnhancementInventory.prefab`](diffhunk://#diff-60a5c25bcdf27a542ed97f3f59d07f408a37dac287f2b4735eaa758b46e08d5bL11616-R11616): Changed `m_SizeDelta` from `{x: 0, y: 300}` to `{x: 0, y: 350}` to increase the vertical size of the UI element.