### PR TITLE
add WORLD_NAME_VANAHEIM

### DIFF
--- a/nekoyume/Assets/StreamingAssets/Localization/world_name.csv
+++ b/nekoyume/Assets/StreamingAssets/Localization/world_name.csv
@@ -21,3 +21,4 @@ DUNGEON","EVENT
 DUNGEON","EVENT
 DUNGEON"
 WORLD_NAME_HEL,Helheim,헬헤임,Helheim,ヘルヘイム,Helheim,Helheim,Helheim,Helheim,Helheim,Helheim,Helheim,Helheim
+WORLD_NAME_VANAHEIM,Vanaheim,바나헤임,Vanaheim,ヴァナハイム,Vanaheim,Vanaheim,Vanaheim,Vanaheim,Vanaheim,Vanaheim,Vanaheim,Vanaheim

--- a/nekoyume/Assets/_Scripts/L10n/L10nManager.cs
+++ b/nekoyume/Assets/_Scripts/L10n/L10nManager.cs
@@ -548,6 +548,7 @@ namespace Nekoyume.L10n
                 6 => Localize("WORLD_NAME_JOTUNHEIM"),
                 7 => Localize("WORLD_NAME_NIFLHEIM"),
                 8 => Localize("WORLD_NAME_HEL"),
+                9 => Localize("WORLD_NAME_VANAHEIM"),
                 10001 => Localize("WORLD_NAME_MIMISBRUNNR"),
                 _ => $"Invalid_World_ID_{worldId}"
             };

--- a/nekoyume/nekoyume.sln.DotSettings
+++ b/nekoyume/nekoyume.sln.DotSettings
@@ -92,5 +92,6 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Unlockable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Unrender/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Unrendered/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=VANAHEIM/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=vanaheimr/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=WORLDBOSS/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>


### PR DESCRIPTION
This pull request introduces support for a new world, "Vanaheim," in the game. The changes include adding localization data, updating the world ID mapping, and extending the user dictionary for spell-checking.

### Localization Updates:
* Added "Vanaheim" (`WORLD_NAME_VANAHEIM`) to the localization file `world_name.csv` with translations for multiple languages.

### Code Updates:
* Updated the `LocalizeWorldName` method in `L10nManager.cs` to include a mapping for the world ID `9` to "Vanaheim."

### Configuration Updates:
* Added "VANAHEIM" to the user dictionary in `nekoyume.sln.DotSettings` to ensure proper handling of the term in development tools.