### PR TITLE
Fix broken links in whitepaper articles section

### DIFF
--- a/docs/whitepaper/index.html
+++ b/docs/whitepaper/index.html
@@ -553,14 +553,12 @@
       <h2 id="h-media">Articles and Media Mentions</h2>
       <ul class="articles">
         <li><a href="https://www.coindesk.com/sponsored-content/planetarium-labs-poised-nine-chronicles-for-winter-proof-sustainable-growth/" target="_blank" rel="noopener"><span class="pub">CoinDesk</span><span class="title">Planetarium Labs poised Nine Chronicles for winter-proof sustainable growth</span></a></li>
-        <li><a href="https://cointelegraph.com/press-releases/nine-chronicles-announces-mint-date-for-its-nft-project-de-centralized-cat" target="_blank" rel="noopener"><span class="pub">Cointelegraph</span><span class="title">Nine Chronicles announces mint date for its NFT project, De:Centralized Cat</span></a></li>
+        <li><a href="https://web.archive.org/web/20230521163120/https://cointelegraph.com/press-releases/nine-chronicles-announces-mint-date-for-its-nft-project-de-centralized-cat" target="_blank" rel="noopener"><span class="pub">Cointelegraph</span><span class="title">Nine Chronicles announces mint date for its NFT project, De:Centralized Cat</span></a></li>
         <li><a href="https://decrypt.co/14824/ubisoft-backed-startup-launches-evolutionary-decentralized-rpg" target="_blank" rel="noopener"><span class="pub">Decrypt</span><span class="title">Ubisoft-backed startup launches 'evolutionary' decentralized RPG</span></a></li>
         <li><a href="https://venturebeat.com/2021/08/04/planetarium-raises-2-6m-for-decentralized-rpg-nine-chronicles/" target="_blank" rel="noopener"><span class="pub">VentureBeat</span><span class="title">Planetarium nabs $2.6M for decentralized RPG Nine Chronicles</span></a></li>
         <li><a href="https://www.thegamer.com/nine-chronicles-mmo-p2p/" target="_blank" rel="noopener"><span class="pub">TheGamer</span><span class="title">Nine Chronicles Is An MMO That Runs On A P2P Network, Giving Players Full Control</span></a></li>
-        <li><a href="https://dappsmarket.net/other/nine-chronicles-pr/" target="_blank" rel="noopener"><span class="pub">DAppsMarket (JP)</span><span class="title">ブロックチェーンゲーム「ナインクロニクル」が無料版アルファの配信を開始</span></a></li>
-        <li><a href="https://www.chainnews.com/news/461252471191.htm" target="_blank" rel="noopener"><span class="pub">ChainNews (CN)</span><span class="title">育碧支持的链游公司 Planetarium 推出其区块链游戏 Nine Chronicles 公测版本</span></a></li>
         <li><a href="https://www.presse-citron.net/nine-chronicles-un-rpg-gratuit-et-totalement-decentralise-via-la-blockchain/" target="_blank" rel="noopener"><span class="pub">Presse-Citron (FR)</span><span class="title">Nine Chronicles, un RPG gratuit et totalement décentralisé via la blockchain</span></a></li>
-        <li><a href="https://www.coindesk.com/every-game-this-south-korean-startup-makes-has-its-own-blockchain" target="_blank" rel="noopener"><span class="pub">CoinDesk</span><span class="title">Every Game This South Korean Startup Makes Has Its Own Blockchain</span></a></li>
+        <li><a href="https://www.coindesk.com/markets/2019/06/05/every-game-this-south-korean-startup-makes-has-its-own-blockchain" target="_blank" rel="noopener"><span class="pub">CoinDesk</span><span class="title">Every Game This South Korean Startup Makes Has Its Own Blockchain</span></a></li>
       </ul>
     </section>
 


### PR DESCRIPTION
## Summary

- Fix CoinDesk 2019 article URL to include correct `/markets/2019/06/05/` path
- Replace broken CoinTelegraph link with Wayback Machine archive (original 404)
- Remove DAppsMarket (JP) link — 404, no archive available
- Remove ChainNews (CN) link — domain defunct since 2021, no archive available

## Test plan

- [ ] Open `docs/whitepaper/index.html` in browser and verify all article links in the "Articles and Media Mentions" section are clickable and resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)