### PR TITLE
Add gRPC keepalive ChannelOptions to RPCAgent channel

### DIFF
--- a/nekoyume/Assets/_Scripts/Blockchain/RPCAgent.cs
+++ b/nekoyume/Assets/_Scripts/Blockchain/RPCAgent.cs
@@ -137,10 +137,20 @@ namespace Nekoyume.Blockchain
         public static void OnRuntimeInitialize()
         {
             // Initialize gRPC channel provider when the application is loaded.
+            //
+            // Keepalive surfaces zombie connections (NAT/proxy idle drop, server soft-hang,
+            // mobile network switch) that TCP RST alone never reports. Without these, a
+            // dropped channel can sit waiting indefinitely; subsequent retry / deadline
+            // logic (#7258, #7264) can't engage because no error ever fires. The headless
+            // side sets Kestrel Http2.KeepAlivePingDelay accordingly in a coordinated PR.
             GrpcChannelProviderHost.Initialize(new LoggingGrpcChannelProvider(
                 new DefaultGrpcChannelProvider(new[]
                 {
                     new ChannelOption("grpc.max_receive_message_length", -1),
+                    new ChannelOption("grpc.keepalive_time_ms", 30000),
+                    new ChannelOption("grpc.keepalive_timeout_ms", 10000),
+                    new ChannelOption("grpc.keepalive_permit_without_calls", 1),
+                    new ChannelOption("grpc.http2.max_pings_without_data", 0),
                 })
             ));
         }

--- a/nekoyume/Assets/_Scripts/Blockchain/RPCAgent.cs
+++ b/nekoyume/Assets/_Scripts/Blockchain/RPCAgent.cs
@@ -222,6 +222,10 @@ namespace Nekoyume.Blockchain
             // OnRuntimeInitialize seeded defaults before CLO was loaded; this call
             // applies per-environment overrides for all downstream ForTarget() users
             // (this.Initialize, RetryRpc, RpcEndpointProber).
+            //
+            // MUST run before any GrpcChannelx.ForTarget call below — channels opened
+            // against the seeded provider would otherwise keep its options after the
+            // re-register destroys that host.
             RegisterGrpcChannelProvider(
                 options.RpcKeepaliveDisabled,
                 options.RpcKeepaliveTimeMs,

--- a/nekoyume/Assets/_Scripts/Blockchain/RPCAgent.cs
+++ b/nekoyume/Assets/_Scripts/Blockchain/RPCAgent.cs
@@ -133,25 +133,47 @@ namespace Nekoyume.Blockchain
         private string _currentRpcServerHost;
         private CancellationTokenSource cancellationTokenSource;
 
+        // Built-in keepalive defaults. Surface zombie connections (NAT/proxy idle drop,
+        // server soft-hang, mobile network switch) that TCP RST alone never reports.
+        // Without these, a dropped channel sits waiting indefinitely; retry / deadline
+        // logic (#7258, #7264) can't engage because no error ever fires. The headless
+        // side ships a coordinated Kestrel Http2.KeepAlivePingDelay env-driven setting.
+        private const int DefaultKeepaliveTimeMs = 30000;
+        private const int DefaultKeepaliveTimeoutMs = 10000;
+
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
         public static void OnRuntimeInitialize()
         {
-            // Initialize gRPC channel provider when the application is loaded.
-            //
-            // Keepalive surfaces zombie connections (NAT/proxy idle drop, server soft-hang,
-            // mobile network switch) that TCP RST alone never reports. Without these, a
-            // dropped channel can sit waiting indefinitely; subsequent retry / deadline
-            // logic (#7258, #7264) can't engage because no error ever fires. The headless
-            // side sets Kestrel Http2.KeepAlivePingDelay accordingly in a coordinated PR.
+            // Boot-time fallback registration. RPCAgent.Initialize re-registers once
+            // CommandLineOptions are loaded so per-environment overrides can apply.
+            RegisterGrpcChannelProvider(
+                keepaliveDisabled: false,
+                keepaliveTimeMs: DefaultKeepaliveTimeMs,
+                keepaliveTimeoutMs: DefaultKeepaliveTimeoutMs);
+        }
+
+        private static void RegisterGrpcChannelProvider(
+            bool keepaliveDisabled,
+            int keepaliveTimeMs,
+            int keepaliveTimeoutMs)
+        {
+            var channelOptions = new List<ChannelOption>
+            {
+                new("grpc.max_receive_message_length", -1),
+            };
+
+            if (!keepaliveDisabled)
+            {
+                var timeMs = keepaliveTimeMs > 0 ? keepaliveTimeMs : DefaultKeepaliveTimeMs;
+                var timeoutMs = keepaliveTimeoutMs > 0 ? keepaliveTimeoutMs : DefaultKeepaliveTimeoutMs;
+                channelOptions.Add(new ChannelOption("grpc.keepalive_time_ms", timeMs));
+                channelOptions.Add(new ChannelOption("grpc.keepalive_timeout_ms", timeoutMs));
+                channelOptions.Add(new ChannelOption("grpc.keepalive_permit_without_calls", 1));
+                channelOptions.Add(new ChannelOption("grpc.http2.max_pings_without_data", 0));
+            }
+
             GrpcChannelProviderHost.Initialize(new LoggingGrpcChannelProvider(
-                new DefaultGrpcChannelProvider(new[]
-                {
-                    new ChannelOption("grpc.max_receive_message_length", -1),
-                    new ChannelOption("grpc.keepalive_time_ms", 30000),
-                    new ChannelOption("grpc.keepalive_timeout_ms", 10000),
-                    new ChannelOption("grpc.keepalive_permit_without_calls", 1),
-                    new ChannelOption("grpc.http2.max_pings_without_data", 0),
-                })
+                new DefaultGrpcChannelProvider(channelOptions)
             ));
         }
         //
@@ -195,6 +217,15 @@ namespace Nekoyume.Blockchain
             Action<bool> callback)
         {
             NcDebug.Log($"[RPCAgent] Start initialization: {options.RpcServerHost}:{options.RpcServerPort}");
+
+            // Re-register the channel provider with values from CommandLineOptions.
+            // OnRuntimeInitialize seeded defaults before CLO was loaded; this call
+            // applies per-environment overrides for all downstream ForTarget() users
+            // (this.Initialize, RetryRpc, RpcEndpointProber).
+            RegisterGrpcChannelProvider(
+                options.RpcKeepaliveDisabled,
+                options.RpcKeepaliveTimeMs,
+                options.RpcKeepaliveTimeoutMs);
 
             cachedRpcServerHosts.Clear();
             foreach (var rpcServerHost in options.RpcServerHosts)

--- a/nekoyume/Assets/_Scripts/Helper/CommandLineOptions.cs
+++ b/nekoyume/Assets/_Scripts/Helper/CommandLineOptions.cs
@@ -338,6 +338,48 @@ namespace Nekoyume.Helper
             }
         }
 
+        private bool rpcKeepaliveDisabled;
+
+        private int rpcKeepaliveTimeMs;
+
+        private int rpcKeepaliveTimeoutMs;
+
+        [Option("rpc-keepalive-disabled", Required = false,
+            HelpText = "Disable gRPC HTTP/2 keepalive PINGs on the RPC channel.")]
+        public bool RpcKeepaliveDisabled
+        {
+            get => rpcKeepaliveDisabled;
+            set
+            {
+                rpcKeepaliveDisabled = value;
+                Empty = false;
+            }
+        }
+
+        [Option("rpc-keepalive-time-ms", Required = false,
+            HelpText = "gRPC keepalive PING interval in ms. 0 = use built-in default.")]
+        public int RpcKeepaliveTimeMs
+        {
+            get => rpcKeepaliveTimeMs;
+            set
+            {
+                rpcKeepaliveTimeMs = value;
+                Empty = false;
+            }
+        }
+
+        [Option("rpc-keepalive-timeout-ms", Required = false,
+            HelpText = "gRPC keepalive PING ACK timeout in ms. 0 = use built-in default.")]
+        public int RpcKeepaliveTimeoutMs
+        {
+            get => rpcKeepaliveTimeoutMs;
+            set
+            {
+                rpcKeepaliveTimeoutMs = value;
+                Empty = false;
+            }
+        }
+
         [Option("auto-play", Required = false, HelpText = "Play automatically in background.")]
         public bool AutoPlay
         {

--- a/nekoyume/Assets/_Scripts/Helper/CommandLineOptions.cs
+++ b/nekoyume/Assets/_Scripts/Helper/CommandLineOptions.cs
@@ -357,7 +357,8 @@ namespace Nekoyume.Helper
         }
 
         [Option("rpc-keepalive-time-ms", Required = false,
-            HelpText = "gRPC keepalive PING interval in ms. 0 = use built-in default.")]
+            HelpText = "gRPC keepalive PING interval in ms. 0 = use built-in default. " +
+                "Values below ~10000 risk server-side ENHANCE_YOUR_CALM rejection.")]
         public int RpcKeepaliveTimeMs
         {
             get => rpcKeepaliveTimeMs;


### PR DESCRIPTION
## Summary

- Adds gRPC HTTP/2 keepalive `ChannelOption`s to the `DefaultGrpcChannelProvider` used by every `GrpcChannelx.ForTarget` call site (main RPC channel, `RetryRpc`, `RpcEndpointProber`).
- Surfaces zombie connections (NAT/proxy idle drop, server soft-hang, mobile network switch) that TCP RST alone never reports — unblocks the retry path added in #7258 and the deadline path planned in Phase 2 of #7264.
- Exposes three `CommandLineOptions` knobs so per-environment tuning (`clo.json` / CLI flag) is possible without a code change. Defaults match the issue's recommended values.

Phase 1 of #7264. Coordinated with [NineChronicles.Headless#2762](https://github.com/planetarium/NineChronicles.Headless/pull/2762) (env-driven `Http2.KeepAlivePingDelay`) — already merged. Rollout on the server side begins with [9c-infra#3410](https://github.com/planetarium/9c-infra/pull/3410) (9c-internal heimdall only).

## Channel options

| Option | Default | Notes |
|---|---|---|
| `grpc.keepalive_time_ms` | 30000 | tunable via `rpcKeepaliveTimeMs` |
| `grpc.keepalive_timeout_ms` | 10000 | tunable via `rpcKeepaliveTimeoutMs` |
| `grpc.keepalive_permit_without_calls` | 1 | hardcoded (policy) |
| `grpc.http2.max_pings_without_data` | 0 | hardcoded (policy) |

When `rpcKeepaliveDisabled=true` the four keepalive options are dropped entirely (emergency off-switch — only `grpc.max_receive_message_length` remains).

## CommandLineOptions

| Field | CLI flag | Default | Meaning |
|---|---|---|---|
| `rpcKeepaliveDisabled` | `--rpc-keepalive-disabled` | `false` | Skip keepalive entirely. |
| `rpcKeepaliveTimeMs` | `--rpc-keepalive-time-ms` | `0` → 30000 | PING interval (ms). `0` = use built-in default. |
| `rpcKeepaliveTimeoutMs` | `--rpc-keepalive-timeout-ms` | `0` → 10000 | PING ACK timeout (ms). `0` = use built-in default. |

## Implementation notes

- `OnRuntimeInitialize` (BeforeSceneLoad) seeds the provider with hardcoded defaults so anything that touches `GrpcChannelx` before CLO is loaded still works. In practice no caller does, but it preserves the existing invariant.
- `RPCAgent.Initialize` re-registers the provider with CLO values before any `ForTarget` call (the prober, the main channel, and any later `RetryRpc`). `GrpcChannelProviderHost.Initialize` is idempotent — it destroys the existing host GameObject and creates a fresh one — so the swap is safe.

## Test plan

- [ ] Run in internal/staging build for 24–48h and observe:
  - [ ] `OnDisconnected` event rate (should rise — this is signal becoming visible, not new failures)
  - [ ] `DimmedLoadingScreen` flicker frequency
  - [ ] `[RPCAgent] RetryRpc()...` log rate
  - [ ] `RpcEndpointProber.RecordFailure()` call rate
- [ ] Confirm no `GOAWAY ENHANCE_YOUR_CALM / too_many_pings` errors against headless / any L7 proxy in path
- [ ] Verify CLO overrides take effect: set `rpcKeepaliveTimeMs: 60000` in `clo.json` and confirm the channel emits PINGs at the new interval
- [ ] Verify `rpcKeepaliveDisabled: true` reverts to pre-PR behaviour

## Related

- #7264 — parent issue (Phase 1 of 5)
- #7258 — PutTransaction transient retry (this PR makes its `DeadlineExceeded` branch reachable once Phase 2 lands)
- #7260 — health-aware RPC endpoint selection (`RetryRpc` benefits from faster zombie detection)
- planetarium/NineChronicles.Headless#2762 — companion Kestrel keepalive env var
- planetarium/9c-infra#3410 — initial server-side rollout (9c-internal heimdall)

🤖 Generated with [Claude Code](https://claude.com/claude-code)