### PR TITLE
Show hard mode UI for legacy accounts before HAS migration

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Module/GuidedQuest.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/GuidedQuest.cs
@@ -608,13 +608,66 @@ namespace Nekoyume.UI.Module
                 .FirstOrDefault();
             if (targetQuest is null)
             {
-                return null;
+                return GetFakeHardModeWorldQuest();
             }
 
             var targetStageId = targetQuest.Goal;
             return !TableSheets.Instance.WorldSheet.TryGetByStageId(targetStageId, out _)
                 ? null
                 : targetQuest;
+        }
+
+        /// <summary>
+        /// Fallback for legacy accounts whose QuestList doesn't yet contain
+        /// hard-mode WorldQuest entries. Creates a fake WorldQuest pointing
+        /// to the first uncompleted hard-mode stage.
+        /// Same pattern as <see cref="GetTargetEventDungeonQuest"/>.
+        /// </summary>
+        private static WorldQuest GetFakeHardModeWorldQuest()
+        {
+            var worldInfo = SharedViewModel.avatarState?.worldInformation;
+            if (worldInfo is null || !worldInfo.IsStageCleared(450))
+            {
+                return null;
+            }
+
+            var worldSheet = TableSheets.Instance.WorldSheet;
+            var hardRows = worldSheet.OrderedList
+                .Where(row => row.Id >= 10 && row.Id < GameConfig.MimisbrunnrWorldId)
+                .OrderBy(row => row.Id);
+
+            foreach (var hardRow in hardRows)
+            {
+                int goal;
+                if (worldInfo.TryGetWorld(hardRow.Id, out var hardWorld) &&
+                    hardWorld.IsStageCleared)
+                {
+                    if (hardWorld.StageClearedId >= hardRow.StageEnd)
+                    {
+                        continue;
+                    }
+
+                    goal = hardWorld.StageClearedId + 1;
+                }
+                else
+                {
+                    goal = hardRow.StageBegin;
+                }
+
+                if (!worldSheet.TryGetByStageId(goal, out _))
+                {
+                    continue;
+                }
+
+                // NOTE: Make fake world quest (same pattern as GetTargetEventDungeonQuest).
+                var goalText = goal.ToString(CultureInfo.InvariantCulture);
+                var row = new WorldQuestSheet.Row();
+                row.Set(new[] { goalText, goalText, goalText });
+                var reward = new QuestReward(new Dictionary<int, int>());
+                return new WorldQuest(row, reward);
+            }
+
+            return null;
         }
 
         private static CombinationEquipmentQuest GetTargetCombinationEquipmentQuest(
@@ -629,7 +682,7 @@ namespace Nekoyume.UI.Module
             }
 
             var recipeSheet = Game.Game.instance.TableSheets.EquipmentItemRecipeSheet;
-            return questList?
+            var result = questList?
                 .OfType<CombinationEquipmentQuest>()
                 .Select(quest => recipeSheet.TryGetValue(quest.RecipeId, out var recipeRow)
                     ? (quest, unlockStageId: recipeRow.UnlockStage)
@@ -639,6 +692,62 @@ namespace Nekoyume.UI.Module
                 .OrderBy(tuple => tuple.unlockStageId)
                 .Select(tuple => tuple.quest)
                 .FirstOrDefault();
+
+            return result ?? GetFakeCombinationEquipmentQuest(questList, lastClearedStageId);
+        }
+
+        /// <summary>
+        /// Fallback for legacy accounts whose QuestList doesn't yet contain
+        /// new CombinationEquipmentQuest entries (added on next HAS).
+        /// Finds the first missing quest from the sheet and creates a fake one.
+        /// </summary>
+        private static CombinationEquipmentQuest GetFakeCombinationEquipmentQuest(
+            QuestList questList, int lastClearedStageId)
+        {
+            var questSheet = Game.Game.instance.TableSheets
+                .CombinationEquipmentQuestSheet;
+            var recipeSheet = Game.Game.instance.TableSheets
+                .EquipmentItemRecipeSheet;
+
+            var existingIds = questList?
+                .OfType<CombinationEquipmentQuest>()
+                .Select(q => q.Id)
+                .ToHashSet() ?? new HashSet<int>();
+
+            var targetRow = questSheet.OrderedList
+                .Where(row => !existingIds.Contains(row.Id))
+                .Where(row =>
+                {
+                    if (!recipeSheet.TryGetValue(row.RecipeId, out var recipeRow))
+                    {
+                        return false;
+                    }
+
+                    return recipeRow.UnlockStage <= lastClearedStageId;
+                })
+                .OrderBy(row =>
+                    recipeSheet.TryGetValue(row.RecipeId, out var r)
+                        ? r.UnlockStage
+                        : int.MaxValue)
+                .FirstOrDefault();
+
+            if (targetRow is null)
+            {
+                return null;
+            }
+
+            if (!recipeSheet.TryGetValue(targetRow.RecipeId, out var recipeRow))
+            {
+                return null;
+            }
+
+            // NOTE: Make fake quest (same pattern as GetTargetCraftEventItemQuest).
+            var goalText = targetRow.Id.ToString(CultureInfo.InvariantCulture);
+            var recipeIdText = targetRow.RecipeId.ToString(CultureInfo.InvariantCulture);
+            var row = new CombinationEquipmentQuestSheet.Row();
+            row.Set(new[] { goalText, goalText, goalText, recipeIdText });
+            var reward = new QuestReward(new Dictionary<int, int>());
+            return new CombinationEquipmentQuest(row, reward, recipeRow.UnlockStage);
         }
 
         private static WorldQuest GetTargetEventDungeonQuest()

--- a/nekoyume/Assets/_Scripts/UI/Widget/WorldMap.cs
+++ b/nekoyume/Assets/_Scripts/UI/Widget/WorldMap.cs
@@ -506,7 +506,28 @@ namespace Nekoyume.UI
             {
                 var hardWorldIds = GetWorldIdsForMode(WorldMapMode.Hard);
                 var isHardModeUnlocked = hardWorldIds.Any(id =>
-                    worldInformation?.IsWorldUnlocked(id) ?? false);
+                {
+                    if (worldInformation?.IsWorldUnlocked(id) ?? false)
+                    {
+                        return true;
+                    }
+
+                    // Fallback for legacy accounts whose worldInformation
+                    // doesn't contain hard worlds yet (added on next HAS).
+                    var unlockRow = TableSheets.Instance.WorldUnlockSheet
+                        .OrderedList
+                        .FirstOrDefault(row => row.WorldIdToUnlock == id);
+                    if (unlockRow is null)
+                    {
+                        return false;
+                    }
+
+                    var unlockRowConsistent = !TableSheets.Instance.WorldSheet
+                        .TryGetByStageId(unlockRow.StageId, out var stageWorld) ||
+                        stageWorld.Id == unlockRow.WorldId;
+                    return unlockRowConsistent &&
+                        IsStageClearedForUi(worldInformation, unlockRow.StageId);
+                });
                 var targetMode = isHardModeUnlocked ? WorldMapMode.Hard : WorldMapMode.Normal;
                 ApplyMode(targetMode);
             }
@@ -735,8 +756,34 @@ namespace Nekoyume.UI
                 .OrderBy(x => x.Goal)
                 .FirstOrDefault()?
                 .Goal ?? -1;
-            StageIdToNotify = questStageId;
 
+            // Fallback for legacy accounts whose QuestList doesn't yet
+            // contain hard-mode WorldQuest entries (added on next HAS).
+            if (questStageId < 0)
+            {
+                var worldInfo = SharedViewModel.WorldInformation
+                    ?? Game.Game.instance.States.CurrentAvatarState?.worldInformation;
+                if (worldInfo != null && IsStageClearedForUi(worldInfo, 450))
+                {
+                    foreach (var hardRow in GetWorldRowsForMode(WorldMapMode.Hard))
+                    {
+                        if (IsStageClearedForUi(worldInfo, hardRow.StageEnd))
+                        {
+                            continue;
+                        }
+
+                        var nextStage = IsStageClearedForUi(worldInfo, hardRow.StageBegin)
+                            ? worldInfo.TryGetWorld(hardRow.Id, out var hw) && hw.IsStageCleared
+                                ? hw.StageClearedId + 1
+                                : hardRow.StageBegin
+                            : hardRow.StageBegin;
+                        questStageId = nextStage;
+                        break;
+                    }
+                }
+            }
+
+            StageIdToNotify = questStageId;
             HasNotification = questStageId > 0;
         }
 


### PR DESCRIPTION
## Summary
- 하드모드 테이블 패치 이전에 스테이지 450을 클리어한 레거시 계정에서 하드모드 관련 UI가 표시되지 않는 문제 수정
- 온체인 마이그레이션(HAS 실행 시)이 아직 안 된 계정에 대해 클라이언트 사이드 폴백 처리
- HAS 실행 후 온체인 상태가 업데이트되면 모든 폴백은 no-op이 됨

### Changes
- **WorldMap**: `isHardModeUnlocked` 체크에 `WorldUnlockSheet` 기반 폴백 추가
- **WorldMap**: `UpdateNotificationInfo()`에서 미완료 WorldQuest 없을 때 하드모드 스테이지 폴백
- **GuidedQuest**: 하드모드 fake `WorldQuest` 생성 (이벤트 던전과 동일 패턴)
- **GuidedQuest**: 누락된 `CombinationEquipmentQuest` 시트 항목에 대한 fake quest 생성

## Test plan
- [ ] 스테이지 450 클리어 + World 10 미언락 계정으로 접속
- [ ] 월드맵 진입 시 하드모드 탭 자동 선택 확인
- [ ] World 10 버튼에 알림(!) 표시 확인
- [ ] 로비 Adventure 버튼에 알림(!) 표시 확인
- [ ] 가이드 퀘스트에 하드모드 스테이지 표시 확인
- [ ] HAS 실행 후 정상 동작 (폴백 → 실제 퀘스트 전환) 확인
- [ ] 노멀 월드 진행 중인 신규 계정에 영향 없는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)