### PR TITLE
fix mimir rank

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Model/Rank.cs
+++ b/nekoyume/Assets/_Scripts/UI/Model/Rank.cs
@@ -128,7 +128,7 @@ namespace Nekoyume.UI.Model
                 AgentAbilityRankingInfos[pair.Key] = new AbilityRankingModel
                 {
                     Rank = myRecord.Rank,
-                    AvatarAddress = myRecord.UserDocument.Address,
+                    AvatarAddress = $"0x{myRecord.UserDocument.Id}",
                     Name = pair.Value.name,
                     AvatarLevel = pair.Value.level,
                     ArmorId = pair.Value.GetArmorId(),
@@ -216,7 +216,7 @@ namespace Nekoyume.UI.Model
                 AgentStageRankingInfos[pair.Key] = new StageRankingModel
                 {
                     Rank = myRecord.Rank,
-                    AvatarAddress = myRecord.UserDocument.Address,
+                    AvatarAddress = $"0x{myRecord.UserDocument.Id}",
                     Name = pair.Value.name,
                     AvatarLevel = pair.Value.level,
                     ArmorId = pair.Value.GetArmorId(),
@@ -249,18 +249,15 @@ namespace Nekoyume.UI.Model
             }
 
             CraftRankingInfos = response.CraftRanking
-                .Select(e =>
+                .Select(e => new CraftRankingModel
                 {
-                    return new CraftRankingModel
-                    {
-                        Rank = e.Ranking,
-                        AvatarAddress = e.AvatarAddress,
-                        Name = e.Name,
-                        AvatarLevel = e.AvatarLevel,
-                        ArmorId = e.ArmorId,
-                        TitleId = e.TitleId,
-                        CraftCount = e.CraftCount
-                    };
+                    Rank = e.Ranking,
+                    AvatarAddress = e.AvatarAddress,
+                    Name = e.Name,
+                    AvatarLevel = e.AvatarLevel,
+                    ArmorId = e.ArmorId,
+                    TitleId = e.TitleId,
+                    CraftCount = e.CraftCount
                 })
                 .Select(t => t)
                 .Where(e => e != null)
@@ -343,20 +340,17 @@ namespace Nekoyume.UI.Model
                 }
 
                 EquipmentRankingInfosMap[subType] = response.EquipmentRanking
-                    .Select(e =>
+                    .Select(e => new EquipmentRankingModel
                     {
-                        return new EquipmentRankingModel
-                        {
-                            Rank = e.Ranking,
-                            AvatarAddress = e.AvatarAddress,
-                            Name = e.Name,
-                            AvatarLevel = e.AvatarLevel,
-                            ArmorId = e.ArmorId,
-                            TitleId = e.TitleId,
-                            Level = e.Level,
-                            Cp = e.Cp,
-                            EquipmentId = e.EquipmentId
-                        };
+                        Rank = e.Ranking,
+                        AvatarAddress = e.AvatarAddress,
+                        Name = e.Name,
+                        AvatarLevel = e.AvatarLevel,
+                        ArmorId = e.ArmorId,
+                        TitleId = e.TitleId,
+                        Level = e.Level,
+                        Cp = e.Cp,
+                        EquipmentId = e.EquipmentId
                     })
                     .Select(t => t)
                     .Where(e => e != null)


### PR DESCRIPTION
This pull request refactors ranking-related methods in the `Rank.cs` file to improve code readability and consistency. The most significant changes involve updating how `AvatarAddress` is formatted and simplifying LINQ expressions by removing unnecessary code blocks.

### Updates to `AvatarAddress` formatting:
* Changed the `AvatarAddress` field in both `FetchMyAdventureCpRanking` and `FetchMyStageRanking` methods to use a formatted string (`$"0x{myRecord.UserDocument.Id}"`) instead of directly accessing the `Address` property. [[1]](diffhunk://#diff-e7cba330640229d50bd2cbe6e1e3c8bec2de7cb40cc24c8dd77c7dbd554273c7L131-R131) [[2]](diffhunk://#diff-e7cba330640229d50bd2cbe6e1e3c8bec2de7cb40cc24c8dd77c7dbd554273c7L219-R219)

### Simplifications in LINQ expressions:
* Refactored the `LoadCraftRankingInfos` method by replacing multi-line LINQ `Select` expressions with single-line expressions for creating `CraftRankingModel` instances. [[1]](diffhunk://#diff-e7cba330640229d50bd2cbe6e1e3c8bec2de7cb40cc24c8dd77c7dbd554273c7L252-R252) [[2]](diffhunk://#diff-e7cba330640229d50bd2cbe6e1e3c8bec2de7cb40cc24c8dd77c7dbd554273c7L263)
* Simplified the `LoadEquipmentRankingInfos` method by replacing multi-line LINQ `Select` expressions with single-line expressions for creating `EquipmentRankingModel` instances. [[1]](diffhunk://#diff-e7cba330640229d50bd2cbe6e1e3c8bec2de7cb40cc24c8dd77c7dbd554273c7L346-R343) [[2]](diffhunk://#diff-e7cba330640229d50bd2cbe6e1e3c8bec2de7cb40cc24c8dd77c7dbd554273c7L359)