### PR TITLE
Fix license install script message

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -14,7 +14,7 @@ install_license() {
         # for local debugging
         cp Unity_v2021.x.ulf "$temp_filename"
     elif [[ "$UNITY_LICENSE" = "" ]]; then
-        echo "The ULF environment variable is missing." > /dev/stderr
+        echo "The UNITY_LICENSE environment variable is missing." > /dev/stderr
         exit 1
     elif [[ "$UNITY_LICENSE" = \<* ]]; then
         # Bare XML


### PR DESCRIPTION
## Summary
- fix license install message to reference the `UNITY_LICENSE` environment variable

## Testing
- `git log -1 --stat`