### PR TITLE
fix event release note popup

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Widget/Popup/EventReleaseNotePopup.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Popup/EventReleaseNotePopup.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using Cysharp.Threading.Tasks;
 using Nekoyume.Game.LiveAsset;
 using Nekoyume.UI.Model;
 using Nekoyume.UI.Module;
@@ -91,6 +92,7 @@ namespace Nekoyume.UI
             var liveAssetManager = LiveAssetManager.instance;
             if (!liveAssetManager.IsInitialized || _isInitialized)
             {
+                NcDebug.LogError("LiveAssetManager is not initialized or already initialized.");
                 return;
             }
 
@@ -173,10 +175,21 @@ namespace Nekoyume.UI
             _isInitialized = true;
         }
 
+        private async UniTask InitializeAsync()
+        {
+            if (_isInitialized)
+            {
+                return;
+            }
+
+            await UniTask.WaitUntil(() => LiveAssetManager.instance.IsInitialized);
+            Initialize();
+        }
+
         protected override void OnEnable()
         {
             base.OnEnable();
-            Initialize();
+            InitializeAsync().Forget();
         }
 
         public override void Close(bool ignoreCloseAnimation = false)
@@ -195,8 +208,18 @@ namespace Nekoyume.UI
         {
             if (!_isInitialized)
             {
-                Initialize();
+                ShowAsync(ignoreShowAnimation).Forget();
+                return;
             }
+
+            base.Show(ignoreShowAnimation);
+            OnForceToggleOnEventTab();
+            PlayerPrefs.SetString(LastReadingDayKey, DateTime.Today.ToString(DateTimeFormat));
+        }
+
+        private async UniTask ShowAsync(bool ignoreShowAnimation = false)
+        {
+            await InitializeAsync();
             base.Show(ignoreShowAnimation);
             OnForceToggleOnEventTab();
             PlayerPrefs.SetString(LastReadingDayKey, DateTime.Today.ToString(DateTimeFormat));
@@ -206,8 +229,21 @@ namespace Nekoyume.UI
         {
             if (!_isInitialized)
             {
-                Initialize();
+                ShowAsync(eventNotice, ignoreStartAnimation).Forget();
+                return;
             }
+            base.Show(ignoreStartAnimation);
+            if (!eventTabButton.IsToggledOn)
+            {
+                OnForceToggleOnEventTab();
+            }
+
+            OnClickEventNoticeItem(_eventBannerItems[eventNotice.Description]);
+        }
+
+        private async UniTask ShowAsync(EventNoticeData eventNotice, bool ignoreStartAnimation = false)
+        {
+            await InitializeAsync();
             base.Show(ignoreStartAnimation);
             if (!eventTabButton.IsToggledOn)
             {


### PR DESCRIPTION
This pull request refactors the `EventReleaseNotePopup` class to improve initialization and handling of asynchronous operations. The changes ensure that the popup's dependencies are fully initialized before proceeding with its functionality, using `UniTask` for asynchronous workflows. The most important changes include adding asynchronous initialization and refactoring the `Show` methods to handle these updates.

### Refactoring for Asynchronous Initialization:

* Added `InitializeAsync` method to handle asynchronous initialization of the `LiveAssetManager`. This method waits until the manager is fully initialized before calling the synchronous `Initialize` method. (`[nekoyume/Assets/_Scripts/UI/Widget/Popup/EventReleaseNotePopup.csR178-R192](diffhunk://#diff-bf48ee0a66b8dbc88bb6124513bd04d6afe3aecdd041494083bdd874ea9441faR178-R192)`)

* Updated the `OnEnable` method to call `InitializeAsync` instead of the synchronous `Initialize` method, ensuring proper initialization in an asynchronous context. (`[nekoyume/Assets/_Scripts/UI/Widget/Popup/EventReleaseNotePopup.csR178-R192](diffhunk://#diff-bf48ee0a66b8dbc88bb6124513bd04d6afe3aecdd041494083bdd874ea9441faR178-R192)`)

### Refactoring `Show` Methods:

* Refactored the `Show(bool ignoreShowAnimation)` method to call a new asynchronous `ShowAsync` method if the popup is not initialized. This ensures initialization is completed before proceeding with the `Show` logic. (`[nekoyume/Assets/_Scripts/UI/Widget/Popup/EventReleaseNotePopup.csL198-R222](diffhunk://#diff-bf48ee0a66b8dbc88bb6124513bd04d6afe3aecdd041494083bdd874ea9441faL198-R222)`)

* Refactored the `Show(EventNoticeData eventNotice, bool ignoreStartAnimation)` method to follow a similar pattern, delegating to a new asynchronous `ShowAsync` method when initialization is required. (`[[1]](diffhunk://#diff-bf48ee0a66b8dbc88bb6124513bd04d6afe3aecdd041494083bdd874ea9441faL209-R233)`, `[[2]](diffhunk://#diff-bf48ee0a66b8dbc88bb6124513bd04d6afe3aecdd041494083bdd874ea9441faR244-R255)`)

### Logging and Debugging:

* Added a debug log in the `Initialize` method to notify if the `LiveAssetManager` is not initialized or already initialized, aiding in debugging initialization issues. (`[nekoyume/Assets/_Scripts/UI/Widget/Popup/EventReleaseNotePopup.csR95](diffhunk://#diff-bf48ee0a66b8dbc88bb6124513bd04d6afe3aecdd041494083bdd874ea9441faR95)`)