### PR TITLE
Introduce CLO version registry to eliminate per-version CLO files

### DIFF
--- a/nekoyume/Assets/Resources/ScriptableObject/LiveAssetEndpoint.asset
+++ b/nekoyume/Assets/Resources/ScriptableObject/LiveAssetEndpoint.asset
@@ -26,8 +26,8 @@ MonoBehaviour:
   <EventRewardPopupDataJsonUrlMainNet>k__BackingField: https://assets.nine-chronicles.com/live-assets/Json/NewEventRewardPopupData.json
   <EventRewardPopupDataJsonUrlInternal>k__BackingField: https://assets.nine-chronicles.com/live-assets/Json/EventRewardPopupData.json
   <NcuJsonUrl>k__BackingField: https://assets.nine-chronicles.com/live-assets/Json/Ncu.json
-  <CloVersionRegistryUrl>k__BackingField: https://assets.nine-chronicles.com/live-assets/Json/version-registry.json
-  <CloMainnetUrl>k__BackingField: https://assets.nine-chronicles.com/live-assets/Json/clo-mainnet.json
-  <CloMainnetKrUrl>k__BackingField: https://assets.nine-chronicles.com/live-assets/Json/clo-mainnet-kr.json
-  <CloInternalUrl>k__BackingField: https://assets.nine-chronicles.com/live-assets/Json/clo-internal.json
-  <CloInternalKrUrl>k__BackingField: https://assets.nine-chronicles.com/live-assets/Json/clo-internal-kr.json
+  <CloVersionRegistryUrl>k__BackingField: https://assets.nine-chronicles.com/live-assets/Clo/version-registry.json
+  <CloMainnetUrl>k__BackingField: https://assets.nine-chronicles.com/live-assets/Clo/clo-mainnet.json
+  <CloMainnetKrUrl>k__BackingField: https://assets.nine-chronicles.com/live-assets/Clo/clo-mainnet-kr.json
+  <CloInternalUrl>k__BackingField: https://assets.nine-chronicles.com/live-assets/Clo/clo-internal.json
+  <CloInternalKrUrl>k__BackingField: https://assets.nine-chronicles.com/live-assets/Clo/clo-internal-kr.json

--- a/nekoyume/Assets/Resources/ScriptableObject/LiveAssetEndpoint.asset
+++ b/nekoyume/Assets/Resources/ScriptableObject/LiveAssetEndpoint.asset
@@ -26,3 +26,8 @@ MonoBehaviour:
   <EventRewardPopupDataJsonUrlMainNet>k__BackingField: https://assets.nine-chronicles.com/live-assets/Json/NewEventRewardPopupData.json
   <EventRewardPopupDataJsonUrlInternal>k__BackingField: https://assets.nine-chronicles.com/live-assets/Json/EventRewardPopupData.json
   <NcuJsonUrl>k__BackingField: https://assets.nine-chronicles.com/live-assets/Json/Ncu.json
+  <CloVersionRegistryUrl>k__BackingField: https://assets.nine-chronicles.com/live-assets/Json/version-registry.json
+  <CloMainnetUrl>k__BackingField: https://assets.nine-chronicles.com/live-assets/Json/clo-mainnet.json
+  <CloMainnetKrUrl>k__BackingField: https://assets.nine-chronicles.com/live-assets/Json/clo-mainnet-kr.json
+  <CloInternalUrl>k__BackingField: https://assets.nine-chronicles.com/live-assets/Json/clo-internal.json
+  <CloInternalKrUrl>k__BackingField: https://assets.nine-chronicles.com/live-assets/Json/clo-internal-kr.json

--- a/nekoyume/Assets/_Scripts/Game/Game.cs
+++ b/nekoyume/Assets/_Scripts/Game/Game.cs
@@ -1495,7 +1495,18 @@ namespace Nekoyume.Game
 
         public bool CheckRequiredUpdate()
         {
-            if (!_commandLineOptions.RequiredUpdate)
+            var needsUpdate = _commandLineOptions.RequiredUpdate;
+
+            if (!needsUpdate && !string.IsNullOrEmpty(_commandLineOptions.MinRequiredVersion))
+            {
+                if (System.Version.TryParse(Application.version, out var current) &&
+                    System.Version.TryParse(_commandLineOptions.MinRequiredVersion, out var minRequired))
+                {
+                    needsUpdate = current < minRequired;
+                }
+            }
+
+            if (!needsUpdate)
             {
                 return false;
             }

--- a/nekoyume/Assets/_Scripts/Game/LiveAsset/CloVersionRegistry.cs
+++ b/nekoyume/Assets/_Scripts/Game/LiveAsset/CloVersionRegistry.cs
@@ -1,0 +1,30 @@
+using System.Text.Json.Serialization;
+
+namespace Nekoyume.Game.LiveAsset
+{
+    public class CloVersionRegistry
+    {
+        [JsonPropertyName("default")]
+        public string Default { get; set; } = "internal";
+
+        [JsonPropertyName("currentMainnetVersion")]
+        public string CurrentMainnetVersion { get; set; }
+
+        [JsonPropertyName("stagingVersion")]
+        public string StagingVersion { get; set; }
+
+        public string GetEnvironment(string appVersion)
+        {
+            if (!string.IsNullOrEmpty(StagingVersion) && appVersion == StagingVersion)
+                return "mainnet";
+
+            if (!string.IsNullOrEmpty(CurrentMainnetVersion) &&
+                System.Version.TryParse(appVersion, out var current) &&
+                System.Version.TryParse(CurrentMainnetVersion, out var mainnet) &&
+                current <= mainnet)
+                return "mainnet";
+
+            return Default ?? "internal";
+        }
+    }
+}

--- a/nekoyume/Assets/_Scripts/Game/LiveAsset/CloVersionRegistry.cs.meta
+++ b/nekoyume/Assets/_Scripts/Game/LiveAsset/CloVersionRegistry.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f902297e532ef4c2b96d9a7368be13c8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/nekoyume/Assets/_Scripts/Game/LiveAsset/LiveAssetManager.cs
+++ b/nekoyume/Assets/_Scripts/Game/LiveAsset/LiveAssetManager.cs
@@ -191,26 +191,28 @@ namespace Nekoyume.Game.LiveAsset
 
         public IEnumerator InitializeApplicationCLO()
         {
-            var osKey = string.Empty;
-#if UNITY_ANDROID
-            osKey = "-aos";
-#elif UNITY_IOS
-            osKey = "-ios";
-#endif
-
-            var languageKey = string.Empty;
-            if (GameConfig.IsKoreanBuild)
-            {
-                languageKey = "-kr";
-            }
-
-            var cloEndpoint = $"{_endpoint.CommandLineOptionsJsonUrlPrefix}{Application.version.Replace(".", "-")}{osKey}{languageKey}.json";
-            NcDebug.Log($"[InitializeApplicationCLO] cloEndpoint: {cloEndpoint}");
+            // 1. version-registry.json으로 환경 결정
+            CloVersionRegistry registry = null;
             yield return StartCoroutine(
                 RequestManager.instance.GetJson(
-                    cloEndpoint,
-                    SetCommandLineOptions));
+                    _endpoint.CloVersionRegistryUrl,
+                    json => registry = JsonSerializer.Deserialize<CloVersionRegistry>(
+                        json, CommandLineOptions.JsonOptions)));
 
+            var env = registry?.GetEnvironment(Application.version) ?? "internal";
+            NcDebug.Log($"[InitializeApplicationCLO] version={Application.version}, env={env}");
+
+            // 2. 환경별 CLO 다운로드
+            var cloUrl = (env, GameConfig.IsKoreanBuild) switch
+            {
+                ("mainnet", true)  => _endpoint.CloMainnetKrUrl,
+                ("mainnet", false) => _endpoint.CloMainnetUrl,
+                (_, true)          => _endpoint.CloInternalKrUrl,
+                _                  => _endpoint.CloInternalUrl,
+            };
+            yield return StartCoroutine(RequestManager.instance.GetJson(cloUrl, SetCommandLineOptions));
+
+            // 3. registry 또는 env CLO 로드 실패 시 기존 default URL로 폴백
             if (CommandLineOptions == null)
             {
                 yield return StartCoroutine(

--- a/nekoyume/Assets/_Scripts/Game/Scene/LoginScene.cs
+++ b/nekoyume/Assets/_Scripts/Game/Scene/LoginScene.cs
@@ -419,7 +419,7 @@ namespace Nekoyume.Game.Scene
             var game = Game.instance;
 
             NcDebug.Log("[LoginScene] CoLogin() invoked");
-            if (CommandLineOptions.Maintenance)
+            if (IsUnderMaintenance(CommandLineOptions))
             {
                 ShowMaintenancePopup();
                 return;
@@ -695,6 +695,23 @@ namespace Nekoyume.Game.Scene
             }
 
             return true;
+        }
+
+        private static bool IsUnderMaintenance(CommandLineOptions options)
+        {
+            if (!options.Maintenance)
+            {
+                return false;
+            }
+
+            if (string.IsNullOrEmpty(options.MaintenanceMaxVersion))
+            {
+                return true;
+            }
+
+            return System.Version.TryParse(Application.version, out var current) &&
+                   System.Version.TryParse(options.MaintenanceMaxVersion, out var maxVer) &&
+                   current <= maxVer;
         }
 
         private void ShowMaintenancePopup()

--- a/nekoyume/Assets/_Scripts/Game/ScriptableObject/LiveAssetEndpointScriptableObject.cs
+++ b/nekoyume/Assets/_Scripts/Game/ScriptableObject/LiveAssetEndpointScriptableObject.cs
@@ -48,5 +48,20 @@ namespace Nekoyume.Game.ScriptableObject
 
         [field: SerializeField]
         public string NcuJsonUrl { get; private set; }
+
+        [field: SerializeField]
+        public string CloVersionRegistryUrl { get; private set; }
+
+        [field: SerializeField]
+        public string CloMainnetUrl { get; private set; }
+
+        [field: SerializeField]
+        public string CloMainnetKrUrl { get; private set; }
+
+        [field: SerializeField]
+        public string CloInternalUrl { get; private set; }
+
+        [field: SerializeField]
+        public string CloInternalKrUrl { get; private set; }
     }
 }

--- a/nekoyume/Assets/_Scripts/Helper/CommandLineOptions.cs
+++ b/nekoyume/Assets/_Scripts/Helper/CommandLineOptions.cs
@@ -382,6 +382,34 @@ namespace Nekoyume.Helper
             }
         }
 
+        [Option("maintenance-max-version", Required = false,
+            HelpText = "Apply maintenance only to versions <= this value (e.g. '420.0.1'). No limit if empty.")]
+        public string MaintenanceMaxVersion
+        {
+            get => _maintenanceMaxVersion;
+            set
+            {
+                _maintenanceMaxVersion = value;
+                Empty = false;
+            }
+        }
+
+        private string _maintenanceMaxVersion;
+
+        [Option("min-required-version", Required = false,
+            HelpText = "Minimum required version. Clients below this version are forced to update (e.g. '420.0.2').")]
+        public string MinRequiredVersion
+        {
+            get => _minRequiredVersion;
+            set
+            {
+                _minRequiredVersion = value;
+                Empty = false;
+            }
+        }
+
+        private string _minRequiredVersion;
+
         [Option("testEnd", Required = false, HelpText = "Test has ended.")]
         public bool TestEnd
         {


### PR DESCRIPTION
## Summary

- `version-registry.json` 단일 파일로 버전→환경(mainnet/internal) 결정. 신규 앱 버전 출시 시 CLO 파일 4개 신규 생성이 불필요해짐
- `clo-mainnet.json` / `clo-internal.json` (+kr 변형) 고정 파일에서 환경별 설정을 받음
- `CloVersionRegistry.cs` 신규 클래스: `currentMainnetVersion`(이하 → mainnet), `stagingVersion`(일치 → mainnet), `default`(나머지 환경) 판별
- `CommandLineOptions`에 `MinRequiredVersion`(강제업데이트), `MaintenanceMaxVersion`(점검 버전 상한) 필드 추가
- `LiveAssetManager.InitializeApplicationCLO()`: registry 다운로드 → 환경 판별 → 환경별 CLO 요청 → 실패 시 `clo-default.json` 폴백

## Release workflow (변경 후)

| 상황 | 변경 파일 |
|------|-----------|
| 인터널 신규 버전 | 없음 |
| 메인넷 사전 테스트 | `version-registry.json` `stagingVersion` 설정 |
| 메인넷 공식 릴리즈 | `version-registry.json` `currentMainnetVersion` 업데이트 + `clo-mainnet.json` APV 업데이트 |
| 강제업데이트 | `clo-mainnet.json` `minRequiredVersion` 설정 |
| 점검 (구버전만 차단) | `clo-mainnet.json` `maintenance: true` + `maintenanceMaxVersion` 설정 |

## Test plan

- [ ] `currentMainnetVersion: "420.0.3"` → 420.0.3 빌드가 mainnet config 수신
- [ ] `default: "internal"` → 미등록 신규 버전 빌드가 internal config 수신
- [ ] `stagingVersion: "421.0.0"` → 421.0.0 빌드가 mainnet config 수신
- [ ] registry 다운로드 실패 → `clo-default.json` 폴백 동작
- [ ] `clo-mainnet.json` `minRequiredVersion: "421.0.0"` → 420.0.3 빌드 강제업데이트 팝업
- [ ] `clo-mainnet.json` `maintenance: true, maintenanceMaxVersion: "420.0.3"` → 420.0.3 점검 팝업, 421.0.0 정상 접속

🤖 Generated with [Claude Code](https://claude.com/claude-code)