### PR TITLE
Fix InfiniteTower background not cycling through stages

### DIFF
--- a/nekoyume/Assets/Resources/Prefab/Background/InfiniteTower_03.prefab
+++ b/nekoyume/Assets/Resources/Prefab/Background/InfiniteTower_03.prefab
@@ -52,7 +52,6 @@ MonoBehaviour:
   particles: []
   backgrounds:
   - {fileID: 4595510115065879989}
-  - {fileID: 0}
   - {fileID: 2137293177556079708}
   - {fileID: 7733790697876881455}
   - {fileID: 3666302208091631458}

--- a/nekoyume/Assets/_Scripts/Game/Battle/Background.cs
+++ b/nekoyume/Assets/_Scripts/Game/Battle/Background.cs
@@ -122,6 +122,11 @@ namespace Nekoyume.Game.Battle
 
         private void LateUpdate()
         {
+            if (_cameraTransform is null)
+            {
+                return;
+            }
+
             var camPosX = _cameraTransform.position.x;
 
             if (!Mathf.Approximately(parallaxSpeed, 0.0f))

--- a/nekoyume/Assets/_Scripts/Game/Battle/Stage.cs
+++ b/nekoyume/Assets/_Scripts/Game/Battle/Stage.cs
@@ -693,7 +693,7 @@ namespace Nekoyume.Game.Battle
 
         private string GetCurrentInfiniteTowerBackgroundKey()
         {
-            return $"{InfiniteTowerBackgroundKey}{_adventureBossFloorCount % 3 + 1}";
+            return $"{InfiniteTowerBackgroundKey}{_infiniteTowerFloorCount % 3 + 1}";
         }
 
         private IEnumerator CoStageEnd(BattleLog log)


### PR DESCRIPTION
## Summary
- `GetCurrentInfiniteTowerBackgroundKey()`에서 `_adventureBossFloorCount` 대신 `_infiniteTowerFloorCount`를 사용하도록 수정하여 무한의탑 스테이지별로 배경이 순환되도록 함
- `Background.LateUpdate()`에 `_cameraTransform` null 체크 추가하여 `Initialize()` 호출 전 NullReferenceException 방지

## Test plan
- [ ] 무한의탑 진입 후 스테이지별 배경이 `InfiniteTower_01`, `02`, `03`으로 순환되는지 확인
- [ ] InfiniteTower_03 프리팹 선택 시 NullReferenceException이 발생하지 않는지 확인
- [ ] 어드벤처 보스 배경 동작에 영향이 없는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)