### PR TITLE
Update CloVersionRegistry to match new version-registry.json schema

### DIFF
--- a/nekoyume/Assets/_Scripts/Game/LiveAsset/CloVersionRegistry.cs
+++ b/nekoyume/Assets/_Scripts/Game/LiveAsset/CloVersionRegistry.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
 namespace Nekoyume.Game.LiveAsset
@@ -7,21 +8,24 @@ namespace Nekoyume.Game.LiveAsset
         [JsonPropertyName("default")]
         public string Default { get; set; } = "internal";
 
-        [JsonPropertyName("currentMainnetVersion")]
-        public string CurrentMainnetVersion { get; set; }
+        [JsonPropertyName("currentMainnetVersions")]
+        public List<string> CurrentMainnetVersions { get; set; }
 
         [JsonPropertyName("stagingVersion")]
         public string StagingVersion { get; set; }
 
+        [JsonPropertyName("internalVersion")]
+        public string InternalVersion { get; set; }
+
         public string GetEnvironment(string appVersion)
         {
+            if (!string.IsNullOrEmpty(InternalVersion) && appVersion == InternalVersion)
+                return "internal";
+
             if (!string.IsNullOrEmpty(StagingVersion) && appVersion == StagingVersion)
                 return "mainnet";
 
-            if (!string.IsNullOrEmpty(CurrentMainnetVersion) &&
-                System.Version.TryParse(appVersion, out var current) &&
-                System.Version.TryParse(CurrentMainnetVersion, out var mainnet) &&
-                current <= mainnet)
+            if (CurrentMainnetVersions != null && CurrentMainnetVersions.Contains(appVersion))
                 return "mainnet";
 
             return Default ?? "internal";


### PR DESCRIPTION
## Summary

- `currentMainnetVersion: string` → `currentMainnetVersions: List<string>`: 단일 버전에서 명시적 버전 목록(배열)으로 변경
- `internalVersion: string` 필드 추가: 설정 시 해당 버전을 최우선으로 internal 환경으로 강제 처리
- 환경 판별 우선순위: `internalVersion` > `stagingVersion` > `currentMainnetVersions` > `default`

## 서버 JSON 포맷 (반영)

```json
{
  "currentMainnetVersions": ["410.0.3", "410.0.4"],
  "stagingVersion": "420.0.1",
  "internalVersion": "",
  "default": "internal"
}
```

현재 `internalVersion`은 비어있어 영향 없음. 특정 빌드 버전을 명시적으로 internal로 고정할 때 사용.

## Test plan

- [ ] `currentMainnetVersions` 목록에 포함된 버전 → mainnet config 수신
- [ ] 목록에 없는 버전 → internal config 수신 (default)
- [ ] `stagingVersion` 일치 → mainnet config 수신
- [ ] `internalVersion` 일치 → stagingVersion 설정과 무관하게 internal config 수신

🤖 Generated with [Claude Code](https://claude.com/claude-code)