### PR TITLE
docs: fix broken README references in README.ko.md

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -2,8 +2,8 @@ Nine Chronicles
 ===============
 
 [![CircleCI][ci-badge]][ci]
-[![Discourse posts](https://img.shields.io/discourse/posts?server=https%3A%2F%2Fdevforum.nine-chronicles.com%2F&logo=discourse&label=9c-devforum&color=00D1C2
-)](https://devforum.nine-chronicles.com)
+[![Discourse posts](https://img.shields.io/discourse/posts?server=https%3A%2F%2Fdevforum.nine-chronicles.com%2F&logo=discourse&label=9c-devforum&color=00D1C2)](https://devforum.nine-chronicles.com)
+
 
 [ci-badge]: https://circleci.com/gh/planetarium/nekoyume-unity.svg?style=svg&circle-token=ca79d4f6281fe60cdde55d0f1c3d97d561106bda
 [ci]: https://circleci.com/gh/planetarium/nekoyume-unity


### PR DESCRIPTION
## Summary
- Automated README maintenance for `planetarium/NineChronicles` focused on dead links and stale API references.

## Changed files
- `README.ko.md`: 2 edit(s)

## Validation
- Reviewed README Markdown files only.
- Kept edits minimal and localized to broken references or outdated API endpoints.

Automated README maintenance pass focused on dead links and stale API references. If this saved you time, coffee on Base is always appreciated: 0x85a7d7eefac69d5f90615cf72a4dcc5657370e2c