### PR TITLE
코스튬 소환 정렬 버그 수정

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Widget/Popup/SummonProbabilityPopup.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Popup/SummonProbabilityPopup.cs
@@ -104,7 +104,7 @@ namespace Nekoyume.UI
                     else
                     {
                         var cellRatio = ratio / ratioSum;
-                        var grade = equipmentRow?.Grade ?? Util.GetTickerGrade(runeTicker);
+                        var grade = equipmentRow?.Grade ?? costumeRow?.Grade ?? Util.GetTickerGrade(runeTicker);
                         var cellModel = new SummonDetailCell.Model
                         {
                             EquipmentRow = equipmentRow,


### PR DESCRIPTION
<img width="1142" height="646" alt="image" src="https://github.com/user-attachments/assets/d9e4301e-9708-42d5-8867-73c2564a2955" />

소환 정보창에서 코스튬 정렬이 제대로 안되는 버그 수정