### PR TITLE
Retry PutTransaction on transient gRPC failure (#7258)

### DIFF
--- a/nekoyume/Assets/_Scripts/Blockchain/RPCAgent.cs
+++ b/nekoyume/Assets/_Scripts/Blockchain/RPCAgent.cs
@@ -57,6 +57,18 @@ namespace Nekoyume.Blockchain
     {
         private const int RpcConnectionRetryCount = 6;
         private const float TxProcessInterval = 1.0f;
+
+        // PutTransaction retry budget — 1 initial call + (MaxStageAttempts - 1) retries.
+        // Backoff array length is exactly MaxStageAttempts - 1 (no wait after the final attempt).
+        private const int MaxStageAttempts = 4;
+
+        private static readonly TimeSpan[] StageRetryBackoffs =
+        {
+            TimeSpan.FromSeconds(2),
+            TimeSpan.FromSeconds(5),
+            TimeSpan.FromSeconds(10),
+        };
+
         private readonly ConcurrentQueue<(ActionBase, Func<TxId, Task<bool>>)> _queuedActions = new();
 
         private readonly TransactionMap _transactions = new(20);
@@ -1184,13 +1196,157 @@ namespace Nekoyume.Blockchain
                 $" Actions=[{actionsText}]");
 
             _onMakeTransactionSubject.OnNext((tx, new List<ActionBase> { action.Item1 }));
-            var result = await _service.PutTransaction(tx.Serialize());
-            OnTxStageEnded.OnNext(result);
-            if (gameActionId != Guid.Empty)
+
+            // Same signed bytes are reused across attempts, so the server safely rejects
+            // any duplicate as NonceTooLow / false. Only transient gRPC codes trigger the
+            // retry path — validation failures (InvalidArgument, etc.) propagate immediately.
+            // Per-host failures are also recorded with RpcEndpointProber so future reconnects
+            // (RetryRpc) and next-session probes (PR #7261) can rotate away from the host
+            // accumulating timeouts.
+            //
+            // We snapshot _service / _currentRpcServerHost up front: a concurrent RetryRpc
+            // can swap _service mid-loop, and once that happens this MakeTransaction's
+            // context (host attribution, in-flight call) is stale. On detected swap we
+            // bail out without emitting OnTxStageEnded(false) — the existing OnNext(false)
+            // handler force-exits the session, which is wrong when the agent has just
+            // recovered onto a healthy channel for everything else.
+            var service = _service;
+            var hostAtStart = _currentRpcServerHost;
+            var txBytes = tx.Serialize();
+            var history = new List<string>(MaxStageAttempts);
+
+            for (var attempt = 0; attempt < MaxStageAttempts; attempt++)
             {
-                _transactions.TryAdd(gameActionId, tx.Id);
+                if (!ReferenceEquals(service, _service))
+                {
+                    NcDebug.LogWarning(
+                        $"[RPCAgent] PutTransaction aborted: channel swapped mid-retry. " +
+                        $"TxId={tx.Id} completedAttempts={attempt} history=[{string.Join(",", history)}]");
+                    return;
+                }
+
+                if (attempt > 0)
+                {
+                    try
+                    {
+                        await Task.Delay(StageRetryBackoffs[attempt - 1], cancellationTokenSource.Token);
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        return;
+                    }
+                }
+
+                try
+                {
+                    var result = await service.PutTransaction(txBytes);
+
+                    // Ambiguous false on a retry: an earlier attempt may have client-side
+                    // timed out but actually staged on the server, in which case the server
+                    // now sees this duplicate as NonceTooLow and answers false. Confirm via
+                    // IsTransactionStaged before signalling failure so we don't push the user
+                    // through UI_TX_STAGE_FAILED → SetConfirmCallbackToExit for a tx that is
+                    // already in flight.
+                    //
+                    // attempt 0 is skipped from this probe path on purpose: the only way a
+                    // first attempt reaches result=false here is a legitimate server-side
+                    // rejection (the only client/transport errors come back as exceptions,
+                    // which retry below). Probing in that case would just hide real failures.
+                    if (!result && attempt > 0)
+                    {
+                        bool? confirmedStaged = null;
+                        try
+                        {
+                            confirmedStaged = await service.IsTransactionStaged(tx.Id.ToByteArray());
+                        }
+                        catch (Exception probeErr)
+                        {
+                            NcDebug.LogWarning(
+                                $"[RPCAgent] PutTransaction retry-false staged probe threw " +
+                                $"TxId={tx.Id}: {probeErr.Message}");
+                        }
+
+                        if (confirmedStaged == true)
+                        {
+                            NcDebug.Log(
+                                $"[RPCAgent] PutTransaction retry returned false but tx is staged — " +
+                                $"earlier attempt succeeded. TxId={tx.Id} attempts={attempt + 1} " +
+                                $"history=[{string.Join(",", history)}]");
+                            OnTxStageEnded.OnNext(true);
+                            if (gameActionId != Guid.Empty)
+                            {
+                                _transactions.TryAdd(gameActionId, tx.Id);
+                            }
+                            return;
+                        }
+
+                        if (confirmedStaged is null)
+                        {
+                            // Probe itself failed — the channel is unstable, so we can't
+                            // tell whether the original attempt staged. Same reasoning as
+                            // the swap/dispose branches: bail without firing OnNext(false)
+                            // so the agent's own reconnect handles it instead of force-
+                            // exiting the user over an unverifiable result.
+                            NcDebug.LogError(
+                                $"[RPCAgent] PutTransaction retry returned false and staged probe " +
+                                $"is inconclusive — bailing without surfacing failure to UI. " +
+                                $"TxId={tx.Id} attempts={attempt + 1} history=[{string.Join(",", history)}]");
+                            return;
+                        }
+                        // confirmedStaged == false → genuine failure, fall through to OnNext.
+                    }
+
+                    if (attempt > 0)
+                    {
+                        NcDebug.Log(
+                            $"[RPCAgent] PutTransaction succeeded on attempt {attempt + 1}/{MaxStageAttempts} " +
+                            $"TxId={tx.Id} history=[{string.Join(",", history)}]");
+                    }
+
+                    OnTxStageEnded.OnNext(result);
+                    if (gameActionId != Guid.Empty)
+                    {
+                        _transactions.TryAdd(gameActionId, tx.Id);
+                    }
+                    return;
+                }
+                catch (RpcException e) when (IsTransientStageError(e))
+                {
+                    history.Add($"attempt{attempt}={e.StatusCode}");
+                    if (!string.IsNullOrEmpty(hostAtStart))
+                    {
+                        RpcEndpointProber.RecordFailure(hostAtStart);
+                    }
+                }
+                catch (TimeoutException)
+                {
+                    history.Add($"attempt{attempt}=Timeout");
+                    if (!string.IsNullOrEmpty(hostAtStart))
+                    {
+                        RpcEndpointProber.RecordFailure(hostAtStart);
+                    }
+                }
+                catch (ObjectDisposedException ode)
+                {
+                    // Channel disposed under our feet — RetryRpc is taking over.
+                    // Same reasoning as the swap branch above: don't force-exit.
+                    NcDebug.LogWarning(
+                        $"[RPCAgent] PutTransaction aborted: channel disposed mid-call. " +
+                        $"TxId={tx.Id} attempts={attempt + 1} history=[{string.Join(",", history)}]: {ode.Message}");
+                    return;
+                }
             }
+
+            NcDebug.LogError(
+                $"[RPCAgent] PutTransaction failed after {MaxStageAttempts} attempts. " +
+                $"TxId={tx.Id} history=[{string.Join(",", history)}]");
+            OnTxStageEnded.OnNext(false);
         }
+
+        private static bool IsTransientStageError(RpcException e) =>
+            e.StatusCode == StatusCode.DeadlineExceeded ||
+            e.StatusCode == StatusCode.Unavailable ||
+            e.StatusCode == StatusCode.ResourceExhausted;
 
         private async Task<long> GetNonceAsync()
         {


### PR DESCRIPTION
## Summary

Closes #7258.

`RPCAgent.MakeTransaction` previously called `_service.PutTransaction` exactly once with no try/catch, so a transient gRPC condition (NetMQ broadcast-state-induced GC pause, momentary `Unavailable`, network jitter) silently dropped the user-initiated action — no popup, no retry, no failure event. Heimdall 2026-05-04 user reports trace to this path.

Wrap the single call in a bounded exponential-backoff retry loop (2/5/10s between attempts, 4 attempts total = 1 initial + 3 retries). Same signed `txBytes` reused across attempts so the server rejects any duplicate as `NonceTooLow` / `false` — no double execution risk.

### Why same host / same tx

Per the issue's risk table: rotating to a new host requires tearing down the StreamingHub `OnRenderBlock`/`ActionRenderer` path mid-call, which is racy and would risk dropping block render events. Same signed tx is idempotent on the server. `RetryRpc` (PR #7261) handles host rotation on hub disconnect; this PR handles unary transient failure on the same host without touching the hub.

### Beyond the issue's proposal

The implementation also addresses three review findings that surfaced during iteration:

- **Idempotency safety against false-positive force-exit**: `OnTxStageEnded.OnNext(false)` triggers `IconAndButtonSystem` with `SetConfirmCallbackToExit()` — i.e. the user is force-exited from their session. If attempt 0 client-side timed out but actually staged on the server, retry attempt 1 would receive `false` (`NonceTooLow` on duplicate) and force-exit a user whose tx is in flight. Mitigation: on retry attempt's `result=false`, probe `IsTransactionStaged(tx.Id)` to disambiguate. Three outcomes — `true` → success path, `false` → genuine failure → `OnNext(false)` as before, throw → inconclusive → bail without `OnNext(false)` so the agent's own reconnect handles it.
- **Channel-swap race**: a concurrent `RetryRpc` can swap `_service`/`_channel`/`_hub` mid-retry. Snapshot `_service` at loop entry, check `ReferenceEquals(service, _service)` at each iteration, and catch `ObjectDisposedException`. Same conservative bail (no `OnNext(false)`) so the recovered session isn't force-exited over a request the new channel will handle.
- **Log noise**: per-attempt warnings are replaced by a single history list emitted once on terminal failure (or once on success after retry). Avoids log flood when many users hit the same incident simultaneously.

### What this does NOT solve

- Persistent server-side stuckness (RH pod with hours of NetMQ accumulation) — infra-side mitigation is being deployed separately on `9c-infra`.
- The `CoTxProcessor` FIXME re-enqueue at `RPCAgent.cs:1136-1142` is intentionally left alone; restoring it as-is would regenerate the nonce on each attempt and risk double execution. The same-tx retry above is the safer alternative.
- Mempool-flush-after-staging edge case: if attempt 0 staged and the block was mined+flushed before the retry's `IsTransactionStaged` probe, the probe returns `false` and the user still sees `UI_TX_STAGE_FAILED`. Very low frequency; out of scope here.

## Risk table

| Risk | Mitigation |
|------|------------|
| Double execution | Same signed tx — server rejects duplicate as `NonceTooLow` / `false` |
| Hub disconnect race | Hub never touched in this path |
| Block render gap | Hub not torn down |
| Infinite retry loop | `MaxStageAttempts = 4`, total wait 17s worst-case |
| False-positive force-exit popup | `IsTransactionStaged` probe + conservative bail on inconclusive |
| Channel swap mid-retry | `_service` snapshot + `ReferenceEquals` check + `ObjectDisposedException` catch + bail |
| Wrong errors retried | Selective `StatusCode` filter: `DeadlineExceeded`, `Unavailable`, `ResourceExhausted` only |
| Log flood under sustained incident | Per-attempt warnings consolidated into single history-line log |
| OnDestroy during retry | `Task.Delay` honors `cancellationTokenSource.Token` |

## Related

- PR #7261 (merged) — health-aware RPC endpoint selection. `RpcEndpointProber.RecordFailure(_currentRpcServerHost)` is invoked on every transient failure here so the prober and rotation paths can naturally route away from an RH that's accumulating timeouts.
- Server-side mitigation in `planetarium/9c-infra` — periodic StatefulSet rotation for the same incident class.

## Test plan

- [ ] Unity Editor build succeeds (`dotnet build Nekoyume.csproj` is green).
- [ ] Trigger a manual transient failure (e.g. block the gRPC port to the connected RH for ~5s), observe `[RPCAgent] PutTransaction transient failure` is absent (compact path) and that the final state surface — success log with `attempts=N history=[...]` or terminal `failed after 4 attempts ... history=[...]`.
- [ ] Confirm the `_TX_STAGE_FAILED` popup no longer fires when retry succeeds.
- [ ] Disconnect-during-retry: while a transient retry is in flight, kill the connection so `RetryRpc` swaps `_service`. Confirm `channel swapped mid-retry` log and **no** force-exit popup.
- [ ] Validation failure (e.g. invalid action) still surfaces as before (no retry, fast fail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)