### PR TITLE
Backport prepare/430.0.x fixes to development

### DIFF
--- a/nekoyume/Assets/_Scripts/Extensions/ActionBaseExtensions.cs
+++ b/nekoyume/Assets/_Scripts/Extensions/ActionBaseExtensions.cs
@@ -19,6 +19,8 @@ namespace Nekoyume
 {
     public static class ActionBaseExtensions
     {
+        public static bool EnableBattleLog = false;
+
         public static ActionTypeAttribute GetActionTypeAttribute(this ActionBase actionBase)
         {
             var gameActionType = actionBase.GetType();
@@ -32,6 +34,7 @@ namespace Nekoyume
 #if !DEBUG_USE
             return;
 #endif
+            if (!EnableBattleLog) return;
 
             var sb = new StringBuilder();
 
@@ -193,6 +196,7 @@ namespace Nekoyume
 #if !DEBUG_USE
             return;
 #endif
+            if (!EnableBattleLog) return;
 
             var sb = new StringBuilder();
 

--- a/nekoyume/Assets/_Scripts/Extensions/ActionBaseExtensions.cs
+++ b/nekoyume/Assets/_Scripts/Extensions/ActionBaseExtensions.cs
@@ -51,7 +51,7 @@ namespace Nekoyume
                     sb.AppendLine($"- WaveNumber: {spawnWave.WaveNumber}, WaveTurn: {spawnWave.WaveTurn}, HasBoss: {spawnWave.HasBoss}");
                     foreach (var enemy in spawnWave.Enemies)
                     {
-                        sb.AppendLine($"- Enemy: {enemy.RowData.Id} (Lv.{enemy.Level})");
+                        sb.AppendLine($"- Enemy: {enemy.RowData?.Id ?? enemy.CharacterId} (Lv.{enemy.Level})");
                     }
 
                     break;


### PR DESCRIPTION
Two commits landed on \`prepare/430.0.x\` but were never merged back into \`development\`. Cherry-picked here so they ride into the upcoming \`prepare/440.0.x\`.

- 56fdeaee99 — Fix NullReferenceException in SpawnWave enemy logging for RaidBoss (orig 01ca6b904b)
- 97268c1ba4 — Add EnableBattleLog flag to toggle battle event logging at runtime (orig 1ac388d3a3)

Both applied cleanly, no conflicts. Version bumps from prepare/430.0.x are intentionally NOT cherry-picked since the next release will jump to 440.0.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)