### PR TITLE
Use node APV value in client version display (PLD-1318)

### DIFF
--- a/nekoyume/Assets/_Scripts/ApiClient/GraphQL/GraphTypes/NodeStatusType.cs
+++ b/nekoyume/Assets/_Scripts/ApiClient/GraphQL/GraphTypes/NodeStatusType.cs
@@ -45,10 +45,16 @@ namespace Nekoyume.GraphQL.GraphTypes
     public class TipResultQuery
     {
         public TipResult Tip;
+        public AppProtocolVersionResult AppProtocolVersion;
     }
 
     public class TipResult
     {
         public string Id;
+    }
+
+    public class AppProtocolVersionResult
+    {
+        public int Version;
     }
 }

--- a/nekoyume/Assets/_Scripts/ApiClient/GraphQL/NineChroniclesAPIClientExtensions.cs
+++ b/nekoyume/Assets/_Scripts/ApiClient/GraphQL/NineChroniclesAPIClientExtensions.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using GraphQL;
 using Libplanet.Crypto;
 using Libplanet.Types.Blocks;
+using Nekoyume.GraphQL.GraphTypes;
 using Nekoyume.UI.Model;
 using Newtonsoft.Json.Linq;
 using UnityEngine;
@@ -87,6 +88,24 @@ query {{
         public class StateQuery
         {
             public List<ArenaParticipantModel> ArenaParticipants;
+        }
+
+        public static async Task<int?> QueryNodeAppProtocolVersionAsync(this NineChroniclesAPIClient client)
+        {
+            if (!client.IsInitialized)
+            {
+                return null;
+            }
+
+            const string query = @"query {
+                nodeStatus {
+                    appProtocolVersion {
+                        version
+                    }
+                }
+            }";
+            var response = await client.GetObjectAsync<NodeStatusResponse>(query);
+            return response?.NodeStatus?.AppProtocolVersion?.Version;
         }
     }
 }

--- a/nekoyume/Assets/_Scripts/Game/Scene/LoginScene.cs
+++ b/nekoyume/Assets/_Scripts/Game/Scene/LoginScene.cs
@@ -15,6 +15,7 @@ using Libplanet.Crypto;
 using Nekoyume.ApiClient;
 using Nekoyume.Blockchain;
 using Nekoyume.Game.Character;
+using Nekoyume.GraphQL;
 using Nekoyume.Multiplanetary;
 using Nekoyume.Game.Factory;
 using Nekoyume.Helper;
@@ -317,8 +318,10 @@ namespace Nekoyume.Game.Scene
             RankPopup.UpdateSharedModel();
             Helper.Util.TryGetAppProtocolVersionFromToken(
                 CommandLineOptions.AppProtocolVersion,
-                out var appProtocolVersion);
-            Widget.Find<VersionSystem>().SetVersion(appProtocolVersion);
+                out var localApv);
+            var versionSystem = Widget.Find<VersionSystem>();
+            versionSystem.SetVersion(localApv);
+            ApplyNodeAppProtocolVersion(versionSystem, localApv).Forget();
             Analyzer.Instance.Track("Unity/Intro/Start/ShowNext");
 
             StartCoroutine(game.CoUpdate());
@@ -331,6 +334,47 @@ namespace Nekoyume.Game.Scene
             EnterNext().Forget();
             totalSw.Stop();
             NcDebug.Log($"[LoginScene] Game Start End. {totalSw.ElapsedMilliseconds}ms.");
+        }
+
+        private static async UniTaskVoid ApplyNodeAppProtocolVersion(VersionSystem versionSystem, int localApv)
+        {
+            var rpcClient = ApiClients.Instance.RpcGraphQlClient;
+            if (rpcClient == null || !rpcClient.IsInitialized)
+            {
+                NcDebug.LogWarning("[LoginScene] ApplyNodeAppProtocolVersion()... RpcGraphQlClient is not initialized. Keep using local APV.");
+                return;
+            }
+
+            int? nodeApv;
+            try
+            {
+                nodeApv = await rpcClient.QueryNodeAppProtocolVersionAsync();
+            }
+            catch (Exception e)
+            {
+                NcDebug.LogWarning($"[LoginScene] ApplyNodeAppProtocolVersion()... query failed, keep using local APV. {e}");
+                return;
+            }
+
+            if (nodeApv is null)
+            {
+                NcDebug.LogWarning("[LoginScene] ApplyNodeAppProtocolVersion()... node APV is null, keep using local APV.");
+                return;
+            }
+
+            if (nodeApv.Value != localApv)
+            {
+                NcDebug.LogWarning($"[LoginScene] APV mismatch detected. local: {localApv}, node: {nodeApv.Value}. Applying node APV.");
+            }
+            else
+            {
+                NcDebug.Log($"[LoginScene] APV from node confirmed: {nodeApv.Value}");
+            }
+
+            if (versionSystem != null)
+            {
+                versionSystem.SetVersion(nodeApv.Value);
+            }
         }
 
         private async UniTask EnterNext()


### PR DESCRIPTION
## Summary
- Client now fetches App Protocol Version from the headless via `nodeStatus { appProtocolVersion { version } }` GraphQL query and applies it to the bottom-left HUD instead of relying solely on the `clo.json` value.
- The clo.json-parsed APV is still set first as an immediate fallback; the node query runs fire-and-forget after `ApiClients.Initialize` and overwrites the display when it returns.
- On mismatch between local and node APV, a warning is logged to surface client/node drift; failures (no client, exception, null response) leave the local value in place.

## Changes
- `NodeStatusType.cs`: extend `TipResultQuery` with `AppProtocolVersion` field; add `AppProtocolVersionResult` (mirrors `TipResult` naming).
- `NineChroniclesAPIClientExtensions.cs`: add `QueryNodeAppProtocolVersionAsync` reusing the existing `NodeStatusResponse` DTO.
- `LoginScene.cs`: split local-APV display from node-APV apply; add `ApplyNodeAppProtocolVersion` fire-and-forget helper.

Resolves [PLD-1318](https://ninecorporation.atlassian.net/browse/PLD-1318).

## Test plan
- [ ] Run Unity Editor against a known headless and confirm the bottom-left HUD shows the node's APV.
- [ ] Set `clo.json` `appProtocolVersion` token to a different version than the connected node and confirm the HUD reflects the node value, with a warning log of the mismatch.
- [ ] Point `RpcServerHost` at an unreachable endpoint and confirm the HUD falls back to the clo.json APV without blocking login.
- [ ] Android build smoke test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PLD-1318]: https://ninecorporation.atlassian.net/browse/PLD-1318?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ