### PR TITLE
[PLD-1371] 워크샵 레시피 셀 스탯 값 단축단위 적용

### DIFF
--- a/nekoyume/Assets/_Scripts/UI/Module/Recipe/RecipeView.cs
+++ b/nekoyume/Assets/_Scripts/UI/Module/Recipe/RecipeView.cs
@@ -62,7 +62,7 @@ namespace Nekoyume.UI.Module
                     normalLevelText.text = string.Format(
                         LevelTextFormat,
                         equipmentStat.StatType,
-                        equipmentStat.StatType.ValueToString((long)equipmentStat.TotalValue));
+                        equipmentStat.StatType.ValueToShortString((long)equipmentStat.TotalValue));
                     normalLevelText.gameObject.SetActive(true);
                     break;
                 case ConsumableItemSheet.Row consumableRow:
@@ -70,7 +70,7 @@ namespace Nekoyume.UI.Module
                     normalLevelText.text = string.Format(
                         LevelTextFormat,
                         consumableStat.StatType,
-                        consumableStat.StatType.ValueToString((long)consumableStat.TotalValue));
+                        consumableStat.StatType.ValueToShortString((long)consumableStat.TotalValue));
                     normalLevelText.gameObject.SetActive(true);
                     break;
                 case MaterialItemSheet.Row:


### PR DESCRIPTION
## 이슈
[PLD-1371](https://ninecorporation.atlassian.net/browse/PLD-1371) — 워크샵에서 신규 장비의 스탯이 두 줄로 출력되는 현상

워크샵(조합) 레시피 그리드의 셀 아이콘에 표시되는 스탯 값이 전체 숫자(예: `HP 57212268`)로 렌더링되어, 값이 큰 신규 장비에서 아이콘 아래 텍스트가 두 줄로 넘쳤습니다.

## 변경
- `RecipeView.cs`의 레시피 셀 스탯 값 포맷을 `ValueToString` → `ValueToShortString`로 변경
- 큰 값이 단축단위(예: `57212268` → `57.21M`)로 한 줄에 표시됨
- 장비/소비 아이템 셀 동일 경로라 둘 다 적용

## 참고
- 단축단위 표기는 강화(Enhancement) 워크샵에서 이미 쓰이는 `ValueToShortString` / `ToCurrencyNotation` 방식과 동일
- 스탯명(`HP` 등) 라벨과 `LevelTextFormat`의 스탯명/값 2줄 구성은 그대로 유지 — 값 자체가 넘쳐 추가로 줄바꿈되던 것만 해결

## 확인
- Unity 에디터 워크샵에서 값이 큰 장비 레시피 셀의 스탯 값이 한 줄로 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PLD-1371]: https://ninecorporation.atlassian.net/browse/PLD-1371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ