### PR TITLE
fix main net notice

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Widget/EventBanner.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/EventBanner.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using Cysharp.Threading.Tasks;
 using Nekoyume.Game.LiveAsset;
 using Nekoyume.UI.Module.Common;
 
@@ -29,9 +30,10 @@ namespace Nekoyume.UI.Module
         [SerializeField]
         private PageView pageView;
 
-        private IEnumerator Start()
+        private async UniTask InitializeAsync()
         {
-            yield return new WaitUntil(() => LiveAssetManager.instance.IsInitialized);
+            await LiveAssetManager.instance.InitializeEventAsync();
+            await UniTask.WaitUntil(() => LiveAssetManager.instance.IsInitialized);
 
             var dataList = LiveAssetManager.instance.BannerData;
             foreach (var data in dataList)
@@ -64,10 +66,12 @@ namespace Nekoyume.UI.Module
         public override void Show(bool ignoreShowAnimation = false)
         {
             base.Show(ignoreShowAnimation);
+
             if (!LiveAssetManager.instance.IsInitialized)
             {
-                LiveAssetManager.instance.InitializeEvent();
+                InitializeAsync().Forget();
             }
+
 #if UNITY_ANDROID || UNITY_IOS
             transform.SetSiblingIndex(Find<LobbyMenu>().transform.GetSiblingIndex()+1);
 #endif


### PR DESCRIPTION
This pull request refactors the initialization logic in the `LiveAssetManager` and `EventBanner` classes to improve asynchronous handling and ensure better code maintainability. The most significant changes include converting coroutine-based methods to use `UniTask`, renaming variables for consistency, and updating the `EventBanner` initialization process.

### Refactoring to `UniTask` for Asynchronous Operations:
* Converted `InitializeEvent` to an asynchronous method `InitializeEventAsync` using `UniTask`, replacing coroutine-based calls with `UniTask.WhenAll` for parallel asynchronous operations. (`LiveAssetManager.cs`, [[1]](diffhunk://#diff-f6e54e53a3bf13357244a21a674ac3f4511c1a7e3a50a7d27ed69408f6d4ac51L104-R103) [[2]](diffhunk://#diff-f6e54e53a3bf13357244a21a674ac3f4511c1a7e3a50a7d27ed69408f6d4ac51L120-R122)
* Updated the `Start` method in `EventBanner` to `InitializeAsync`, utilizing `UniTask` for asynchronous initialization of event data. (`EventBanner.cs`, [nekoyume/Assets/_Scripts/UI/Widget/EventBanner.csL32-R36](diffhunk://#diff-50574043bf0484ccf21a7b4a6bbeab617bacf4d9a1396ba54c5035c780828b11L32-R36))

### Code Consistency Improvements:
* Renamed the variable `isMainnet` to `isMainNet` for consistent naming convention across the codebase. (`LiveAssetManager.cs`, [[1]](diffhunk://#diff-f6e54e53a3bf13357244a21a674ac3f4511c1a7e3a50a7d27ed69408f6d4ac51L281-R282) [[2]](diffhunk://#diff-f6e54e53a3bf13357244a21a674ac3f4511c1a7e3a50a7d27ed69408f6d4ac51L306-R307)

### EventBanner Initialization Enhancements:
* Modified the `Show` method in `EventBanner` to call `InitializeAsync` with `.Forget()` if the `LiveAssetManager` is not yet initialized, ensuring proper asynchronous initialization. (`EventBanner.cs`, [nekoyume/Assets/_Scripts/UI/Widget/EventBanner.csR69-R74](diffhunk://#diff-50574043bf0484ccf21a7b4a6bbeab617bacf4d9a1396ba54c5035c780828b11R69-R74))

### Dependency Updates:
* Added a new `using` directive for `Cysharp.Threading.Tasks` in `EventBanner.cs` to support `UniTask` usage. (`EventBanner.cs`, [nekoyume/Assets/_Scripts/UI/Widget/EventBanner.csR7](diffhunk://#diff-50574043bf0484ccf21a7b4a6bbeab617bacf4d9a1396ba54c5035c780828b11R7))