### PR TITLE
fix ShowManyWorldUnlockPopup

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Widget/WorldMap.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/WorldMap.cs
@@ -423,35 +423,80 @@ namespace Nekoyume.UI
 
         private bool ShowManyWorldUnlockPopup(WorldInformation worldInformation)
         {
-            if (worldInformation.TryGetLastClearedStageId(out var stageId))
+            if (!worldInformation.TryGetLastClearedStageId(out var stageId))
             {
-                var tableSheets = TableSheets.Instance;
-                var countOfCanUnlockWorld = Math.Min(stageId / 50,
-                    tableSheets.WorldUnlockSheet.Count - 1);
-                var worldIdListForUnlock = Enumerable.Range(2, countOfCanUnlockWorld)
-                    .Where(i => !SharedViewModel.UnlockedWorldIds.Contains(i))
-                    .ToList();
-
-                if (worldIdListForUnlock.Count > 1)
-                {
-                    var paymentPopup = Find<PaymentPopup>();
-                    var cost = CrystalCalculator.CalculateWorldUnlockCost(worldIdListForUnlock,
-                        tableSheets.WorldUnlockSheet).MajorUnit;
-                    paymentPopup.ShowCheckPaymentCrystal(
-                        States.Instance.CrystalBalance.MajorUnit,
-                        cost,
-                        L10nManager.Localize("CRYSTAL_MIGRATION_WORLD_ALL_OPEN_FORMAT", cost),
-                        () =>
-                        {
-                            Find<LoadingScreen>().Show(LoadingScreen.LoadingType.WorldUnlock);
-                            ActionManager.Instance.UnlockWorld(worldIdListForUnlock, (int)cost)
-                                .Subscribe();
-                        });
-                    return true;
-                }
+                return false;
             }
 
-            return false;
+            var stageGap = 50;
+            var worldSheet = TableSheets.Instance.WorldSheet;
+            var currentWorld = worldSheet?
+                .OrderedList?
+                .FirstOrDefault(row => row.StageBegin <= stageId && row.StageEnd >= stageId);
+
+            if (currentWorld is not null)
+            {
+                stageGap = currentWorld.StageEnd - currentWorld.StageBegin + 1;
+            }
+
+            var tableSheets = TableSheets.Instance;
+            var countOfCanUnlockWorld = Math.Min(stageId / stageGap,
+                tableSheets.WorldUnlockSheet.Count - 1);
+            var worldIdListForUnlock = Enumerable.Range(2, countOfCanUnlockWorld)
+                .Where(i => !SharedViewModel.UnlockedWorldIds.Contains(i))
+                .ToList();
+
+            if (worldIdListForUnlock.Count <= 1)
+            {
+                return false;
+            }
+
+            var paymentPopup = Find<PaymentPopup>();
+            var cost = CrystalCalculator.CalculateWorldUnlockCost(worldIdListForUnlock,
+                tableSheets.WorldUnlockSheet).MajorUnit;
+            paymentPopup.ShowCheckPaymentCrystal(
+                States.Instance.CrystalBalance.MajorUnit,
+                cost,
+                L10nManager.Localize("CRYSTAL_MIGRATION_WORLD_ALL_OPEN_FORMAT", cost),
+                () =>
+                {
+                    Find<LoadingScreen>().Show(LoadingScreen.LoadingType.WorldUnlock);
+                    ActionManager.Instance.UnlockWorld(worldIdListForUnlock, (int)cost)
+                        .Subscribe();
+                });
+
+            return true;
+        }
+
+        private int GetCountOfCanUnlockWorld(int stageId)
+        {
+            var countOfCanUnlockWorld = 0;
+            var copyOfStageId = stageId;
+
+            while(copyOfStageId > 0)
+            {
+                var stageGap = GetStageGap(copyOfStageId);
+                copyOfStageId -= stageGap;
+                countOfCanUnlockWorld++;
+            }
+
+            return countOfCanUnlockWorld;
+        }
+
+        private int GetStageGap(int stageId)
+        {
+            var stageGap = 50;
+            var worldSheet = TableSheets.Instance.WorldSheet;
+            var currentWorld = worldSheet?
+                .OrderedList?
+                .FirstOrDefault(row => row.StageBegin <= stageId && row.StageEnd >= stageId);
+
+            if (currentWorld is not null)
+            {
+                stageGap = currentWorld.StageEnd - currentWorld.StageBegin + 1;
+            }
+
+            return stageGap;
         }
 
         private void SetWorldOpenCostTextColor(FungibleAssetValue crystal)

--- a/nekoyume/Assets/_Scripts/UI/Widget/WorldMap.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/WorldMap.cs
@@ -491,10 +491,20 @@ namespace Nekoyume.UI
                 .OrderedList?
                 .FirstOrDefault(row => row.StageBegin <= stageId && row.StageEnd >= stageId);
 
-            if (currentWorld is not null)
+            if (currentWorld is null)
             {
-                stageGap = currentWorld.StageEnd - currentWorld.StageBegin + 1;
+                return stageGap;
             }
+
+            stageGap = currentWorld.StageEnd - currentWorld.StageBegin + 1;
+
+            if (stageGap > 0)
+            {
+                return stageGap;
+            }
+
+            NcDebug.LogWarning($"Invalid stage gap computed: {stageGap}. Using default value of 50.");
+            stageGap = 50;
 
             return stageGap;
         }


### PR DESCRIPTION
This pull request refactors the logic for determining the number of worlds that can be unlocked and introduces helper methods to improve code readability and maintainability in the `WorldMap` class. The changes focus on modularizing calculations and ensuring consistent behavior when determining stage gaps and unlockable worlds.

### Refactoring and modularization:

* **Refactored `ShowManyWorldUnlockPopup` logic**: Adjusted the condition to return early if the last cleared stage ID is not found or if fewer than two worlds can be unlocked. The calculation for the number of unlockable worlds now uses a dynamic `stageGap` instead of a fixed value. (`[nekoyume/Assets/_Scripts/UI/Widget/WorldMap.csL426-R453](diffhunk://#diff-11f2bed614853e5f068842566577382f6c2d481522edb0218f5da0746eac41a3L426-R453)`)
* **Introduced `GetCountOfCanUnlockWorld` method**: Added a helper method to calculate the number of worlds that can be unlocked based on the stage ID, iterating through stage gaps dynamically. (`[nekoyume/Assets/_Scripts/UI/Widget/WorldMap.csR467-R499](diffhunk://#diff-11f2bed614853e5f068842566577382f6c2d481522edb0218f5da0746eac41a3R467-R499)`)
* **Introduced `GetStageGap` method**: Added a helper method to determine the stage gap dynamically based on the current world configuration, replacing the previous fixed value of 50. (`[nekoyume/Assets/_Scripts/UI/Widget/WorldMap.csR467-R499](diffhunk://#diff-11f2bed614853e5f068842566577382f6c2d481522edb0218f5da0746eac41a3R467-R499)`)