### PR TITLE
Display upgrade level filter as +N format instead of LevelN

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Widget/Popup/ItemFilterPopupBase.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/Popup/ItemFilterPopupBase.cs
@@ -166,7 +166,18 @@ namespace Nekoyume.UI
             public UpgradeLevel upgradeLevel;
 
             public override bool IsAll => upgradeLevel == UpgradeLevel.All;
-            public override string GetOptionName => upgradeLevel.ToString();
+            public override string GetOptionName => upgradeLevel switch
+            {
+                UpgradeLevel.All => "All",
+                UpgradeLevel.Level0 => "+0",
+                UpgradeLevel.Level1 => "+1",
+                UpgradeLevel.Level2 => "+2",
+                UpgradeLevel.Level3 => "+3",
+                UpgradeLevel.Level4 => "+4",
+                UpgradeLevel.Level5 => "+5",
+                UpgradeLevel.Level6More => "+6 more",
+                _ => upgradeLevel.ToString()
+            };
         }
 
         [Serializable]


### PR DESCRIPTION
## Summary
- `ItemFilterPopupBase`의 업그레이드 레벨 필터 표기를 `Level0`, `Level1` 형식에서 `+0`, `+1` 형식으로 변경
- `Level6More`는 `+6 more`로 표시

## Test plan
- [ ] 아이템 필터 팝업 열어 Upgrade 필터 항목이 +0, +1, +2, +3, +4, +5, +6 more로 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)