### PR TITLE
rollback app icon from 1st anniversary

### DIFF
--- a/nekoyume/ProjectSettings/ProjectSettings.asset
+++ b/nekoyume/ProjectSettings/ProjectSettings.asset
@@ -280,7 +280,7 @@ PlayerSettings:
   - m_BuildTarget: 
     m_Icons:
     - serializedVersion: 2
-      m_Icon: {fileID: 2800000, guid: a71884417892512488fc67d2adc5ebeb, type: 3}
+      m_Icon: {fileID: 2800000, guid: d5c1093d54fd27444b163d616ea86348, type: 3}
       m_Width: 128
       m_Height: 128
       m_Kind: 0
@@ -288,231 +288,231 @@ PlayerSettings:
   - m_BuildTarget: iPhone
     m_Icons:
     - m_Textures:
-      - {fileID: 2800000, guid: 56b4c7998f17a334c84291658e1df38d, type: 3}
+      - {fileID: 2800000, guid: e17218f4ab604764e8f36042fecd0c90, type: 3}
       m_Width: 180
       m_Height: 180
       m_Kind: 0
       m_SubKind: iPhone
     - m_Textures:
-      - {fileID: 2800000, guid: 56b4c7998f17a334c84291658e1df38d, type: 3}
+      - {fileID: 2800000, guid: e17218f4ab604764e8f36042fecd0c90, type: 3}
       m_Width: 120
       m_Height: 120
       m_Kind: 0
       m_SubKind: iPhone
     - m_Textures:
-      - {fileID: 2800000, guid: 56b4c7998f17a334c84291658e1df38d, type: 3}
+      - {fileID: 2800000, guid: e17218f4ab604764e8f36042fecd0c90, type: 3}
       m_Width: 167
       m_Height: 167
       m_Kind: 0
       m_SubKind: iPad
     - m_Textures:
-      - {fileID: 2800000, guid: 56b4c7998f17a334c84291658e1df38d, type: 3}
+      - {fileID: 2800000, guid: e17218f4ab604764e8f36042fecd0c90, type: 3}
       m_Width: 152
       m_Height: 152
       m_Kind: 0
       m_SubKind: iPad
     - m_Textures:
-      - {fileID: 2800000, guid: 56b4c7998f17a334c84291658e1df38d, type: 3}
+      - {fileID: 2800000, guid: e17218f4ab604764e8f36042fecd0c90, type: 3}
       m_Width: 76
       m_Height: 76
       m_Kind: 0
       m_SubKind: iPad
     - m_Textures:
-      - {fileID: 2800000, guid: 56b4c7998f17a334c84291658e1df38d, type: 3}
+      - {fileID: 2800000, guid: e17218f4ab604764e8f36042fecd0c90, type: 3}
       m_Width: 120
       m_Height: 120
       m_Kind: 3
       m_SubKind: iPhone
     - m_Textures:
-      - {fileID: 2800000, guid: 56b4c7998f17a334c84291658e1df38d, type: 3}
+      - {fileID: 2800000, guid: e17218f4ab604764e8f36042fecd0c90, type: 3}
       m_Width: 80
       m_Height: 80
       m_Kind: 3
       m_SubKind: iPhone
     - m_Textures:
-      - {fileID: 2800000, guid: 56b4c7998f17a334c84291658e1df38d, type: 3}
+      - {fileID: 2800000, guid: e17218f4ab604764e8f36042fecd0c90, type: 3}
       m_Width: 80
       m_Height: 80
       m_Kind: 3
       m_SubKind: iPad
     - m_Textures:
-      - {fileID: 2800000, guid: 56b4c7998f17a334c84291658e1df38d, type: 3}
+      - {fileID: 2800000, guid: e17218f4ab604764e8f36042fecd0c90, type: 3}
       m_Width: 40
       m_Height: 40
       m_Kind: 3
       m_SubKind: iPad
     - m_Textures:
-      - {fileID: 2800000, guid: 56b4c7998f17a334c84291658e1df38d, type: 3}
-      m_Width: 87
-      m_Height: 87
-      m_Kind: 1
-      m_SubKind: iPhone
+      - {fileID: 2800000, guid: e17218f4ab604764e8f36042fecd0c90, type: 3}
+      m_Width: 1024
+      m_Height: 1024
+      m_Kind: 4
+      m_SubKind: App Store
     - m_Textures:
-      - {fileID: 2800000, guid: 56b4c7998f17a334c84291658e1df38d, type: 3}
-      m_Width: 58
-      m_Height: 58
-      m_Kind: 1
-      m_SubKind: iPhone
-    - m_Textures:
-      - {fileID: 2800000, guid: 56b4c7998f17a334c84291658e1df38d, type: 3}
-      m_Width: 29
-      m_Height: 29
-      m_Kind: 1
-      m_SubKind: iPhone
-    - m_Textures:
-      - {fileID: 2800000, guid: 56b4c7998f17a334c84291658e1df38d, type: 3}
-      m_Width: 58
-      m_Height: 58
-      m_Kind: 1
-      m_SubKind: iPad
-    - m_Textures:
-      - {fileID: 2800000, guid: 56b4c7998f17a334c84291658e1df38d, type: 3}
-      m_Width: 29
-      m_Height: 29
-      m_Kind: 1
-      m_SubKind: iPad
-    - m_Textures:
-      - {fileID: 2800000, guid: 56b4c7998f17a334c84291658e1df38d, type: 3}
+      - {fileID: 2800000, guid: e17218f4ab604764e8f36042fecd0c90, type: 3}
       m_Width: 60
       m_Height: 60
       m_Kind: 2
       m_SubKind: iPhone
     - m_Textures:
-      - {fileID: 2800000, guid: 56b4c7998f17a334c84291658e1df38d, type: 3}
+      - {fileID: 2800000, guid: e17218f4ab604764e8f36042fecd0c90, type: 3}
       m_Width: 40
       m_Height: 40
       m_Kind: 2
       m_SubKind: iPhone
     - m_Textures:
-      - {fileID: 2800000, guid: 56b4c7998f17a334c84291658e1df38d, type: 3}
+      - {fileID: 2800000, guid: e17218f4ab604764e8f36042fecd0c90, type: 3}
       m_Width: 40
       m_Height: 40
       m_Kind: 2
       m_SubKind: iPad
     - m_Textures:
-      - {fileID: 2800000, guid: 56b4c7998f17a334c84291658e1df38d, type: 3}
+      - {fileID: 2800000, guid: e17218f4ab604764e8f36042fecd0c90, type: 3}
       m_Width: 20
       m_Height: 20
       m_Kind: 2
       m_SubKind: iPad
     - m_Textures:
-      - {fileID: 2800000, guid: 56b4c7998f17a334c84291658e1df38d, type: 3}
-      m_Width: 1024
-      m_Height: 1024
-      m_Kind: 4
-      m_SubKind: App Store
+      - {fileID: 2800000, guid: e17218f4ab604764e8f36042fecd0c90, type: 3}
+      m_Width: 87
+      m_Height: 87
+      m_Kind: 1
+      m_SubKind: iPhone
+    - m_Textures:
+      - {fileID: 2800000, guid: e17218f4ab604764e8f36042fecd0c90, type: 3}
+      m_Width: 58
+      m_Height: 58
+      m_Kind: 1
+      m_SubKind: iPhone
+    - m_Textures:
+      - {fileID: 2800000, guid: e17218f4ab604764e8f36042fecd0c90, type: 3}
+      m_Width: 29
+      m_Height: 29
+      m_Kind: 1
+      m_SubKind: iPhone
+    - m_Textures:
+      - {fileID: 2800000, guid: e17218f4ab604764e8f36042fecd0c90, type: 3}
+      m_Width: 58
+      m_Height: 58
+      m_Kind: 1
+      m_SubKind: iPad
+    - m_Textures:
+      - {fileID: 2800000, guid: e17218f4ab604764e8f36042fecd0c90, type: 3}
+      m_Width: 29
+      m_Height: 29
+      m_Kind: 1
+      m_SubKind: iPad
   - m_BuildTarget: Android
     m_Icons:
     - m_Textures:
-      - {fileID: 2800000, guid: 9ec7de17a9efc884faeba00ce12266b7, type: 3}
-      - {fileID: 2800000, guid: 7ccdb30ffc13b314da34f63b54cfbb96, type: 3}
+      - {fileID: 2800000, guid: 62bb4d6c133850a47b612b2e68a36539, type: 3}
+      - {fileID: 2800000, guid: 18d5bb4ad9c8a7f4894692411ac7948a, type: 3}
       m_Width: 432
       m_Height: 432
       m_Kind: 2
       m_SubKind: 
     - m_Textures:
-      - {fileID: 2800000, guid: 9ec7de17a9efc884faeba00ce12266b7, type: 3}
-      - {fileID: 2800000, guid: 7ccdb30ffc13b314da34f63b54cfbb96, type: 3}
+      - {fileID: 2800000, guid: 62bb4d6c133850a47b612b2e68a36539, type: 3}
+      - {fileID: 2800000, guid: 18d5bb4ad9c8a7f4894692411ac7948a, type: 3}
       m_Width: 324
       m_Height: 324
       m_Kind: 2
       m_SubKind: 
     - m_Textures:
-      - {fileID: 2800000, guid: 9ec7de17a9efc884faeba00ce12266b7, type: 3}
-      - {fileID: 2800000, guid: 7ccdb30ffc13b314da34f63b54cfbb96, type: 3}
+      - {fileID: 2800000, guid: 62bb4d6c133850a47b612b2e68a36539, type: 3}
+      - {fileID: 2800000, guid: 18d5bb4ad9c8a7f4894692411ac7948a, type: 3}
       m_Width: 216
       m_Height: 216
       m_Kind: 2
       m_SubKind: 
     - m_Textures:
-      - {fileID: 2800000, guid: 9ec7de17a9efc884faeba00ce12266b7, type: 3}
-      - {fileID: 2800000, guid: 7ccdb30ffc13b314da34f63b54cfbb96, type: 3}
+      - {fileID: 2800000, guid: 62bb4d6c133850a47b612b2e68a36539, type: 3}
+      - {fileID: 2800000, guid: 18d5bb4ad9c8a7f4894692411ac7948a, type: 3}
       m_Width: 162
       m_Height: 162
       m_Kind: 2
       m_SubKind: 
     - m_Textures:
-      - {fileID: 2800000, guid: 9ec7de17a9efc884faeba00ce12266b7, type: 3}
-      - {fileID: 2800000, guid: 7ccdb30ffc13b314da34f63b54cfbb96, type: 3}
+      - {fileID: 2800000, guid: 62bb4d6c133850a47b612b2e68a36539, type: 3}
+      - {fileID: 2800000, guid: 18d5bb4ad9c8a7f4894692411ac7948a, type: 3}
       m_Width: 108
       m_Height: 108
       m_Kind: 2
       m_SubKind: 
     - m_Textures:
-      - {fileID: 2800000, guid: 9ec7de17a9efc884faeba00ce12266b7, type: 3}
-      - {fileID: 2800000, guid: 7ccdb30ffc13b314da34f63b54cfbb96, type: 3}
+      - {fileID: 2800000, guid: 62bb4d6c133850a47b612b2e68a36539, type: 3}
+      - {fileID: 2800000, guid: 18d5bb4ad9c8a7f4894692411ac7948a, type: 3}
       m_Width: 81
       m_Height: 81
       m_Kind: 2
       m_SubKind: 
     - m_Textures:
-      - {fileID: 2800000, guid: 56b4c7998f17a334c84291658e1df38d, type: 3}
+      - {fileID: 2800000, guid: e17218f4ab604764e8f36042fecd0c90, type: 3}
       m_Width: 192
       m_Height: 192
       m_Kind: 1
       m_SubKind: 
     - m_Textures:
-      - {fileID: 2800000, guid: 56b4c7998f17a334c84291658e1df38d, type: 3}
+      - {fileID: 2800000, guid: e17218f4ab604764e8f36042fecd0c90, type: 3}
       m_Width: 144
       m_Height: 144
       m_Kind: 1
       m_SubKind: 
     - m_Textures:
-      - {fileID: 2800000, guid: 56b4c7998f17a334c84291658e1df38d, type: 3}
+      - {fileID: 2800000, guid: e17218f4ab604764e8f36042fecd0c90, type: 3}
       m_Width: 96
       m_Height: 96
       m_Kind: 1
       m_SubKind: 
     - m_Textures:
-      - {fileID: 2800000, guid: 56b4c7998f17a334c84291658e1df38d, type: 3}
+      - {fileID: 2800000, guid: e17218f4ab604764e8f36042fecd0c90, type: 3}
       m_Width: 72
       m_Height: 72
       m_Kind: 1
       m_SubKind: 
     - m_Textures:
-      - {fileID: 2800000, guid: 56b4c7998f17a334c84291658e1df38d, type: 3}
+      - {fileID: 2800000, guid: e17218f4ab604764e8f36042fecd0c90, type: 3}
       m_Width: 48
       m_Height: 48
       m_Kind: 1
       m_SubKind: 
     - m_Textures:
-      - {fileID: 2800000, guid: 56b4c7998f17a334c84291658e1df38d, type: 3}
+      - {fileID: 2800000, guid: e17218f4ab604764e8f36042fecd0c90, type: 3}
       m_Width: 36
       m_Height: 36
       m_Kind: 1
       m_SubKind: 
     - m_Textures:
-      - {fileID: 2800000, guid: 56b4c7998f17a334c84291658e1df38d, type: 3}
+      - {fileID: 2800000, guid: e17218f4ab604764e8f36042fecd0c90, type: 3}
       m_Width: 192
       m_Height: 192
       m_Kind: 0
       m_SubKind: 
     - m_Textures:
-      - {fileID: 2800000, guid: 56b4c7998f17a334c84291658e1df38d, type: 3}
+      - {fileID: 2800000, guid: e17218f4ab604764e8f36042fecd0c90, type: 3}
       m_Width: 144
       m_Height: 144
       m_Kind: 0
       m_SubKind: 
     - m_Textures:
-      - {fileID: 2800000, guid: 56b4c7998f17a334c84291658e1df38d, type: 3}
+      - {fileID: 2800000, guid: e17218f4ab604764e8f36042fecd0c90, type: 3}
       m_Width: 96
       m_Height: 96
       m_Kind: 0
       m_SubKind: 
     - m_Textures:
-      - {fileID: 2800000, guid: 56b4c7998f17a334c84291658e1df38d, type: 3}
+      - {fileID: 2800000, guid: e17218f4ab604764e8f36042fecd0c90, type: 3}
       m_Width: 72
       m_Height: 72
       m_Kind: 0
       m_SubKind: 
     - m_Textures:
-      - {fileID: 2800000, guid: 56b4c7998f17a334c84291658e1df38d, type: 3}
+      - {fileID: 2800000, guid: e17218f4ab604764e8f36042fecd0c90, type: 3}
       m_Width: 48
       m_Height: 48
       m_Kind: 0
       m_SubKind: 
     - m_Textures:
-      - {fileID: 2800000, guid: 56b4c7998f17a334c84291658e1df38d, type: 3}
+      - {fileID: 2800000, guid: e17218f4ab604764e8f36042fecd0c90, type: 3}
       m_Width: 36
       m_Height: 36
       m_Kind: 0


### PR DESCRIPTION
This pull request updates the icon assets in the `PlayerSettings` configuration for multiple platforms, including iPhone, iPad, Android, and App Store. The changes involve replacing old GUID references with new ones and adding new icon sizes and configurations for better platform compatibility.

### Icon Updates:

* **iPhone/iPad Icons**: Updated GUID references for existing icons and added new icon configurations for sizes such as 60x60, 40x40, and 20x20, along with a new 1024x1024 App Store icon.
* **Android Icons**: Updated GUID references for existing icons and replaced them with new ones for various sizes (e.g., 432x432, 324x324).